### PR TITLE
intoTheSunset

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -609,10 +609,7 @@
 			// If they have a mind and they're not in the brig, they escaped
 			if(M.mind && !istype(t, /turf/open/floor/mineral/plastitanium/red/brig))
 				M.mind.force_escaped = TRUE
-			// Ghostize them and put them in nullspace stasis (for stat & possession checks)
-			M.notransform = TRUE
-			M.ghostize(FALSE)
-			M.moveToNullspace()
+			M.Destroy()
 
 	// Now that mobs are stowed, delete the shuttle
 	jumpToNullSpace()


### PR DESCRIPTION
# About The Pull Request
Мобы теперь удаляются после БлюСпейс прыжка.
В орбит-меню не будет теперь кнопок с именами, которые нельзя нажать.

Рантаймы не обнаружены.
Какие это проблемы принесёт, не ясно.

## Why It's Good For The Game
Мобы удаляются там где они должны удаляться.
Меньше спама в орбит-меню.
Новые потенциальные баги.

## Changelog

:cl:
change: Теперь ко всем мобам в БлюСпейс прыжке применяется Destroy(), а не moveToNullspace().
fix: "мёртвые" кнопки в orbit
/:cl: