### PR TITLE
Lets you take rounds out of a pocket ammo box (#2387) - тестовый мердж с оффами

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -127,7 +127,8 @@
 		return
 
 	A.forceMove(drop_location())
-	if(!user.is_holding(src) || !user.put_in_hands(A)) //incase they're using TK
+	var/mob/living/carbon/human/H = user
+	if(!(user.is_holding(src) || H.l_store == src || H.r_store == src) || !user.put_in_hands(A)) //incase they're using TK
 		A.bounce_away(FALSE, NONE)
 	playsound(src, 'sound/weapons/gun/general/mag_bullet_insert.ogg', 60, TRUE)
 	to_chat(user, "<span class='notice'>You remove a round from [src]!</span>")
@@ -158,6 +159,19 @@
 	for(var/material in bullet_cost)
 		temp_materials[material] = (bullet_cost[material] * stored_ammo.len) + base_cost[material]
 	set_custom_materials(temp_materials)
+
+/obj/item/ammo_box/AltClick(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if((user.is_holding(src) ||H.l_store == src || H.r_store == src) && !(caliber || istype(src, /obj/item/ammo_box/magazine) || instant_load))	//caliber because boxes have none, instant load because speedloaders use the base ammo box type with instant load on, and magazine for the obvious.
+			attack_self(user)
+			return
+	..()
+
+/obj/item/ammo_box/examine(mob/user)
+	. = ..()
+	if(!(caliber || istype(src, /obj/item/ammo_box/magazine) || instant_load))
+		. += "Alt-click on [src] while it in a pocket or your off-hand to take out a round while it is there."
 
 /obj/item/ammo_box/magazine
 	w_class = WEIGHT_CLASS_SMALL //Default magazine weight, only differs for tiny mags and drums


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. If an ammo box is in your pocket, alt-clicking on it will, instead of taking the box, take a round out of the box. ~~You can take it into your hand like you would a deck of cards
- by click-dragging.~~ With the action moved to alt-click, other interactions of an ammo box should be unaffected.

## Why It's Good For The Game

Manual reload style points. I love reloading in the middle of a battle!

## Changelog

:cl:
tweak: You can now take individual rounds out of an ammo box in your pocket by alt-clicking!
/:cl:

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
