### PR TITLE
tweak: Blueprints QoL

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -345,7 +345,7 @@
 		newA = new area_choice
 		newA.setup(str)
 		newA.set_dynamic_lighting()
-		newA.has_gravity = oldA.has_gravity
+		newA.has_gravity = TRUE
 	else
 		newA = area_choice
 


### PR DESCRIPTION
Чертежи шаттла при создании новой зоны копировали параметры гравитации у предыдущей зоны, в случае космоса гравитация была равна 0 и требовала педальской магии для изменения зоны. Теперь принудительно заставляет чертежи шаттла устанавливать гравитацию, вместо того, чтобы звать педаль или специально садиться на планету.