### PR TITLE
Hotfix: ships and outpost

### DIFF
--- a/_maps/outpost/indie_space.dmm
+++ b/_maps/outpost/indie_space.dmm
@@ -2556,6 +2556,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/medbot,
 /turf/open/floor/plating,
 /area/outpost/maintenance/fore)
 "rp" = (
@@ -5819,11 +5820,14 @@
 /turf/open/floor/plasteel,
 /area/outpost/hallway/central)
 "Ki" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/neutral/diagonal,
+/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
+	dir = 8
 	},
-/turf/closed/indestructible/rock,
-/area/outpost/external)
+/mob/living/simple_animal/bot/medbot,
+/turf/open/floor/plasteel,
+/area/outpost/storage)
 "Kl" = (
 /obj/effect/turf_decal/corner/opaque/grey/full,
 /obj/structure/cable/yellow{
@@ -14401,7 +14405,7 @@ Rg
 Kx
 Kx
 Ml
-aw
+Ki
 aw
 zr
 Kx
@@ -19339,7 +19343,7 @@ mC
 mC
 HD
 HD
-Ki
+HD
 HD
 mC
 mC

--- a/_maps/shuttles/InteQ/inteq_hammerhead.dmm
+++ b/_maps/shuttles/InteQ/inteq_hammerhead.dmm
@@ -475,7 +475,7 @@
 	faction = list("turret","InteQ")
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/bridge)
 "ca" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -1608,7 +1608,7 @@
 	faction = list("turret","InteQ")
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/bridge)
 "jl" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -2431,7 +2431,7 @@
 	faction = list("turret","InteQ")
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/bridge)
 "oP" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4957,8 +4957,8 @@
 	req_access_txt = "147;148"
 	},
 /obj/machinery/light/directional/north,
-/obj/item/gun/ballistic/automatic/smg/inteq,
 /obj/item/gun/ballistic/shotgun/bulldog/inteq,
+/obj/item/ammo_box/magazine/m12g,
 /turf/open/floor/engine{
 	icon_state = "plastitanium";
 	explosion_block = 7
@@ -7495,7 +7495,7 @@
 	faction = list("turret","InteQ")
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/maintenance/central)
+/area/ship/bridge)
 "Ta" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,

--- a/_maps/shuttles/inteq/inteq_iron_maiden.dmm
+++ b/_maps/shuttles/inteq/inteq_iron_maiden.dmm
@@ -785,6 +785,8 @@
 /obj/item/ammo_box/magazine/p16/g36sh,
 /obj/item/ammo_box/magazine/smgm10mm,
 /obj/item/ammo_box/magazine/smgm10mm,
+/obj/item/ammo_box/magazine/skm_762_40,
+/obj/item/ammo_box/magazine/skm_762_40,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "EH" = (
@@ -1245,7 +1247,7 @@
 	req_access_txt = "147"
 	},
 /obj/item/gun/ballistic/automatic/assault/g36sh/inteq,
-/obj/item/gun/ballistic/automatic/smg/inteq,
+/obj/item/gun/ballistic/automatic/assault/skm/inteq,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "UC" = (
@@ -1479,6 +1481,7 @@
 /obj/item/ammo_box/c10mm,
 /obj/item/ammo_box/c10mm,
 /obj/item/ammo_box/c10mm,
+/obj/item/ammo_box/a762_40,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "ZZ" = (


### PR DESCRIPTION
Починка нескольких кораблей и удаление лишнего тайла на аванпосту.
Hammerhead: Управление всеми турелями корабля теперь осуществляется с одной консоли
Iron Maden: Замена утерянной винтовки