### PR TITLE
Небольшой ремапп

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -1,14 +1,35 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"aD" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
-	dir = 1
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/item/storage/bag/ore,
+/obj/structure/rack,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/mining_scanner,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
+"aD" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/industrial/outline,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/machinery/vending/wallmed{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "aK" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plasteel/tech/grid,
@@ -17,23 +38,11 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/medical)
 "aZ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
+/obj/machinery/light/directional/south,
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "bc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering";
-	req_access_txt = "10";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -46,14 +55,26 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "be" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/tank/jetpack/carbondioxide,
 /obj/item/clothing/suit/space/hardsuit/engine,
-/turf/open/floor/plasteel/tech/grid,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/structure/sign/poster/official/moth/delam{
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "bq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -65,17 +86,22 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "bx" = (
-/obj/effect/turf_decal/corner/opaque/black/half,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/light/directional/north,
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "by" = (
@@ -103,139 +129,27 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/dorm)
 "bB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"bL" = (
-/obj/machinery/mineral/ore_redemption{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"bL" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "bV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
-"cc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/flora/driftwood,
-/obj/structure/flora/ausbushes/leafybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/ship/dirt,
-/area/ship/hallway/central)
-"ch" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/border,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
-"cv" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"cD" = (
-/obj/machinery/door/airlock/security/glass{
-	req_one_access_txt = "1";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
-/area/ship/security)
-"cK" = (
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 10
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"cL" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"cN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/dorm)
-"cP" = (
-/obj/structure/chair/sofa/blue/corpo/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e"
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"dc" = (
-/obj/structure/chair/office{
-	dir = 4;
-	name = "tactical swivel chair"
-	},
-/obj/effect/decal/cleanable/food/pie_smudge,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
-"dh" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
@@ -246,18 +160,139 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"cc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"ch" = (
+/obj/effect/turf_decal/ntspaceworks_big/three{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"cv" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"cD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4;
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ship/security)
+"cK" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 8
+	},
+/obj/machinery/light/directional/west{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"cL" = (
+/obj/structure/closet/secure_closet/security,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/storage/belt/military,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/clothing/suit/armor/vest/bulletproof,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/stack/medical/gauze{
+	amount = 3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"cN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/mahogany,
+/area/ship/crew/dorm)
+"cP" = (
+/obj/structure/chair/sofa/blue/corpo/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 2
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"dc" = (
+/obj/machinery/button/door{
+	id = "teardrop_cargo";
+	pixel_x = -5;
+	pixel_y = 25
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "teardrop_holo";
+	pixel_x = 5;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/closet/mob_capture,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"dh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "di" = (
 /obj/structure/railing{
-	dir = 5
+	dir = 5;
+	layer = 2.08
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "du" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -265,25 +300,32 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "dv" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "dz" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 2
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "dK" = (
-/obj/effect/turf_decal/ntspaceworks_big/three,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "dP" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -292,25 +334,36 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "dU" = (
-/obj/effect/turf_decal/industrial/outline,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/glass/five{
-	pixel_x = 2;
-	pixel_y = 5
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 10
 	},
-/obj/item/stack/sheet/metal/five{
-	pixel_x = -3
+/obj/structure/closet/secure_closet/wall{
+	dir = 8;
+	name = "medicine cabinet";
+	pixel_x = -28
 	},
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
+/obj/item/storage/box/bodybags,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -2;
+	pixel_y = 7
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/item/storage/firstaid{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_y = -3;
+	pixel_x = -8
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/gun/ballistic/automatic/smg/proto,
+/obj/item/ammo_box/magazine/smgm9mm,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "dW" = (
-/obj/machinery/door/airlock/security/glass{
-	req_one_access_txt = "1";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -319,66 +372,83 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
+	},
+/obj/machinery/door/airlock/security/glass{
+	dir = 4;
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "ee" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
+"ev" = (
+/obj/structure/closet/wall{
+	name = "uniform closet";
+	pixel_y = -30
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/wood/mahogany,
+/area/ship/crew/dorm)
+"eF" = (
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"ev" = (
-/obj/machinery/light/directional/south,
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"eF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/item/radio/intercom/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "fa" = (
 /turf/template_noop,
 /area/template_noop)
 "fh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/down,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/decal/cleanable/garbage,
+/obj/machinery/light/broken/directional/north,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "fl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/vending/wallmed{
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/defibrillator_mount/loaded{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "fq" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "ft" = (
-/obj/structure/railing,
-/obj/structure/rack,
-/obj/item/pickaxe,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "fI" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -402,17 +472,20 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/security)
 "gl" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/railing{
+	dir = 6;
+	layer = 4.1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -20
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plating,
+/area/ship/engineering)
 "gz" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -431,32 +504,42 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "gD" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/storage/belt/military,
-/obj/item/radio{
-	icon_state = "sec_radio"
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/clothing/suit/armor/vest/bulletproof,
-/obj/item/kitchen/knife/combat/survival,
-/obj/machinery/light/directional/west,
-/obj/item/stack/medical/gauze{
-	amount = 3
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/security)
-"hc" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
-	dir = 1
+/obj/structure/closet/secure_closet{
+	icon_state = "brig_phys";
+	name = "paramedic's locker"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
+/obj/item/clothing/accessory/pocketprotector,
+/obj/item/clothing/glasses/hud/health/sunglasses,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/storage/belt/medical/webbing/paramedic,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/belt/medical/webbing/paramedic,
+/obj/item/storage/backpack/duffelbag/med,
+/obj/item/storage/backpack/satchel/med,
+/obj/item/storage/backpack/medic,
+/obj/item/storage/backpack/messenger/para,
+/obj/item/clothing/shoes/sneakers/blue,
+/obj/item/clothing/under/rank/medical/paramedic/skirt,
+/obj/item/clothing/under/rank/medical/paramedic,
+/obj/item/clothing/head/soft/paramedic,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"hc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "hg" = (
 /obj/structure/closet/wall/orange{
 	dir = 4;
@@ -476,6 +559,17 @@
 /obj/item/stock_parts/capacitor/adv,
 /obj/item/stock_parts/micro_laser/high,
 /obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/circuitboard/machine/pacman/super{
+	pixel_x = 6;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "hh" = (
@@ -496,16 +590,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ho" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/sprayweb,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "hv" = (
 /obj/structure/table,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 1
-	},
 /obj/item/newspaper{
 	pixel_x = -2;
 	pixel_y = 7
@@ -517,6 +607,10 @@
 /obj/item/newspaper{
 	pixel_y = -3;
 	pixel_x = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 1
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
@@ -542,12 +636,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/stairs/right{
-	dir = 8
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "ih" = (
-/obj/effect/turf_decal/corner/opaque/black/three_quarters,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "ii" = (
@@ -558,19 +651,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "it" = (
-/obj/effect/turf_decal/ntspaceworks_big/four,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/structure/closet/emcloset/wall/directional/south,
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "iz" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/medical)
@@ -603,64 +696,52 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "iS" = (
-/obj/structure/sign/poster/official/help_others{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "iU" = (
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ja" = (
-/obj/structure/railing/corner{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"jd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/holosign/barrier/engineering/infinite,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
-"jd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
 "jh" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "jj" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/landmark/observer_start,
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/machinery/light/directional/west,
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
 "jn" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 4
@@ -668,23 +749,21 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "jp" = (
-/obj/machinery/door/poddoor{
-	id = "teardrop_cargo";
-	name = "Cargo Bay"
+/obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 6
 	},
-/obj/docking_port/mobile{
-	can_move_docking_ports = 1;
-	port_direction = 4;
-	preferred_direction = 4
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "jG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "jT" = (
 /obj/structure/table/reinforced,
@@ -714,27 +793,38 @@
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "kh" = (
-/obj/docking_port/stationary{
-	dwidth = 8;
-	width = 27;
-	height = 15;
-	dir = 2
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_y = 23;
+	pixel_x = 11
 	},
-/turf/template_noop,
-/area/template_noop)
-"kl" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+/obj/machinery/computer/crew,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"kl" = (
+/obj/structure/closet/firecloset/wall/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ko" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -745,24 +835,32 @@
 	},
 /area/ship/engineering)
 "kB" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"kG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/computer/operating,
+/obj/structure/window/reinforced{
+	dir = 9
 	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"kG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "kW" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/corner/opaque/black/three_quarters{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/hallway/central)
 "ll" = (
 /turf/closed/wall/mineral/titanium,
@@ -772,6 +870,13 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/stairs/right{
 	dir = 1
 	},
@@ -783,11 +888,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "lI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/salvageable/protolathe,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "lL" = (
 /obj/structure/cable{
@@ -812,97 +915,80 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "lR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table,
+/obj/effect/decal/cleanable/sprayweb,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "lV" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer2,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"lW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"lW" = (
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 5
+	},
+/obj/structure/chair/sofa/grey/right/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "ma" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/flora/rock/asteroid,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/ship/dirt,
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "mb" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 7
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 8;
+	name = "Environment to Air"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "mc" = (
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/corner/opaque/black/three_quarters,
+/obj/machinery/computer/arcade/battle{
+	dir = 8;
+	pixel_x = 5
 	},
-/obj/machinery/computer/helm/viewscreen/directional/east,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "mi" = (
 /turf/open/floor/engine/hull,
 /area/ship/external)
 "mo" = (
+/obj/structure/railing,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "mq" = (
-/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/ship/security)
 "mv" = (
@@ -916,26 +1002,38 @@
 /area/ship/crew/dorm/dormtwo)
 "mx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/machinery/computer/monitor{
+	dir = 8;
+	pixel_x = 12;
+	density = 0
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "mK" = (
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "mO" = (
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "nh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "engine fuel pump"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /mob/living/simple_animal/mouse/white{
 	name = "Wire eaters"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "nl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -952,142 +1050,184 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
 "no" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
+"nq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"nq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/reagent_dispensers/fueltank{
-	tank_volume = 0
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "nr" = (
-/obj/machinery/holopad/emergency/medical,
-/obj/effect/turf_decal/box/white{
-	color = "#2CB2E8"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"nt" = (
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
-"nu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/left{
+	dir = 1
+	},
+/area/ship/cargo)
+"nt" = (
+/obj/effect/turf_decal/ntspaceworks_big/eight{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"nu" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
+	},
+/turf/open/floor/plating,
 /area/ship/engineering)
 "nA" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench/beige/directional/south,
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/number/right_zero,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "nB" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "nF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/item/radio/old,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "nO" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "nQ" = (
-/obj/machinery/power/shieldwallgen/atmos{
-	anchored = 1;
-	dir = 4;
-	id = "teardrop_holo";
-	locked = 1
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 10
 	},
-/obj/machinery/door/poddoor{
-	id = "teardrop_cargo";
-	name = "Cargo Bay"
-	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "ob" = (
 /obj/structure/chair/sofa/blue/corpo/right/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/structure/sign/poster/official/moth/smokey{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 4
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "oc" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/number/left_four,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "ot" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ov" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/item/kirbyplants/dead,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ow" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ox" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/airalarm/directional/south,
-/obj/structure/closet/crate/bin,
+/obj/item/bedsheet/random,
+/obj/structure/bed,
+/obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "oI" = (
@@ -1098,19 +1238,27 @@
 /area/ship/bridge)
 "oO" = (
 /obj/structure/chair/sofa/olive/old/left/directional/south,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "oU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage,
-/obj/machinery/light/broken/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/machinery/light/directional/east,
+/obj/structure/fluff/hedge/opaque,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "oX" = (
-/obj/effect/turf_decal/ntspaceworks_big/one,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 7
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "pd" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -1118,88 +1266,95 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "pf" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "teardrop_eng";
+	name = "Engine Shutters";
+	pixel_x = 31;
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "pg" = (
-/obj/machinery/computer/med_data{
+/obj/effect/decal/cleanable/wrapping,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
+"ph" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"ph" = (
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "pr" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -20
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/decal/cleanable/greenglow/ecto,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "px" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/light/directional/south,
+/obj/machinery/mineral/ore_redemption{
+	dir = 8;
+	output_dir = 8;
+	input_dir = 8
 	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "pI" = (
-/obj/structure/closet/wall{
-	name = "Janitorial supplies";
-	pixel_y = 30;
-	dir = 1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/obj/item/storage/bag/trash,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/suit/space/hardsuit/engine,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "pP" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 5
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "pW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "pX" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/machinery/computer/med_data,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "qe" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/fancy/royalblack,
@@ -1217,24 +1372,22 @@
 /area/ship/crew/dorm/dormtwo)
 "qn" = (
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"qq" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/clothing/suit/space/hardsuit/security,
-/obj/item/clothing/mask/gas/clown_hat,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
-"qv" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"qq" = (
+/obj/machinery/porta_turret/ship/ballistic{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
+"qv" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
 /area/ship/hallway/central)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1247,22 +1400,32 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "re" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4";
+	tag = null
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "rk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "rp" = (
 /obj/structure/table,
@@ -1270,19 +1433,14 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 9
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "rV" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "rW" = (
@@ -1293,23 +1451,21 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "so" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/effect/turf_decal/number/right_four,
-/obj/effect/turf_decal/number/left_two,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "sw" = (
-/obj/machinery/vending/cigarette,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 4
+	color = "#2e211e";
+	dir = 1
 	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "sy" = (
@@ -1327,24 +1483,47 @@
 /area/ship/engineering)
 "sC" = (
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e"
+	color = "#2e211e";
+	dir = 2
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "sG" = (
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -32
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/blue/full,
+/obj/effect/turf_decal/corner/opaque/mauve/border{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/medical,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/toy/plush/blahaj{
+	name = "Best medic in the sector"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "sH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/blue/corpo/directional/east,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/light/directional/west{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
+"sN" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "teardrop_windows"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "sW" = (
 /obj/machinery/door/poddoor{
 	id = "teardrop_cargo";
@@ -1375,35 +1554,26 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "tk" = (
-/obj/structure/chair/sofa/blue/corpo/left/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 9
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
 	},
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/ebony,
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "tn" = (
 /obj/structure/railing{
-	dir = 6;
-	layer = 4.1
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/industrial/warning{
-	dir = 10
+	dir = 9
 	},
+/obj/machinery/power/terminal,
+/obj/machinery/power/port_gen/pacman,
 /obj/item/stack/sheet/mineral/plasma/twenty,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "tp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1412,9 +1582,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "tt" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "ty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -1423,12 +1593,14 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "tM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/reagent_dispensers/fueltank{
+	tank_volume = 0
 	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/ash/large,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "tR" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -1438,33 +1610,40 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "ul" = (
-/obj/effect/turf_decal/ntspaceworks_big/seven,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/insectguts,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"ur" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/effect/turf_decal/corner/opaque/green/border,
-/obj/structure/table,
-/obj/item/radio/old,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"ut" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"ur" = (
+/obj/machinery/light/directional/east,
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = 32
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/industrial/outline/red,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"ut" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ux" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1482,16 +1661,21 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "vf" = (
-/obj/structure/railing,
-/obj/machinery/computer/cargo/express{
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
+	},
+/obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "vx" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 1
 	},
 /turf/open/floor/wood/ebony,
@@ -1504,7 +1688,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e"
+	color = "#2e211e";
+	dir = 2
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
@@ -1519,17 +1704,17 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "vV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/table/optable,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "vY" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/mask/gas/sechailer,
@@ -1561,103 +1746,107 @@
 	},
 /area/ship/bridge)
 "wc" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/ash/large,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/power/rtg{
+	anchored = 0
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "we" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/structure/table/greyscale,
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
-"wf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"wm" = (
+/obj/effect/turf_decal/ntspaceworks_big/five{
 	dir = 1
 	},
-/obj/structure/closet/wall/orange/directional/east,
-/obj/item/radio/headset/headset_eng,
-/obj/item/radio/headset/headset_eng,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/clothing/glasses/welding,
-/obj/item/storage/backpack/industrial,
-/obj/item/clothing/glasses/meson/sunglasses,
-/obj/item/clothing/glasses/meson/sunglasses,
-/obj/item/clothing/under/rank/engineering/engineer/nt/lp,
-/obj/item/clothing/under/rank/engineering/engineer/nt/lp,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"wm" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "wu" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/storage/belt/military,
-/obj/item/radio{
-	icon_state = "sec_radio"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/item/clothing/suit/armor/vest/bulletproof,
-/obj/item/kitchen/knife/combat/survival,
-/obj/item/stack/medical/gauze{
-	amount = 3
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/security)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing{
+	dir = 5;
+	layer = 2.08
+	},
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/driftwood,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/ship/dirt,
+/area/ship/hallway/central)
 "wx" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "wy" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "brig_phys";
-	name = "paramedic's locker"
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
 	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/head/soft/paramedic,
-/obj/item/clothing/under/rank/medical/paramedic,
-/obj/item/clothing/under/rank/medical/paramedic/skirt,
-/obj/item/clothing/shoes/sneakers/blue,
-/obj/item/storage/backpack/messenger/para,
-/obj/item/storage/backpack/medic,
-/obj/item/storage/backpack/satchel/med,
-/obj/item/storage/backpack/duffelbag/med,
-/obj/item/storage/belt/medical/webbing/paramedic,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/accessory/pocketprotector,
-/obj/item/storage/belt/medical/webbing/paramedic,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/computer/cargo/express,
+/obj/item/toy/plush/lizardplushie{
+	pixel_x = 14
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "wD" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm/dormtwo)
 "wF" = (
-/obj/effect/turf_decal/ntspaceworks_big/two,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"wI" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1688,31 +1877,19 @@
 /area/ship/crew/dorm)
 "xj" = (
 /obj/structure/chair/sofa/blue/corpo/corner/directional/north,
+/obj/effect/decal/cleanable/food/pie_smudge,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 10
 	},
-/obj/effect/decal/cleanable/food/pie_smudge,
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "xz" = (
-/obj/structure/closet/secure_closet/security,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/storage/belt/military,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/suit/armor/vest/bulletproof,
-/obj/item/toy/plush/nukeplushie{
-	name = "Spy Syndicate plush"
-	},
-/obj/item/kitchen/knife/combat/survival,
-/obj/machinery/light/directional/east,
-/obj/item/stack/medical/gauze{
-	amount = 3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/security)
+/obj/machinery/airalarm/directional/south,
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "xH" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/gun/ballistic/revolver/russian{
@@ -1798,9 +1975,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/stairs/left{
-	dir = 8
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "yk" = (
 /obj/machinery/door/airlock{
@@ -1848,18 +2023,25 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "yL" = (
-/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "yZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/holosign/barrier/engineering,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/table,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "zk" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1874,14 +2056,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "zw" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "zC" = (
 /turf/open/floor/plasteel/stairs{
@@ -1889,22 +2072,12 @@
 	},
 /area/ship/security)
 "zQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/light/directional/south,
+/obj/machinery/space_heater,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "zR" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -20
-	},
-/obj/machinery/firealarm/directional/south{
-	pixel_y = -36
-	},
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_x = -6
@@ -1915,25 +2088,22 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/ship/security)
 "zZ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Treatment Center"
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "Aa" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -1959,6 +2129,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
+"Av" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
 "Ax" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
@@ -1978,28 +2154,41 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "AS" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/sovietsoda{
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "AU" = (
-/turf/open/floor/plasteel/stairs/left{
-	dir = 8
-	},
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "AY" = (
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/black/three_quarters{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
@@ -2013,6 +2202,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Bw" = (
@@ -2020,51 +2213,86 @@
 /area/ship/hallway/central)
 "BD" = (
 /obj/machinery/porta_turret/ship/ballistic{
-	dir = 10
+	dir = 9
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
 "BO" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/number/left_zero,
-/obj/effect/turf_decal/number/right_five,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "BR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
-/turf/open/floor/wood/ebony,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "BW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "BZ" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/effect/turf_decal/corner/opaque/green/border,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Cj" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/ntspaceworks_big/one{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Cj" = (
+/obj/machinery/power/shieldwallgen/atmos{
+	anchored = 1;
+	dir = 8;
+	id = "teardrop_holo";
+	locked = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "teardrop_cargo";
+	name = "Cargo Bay"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "Cn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -2093,36 +2321,27 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Cw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/corner/opaque/black/half,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"CB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/ship/dirt,
-/area/ship/hallway/central)
-"CG" = (
 /obj/structure/sign/poster/official/get_your_legs{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"CB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"CG" = (
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "CM" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -2131,12 +2350,25 @@
 /turf/open/floor/plating,
 /area/ship/crew/dorm/dormtwo)
 "CS" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench/beige/directional/north,
-/obj/effect/turf_decal/corner/opaque/black/half,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/gas/clown_hat,
+/obj/item/clothing/suit/space/hardsuit/security,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -12
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -39
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/ship/security)
 "Dl" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -2157,44 +2389,59 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Ds" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 2
+/obj/machinery/light/directional/south,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Dt" = (
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
-"DD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/left,
-/area/ship/cargo)
-"DM" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/half{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"Dt" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/ship/security)
+"DD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"DM" = (
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/storage/belt/military,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/clothing/suit/armor/vest/bulletproof,
+/obj/item/toy/plush/nukeplushie{
+	name = "Spy Syndicate plush"
+	},
+/obj/item/kitchen/knife/combat/survival,
+/obj/machinery/light/directional/east,
+/obj/item/stack/medical/gauze{
+	amount = 3
+	},
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
 "DN" = (
 /obj/effect/turf_decal/corner/opaque/black/half,
 /turf/open/floor/plasteel,
@@ -2206,12 +2453,10 @@
 	pixel_x = 15
 	},
 /obj/item/toy/plush/moth/punished,
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "DX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -2228,40 +2473,56 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"Eb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
+"Eb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "Eg" = (
-/obj/structure/chair/sofa/purple/left/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/item/storage/bag/ore,
+/obj/structure/rack,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/mining_scanner,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "Eh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/machinery/light/directional/west{
+	light_color = "#e8eaff"
 	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/pipedispenser,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Ey" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/dormtwo)
 "EH" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering";
-	req_access_txt = "10";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -2271,24 +2532,26 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering";
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Fc" = (
-/obj/machinery/button/door{
-	dir = 1;
-	id = "teardrop_cargo";
-	pixel_x = -5;
-	pixel_y = -25
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/food/pie_smudge,
+/obj/structure/chair/office{
+	dir = 8;
+	name = "tactical swivel chair"
 	},
-/obj/machinery/button/shieldwallgen{
-	dir = 1;
-	id = "teardrop_holo";
-	pixel_x = 5;
-	pixel_y = -24
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/structure/chair/office{
+	dir = 8;
+	name = "tactical swivel chair"
 	},
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Fd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -2300,9 +2563,6 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/caseless/a858{
 	pixel_y = 11;
@@ -2311,37 +2571,50 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Fr" = (
-/obj/machinery/light/directional/east,
-/obj/structure/fluff/hedge/opaque,
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Fs" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/border,
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/secure/weapon{
+	req_access_txt = "1"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/obj/item/gun/ballistic/automatic/smg/proto,
+/obj/item/gun/ballistic/automatic/smg/proto,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/ammo_box/magazine/smgm9mm,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "FH" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"FL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Gf" = (
-/obj/structure/table,
-/obj/machinery/computer/helm/viewscreen/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
+"FL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 1
+	},
+/area/ship/cargo)
 "Gk" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -2351,8 +2624,15 @@
 /turf/open/floor/plating,
 /area/ship/medical)
 "Gm" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "GY" = (
@@ -2360,53 +2640,56 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "GZ" = (
-/obj/effect/turf_decal/ntspaceworks_big/eight,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Hh" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "Hi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/effect/landmark/observer_start,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/number/left_five,
+/obj/effect/turf_decal/number/right_two,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Hx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 6
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Hy" = (
 /obj/item/radio/intercom/directional/east,
+/obj/structure/closet/secure_closet/security,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/storage/belt/military,
+/obj/item/clothing/suit/armor/vest/bulletproof,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/stack/medical/gauze{
+	amount = 3
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "HL" = (
@@ -2420,11 +2703,11 @@
 /area/ship/engineering)
 "HT" = (
 /obj/structure/chair/sofa/blue/corpo/corner/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "Ia" = (
@@ -2432,60 +2715,63 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Ik" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"Is" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Is" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/holosign/barrier/engineering/infinite,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Ix" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
-	dir = 1
+/obj/effect/decal/cleanable/garbage{
+	pixel_y = -2
 	},
+/obj/effect/decal/cleanable/garbage{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/garbage{
+	pixel_y = 7;
+	pixel_x = 9
+	},
+/obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "IB" = (
+/obj/structure/railing,
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/obj/structure/railing,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "IG" = (
-/obj/machinery/holopad/emergency/cargo,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "IS" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ship/security)
 "IT" = (
-/turf/open/floor/plasteel/stairs/right,
-/area/ship/cargo)
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 6
+	},
+/obj/structure/chair/sofa/grey/left/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Ji" = (
 /obj/structure/railing{
 	dir = 10
@@ -2496,15 +2782,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Jk" = (
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/power/terminal{
 	dir = 8
 	},
+/obj/structure/closet/crate/trashcart,
+/obj/item/reagent_containers/food/snacks/grown/cabbage,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "JY" = (
@@ -2524,10 +2810,10 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "Ke" = (
-/obj/effect/turf_decal/corner/opaque/black/half,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/turf_decal/corner/opaque/neutral/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Km" = (
@@ -2558,9 +2844,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "KE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/plasteel/stairs/left,
 /area/ship/engineering)
 "KI" = (
@@ -2571,9 +2854,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "KP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
@@ -2597,20 +2877,20 @@
 /area/ship/hallway/central)
 "KW" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/guncase{
-	desc = "A locker that holds weapons.";
-	name = "weapon locker"
+/obj/structure/closet/secure_closet/security,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/storage/belt/military,
+/obj/item/radio{
+	icon_state = "sec_radio"
 	},
-/obj/item/gun/ballistic/automatic/smg/vector{
-	pixel_y = 7
+/obj/item/clothing/suit/armor/vest/bulletproof,
+/obj/item/kitchen/knife/combat/survival,
+/obj/item/stack/medical/gauze{
+	amount = 3
 	},
-/obj/item/gun/ballistic/automatic/smg/vector{
-	pixel_y = -7
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/gun/ballistic/automatic/smg/vector{
-	pixel_y = -13
-	},
-/obj/item/gun/ballistic/automatic/smg/vector,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "KX" = (
@@ -2622,20 +2902,34 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "Ld" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "engine fuel pump"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Le" = (
-/obj/machinery/light/directional/east,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Li" = (
 /obj/machinery/computer/cryopod/directional/north,
 /obj/structure/table/wood,
 /obj/item/toy/plush/slimeplushie,
+/obj/structure/bedsheetbin,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "Lo" = (
@@ -2645,26 +2939,24 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Lq" = (
+/obj/machinery/vending/security,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/ship/security)
+"LE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"LE" = (
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/ship/dirt,
 /area/ship/hallway/central)
 "LI" = (
-/obj/structure/chair/sofa/blue/corpo/directional/east,
+/obj/structure/chair/sofa/blue/corpo/left/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
-	dir = 8
+	color = "#2e211e";
+	dir = 9
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/ebony,
@@ -2677,42 +2969,76 @@
 /turf/open/floor/plating,
 /area/ship/crew/dorm)
 "Mg" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/structure/railing{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/chair/bench/beige/directional/south,
-/obj/effect/turf_decal/corner/opaque/black/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/number/left_two,
+/obj/effect/turf_decal/number/right_zero,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "MP" = (
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 5
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
-"MS" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/effect/turf_decal/corner/opaque/green/border,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 8
 	},
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"MS" = (
+/obj/effect/turf_decal/ntspaceworks_big/two{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "Ne" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/ship/security)
+"Nn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "No" = (
 /obj/structure/chair/sofa/olive/old/right/directional/south,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Nr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2722,10 +3048,19 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 2
+	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Nt" = (
@@ -2735,16 +3070,17 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "NB" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/turf_decal/ntspaceworks_big/six{
+	dir = 1
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/suit/space/hardsuit/medical,
-/obj/item/toy/plush/blahaj,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "NO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -2779,20 +3115,34 @@
 	pixel_x = 21;
 	pixel_y = -12
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Oc" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/obj/machinery/power/shieldwallgen/atmos{
+	anchored = 1;
+	dir = 4;
+	id = "teardrop_holo";
+	locked = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "teardrop_cargo";
+	name = "Cargo Bay"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "Oi" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"Oo" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/corner/opaque/black/half{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -2814,16 +3164,21 @@
 /obj/item/radio/headset/heads/captain/alt,
 /obj/item/screwdriver,
 /obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/tank/jetpack/suit,
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "Ou" = (
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench/beige/directional/north,
-/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/machinery/light_switch{
+	pixel_y = 23;
+	pixel_x = 11
+	},
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Ow" = (
@@ -2833,28 +3188,29 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/dorm)
 "OP" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/poddoor{
+	id = "teardrop_cargo";
+	name = "Cargo Bay"
 	},
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/docking_port/mobile{
+	dir = 2;
+	launch_status = 0;
+	port_direction = 1;
+	preferred_direction = 1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo)
 "OY" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Pa" = (
@@ -2868,57 +3224,62 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "PL" = (
-/obj/effect/turf_decal/ntspaceworks_big/six,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "PS" = (
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4";
-	tag = null
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 9
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "PV" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/item/defibrillator/loaded,
-/obj/structure/closet/secure_closet/wall{
-	dir = 4;
-	name = "medicine cabinet";
-	pixel_x = 28
-	},
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid/medical{
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"PZ" = (
+/obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
+"PZ" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 10
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "Qb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 2
+	},
+/obj/structure/filingcabinet/double{
+	pixel_y = 14;
+	density = 0;
+	pixel_x = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Qg" = (
@@ -2929,26 +3290,22 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Qm" = (
-/obj/effect/turf_decal/corner/opaque/mauve/full,
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/security,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/ship/security)
 "Qq" = (
-/obj/structure/railing/corner,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "QC" = (
@@ -2964,16 +3321,21 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "QF" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/autolathe,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/greenglow/ecto,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "QG" = (
-/obj/effect/turf_decal/corner/opaque/ntblue/border,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/obj/effect/turf_decal/ntspaceworks_big/four{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "QP" = (
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
@@ -2982,23 +3344,17 @@
 	dir = 8;
 	layer = 4.1
 	},
-/obj/machinery/holopad/emergency/engineering,
-/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "QY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 1
+	},
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/effect/turf_decal/number/left_zero,
-/obj/effect/turf_decal/number/right_two,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Rc" = (
@@ -3006,21 +3362,31 @@
 /area/ship/cargo)
 "Ro" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/right,
 /area/ship/engineering)
 "Rp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/railing/corner,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "Rq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3043,85 +3409,87 @@
 /area/ship/security)
 "RA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "RJ" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "RR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "RS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm)
 "Sb" = (
-/obj/structure/closet/wall{
-	name = "uniform closet";
-	pixel_y = -30
-	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/obj/item/flashlight/seclite,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/dorm)
-"Sc" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/obj/structure/closet/firecloset/wall/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Sd" = (
-/obj/machinery/power/terminal{
+/obj/structure/closet/wall{
+	name = "Janitorial supplies";
+	pixel_y = 30;
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/mop,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"Sc" = (
+/obj/machinery/light/directional/west{
+	light_color = "#e8eaff"
+	},
+/obj/structure/railing,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Sd" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/effect/decal/cleanable/glass,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Sf" = (
-/obj/machinery/light/directional/east,
-/obj/structure/fluff/hedge/opaque,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/corner/opaque/neutral/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Sg" = (
@@ -3132,54 +3500,67 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "So" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"Sr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"SM" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/engine,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/structure/sign/poster/official/moth/delam{
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"ST" = (
-/obj/structure/table/glass,
 /obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Sr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 1
+	},
+/obj/structure/table/greyscale,
+/obj/item/paper_bin{
+	pixel_x = -6
+	},
+/obj/item/pen/fountain{
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"ST" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/ntblue/mono,
+/obj/effect/turf_decal/siding/wood{
+	color = "#c0c0c0";
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "SU" = (
-/obj/structure/railing,
-/obj/structure/chair/bench/beige/directional/north,
-/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/structure/sign/poster/official/help_others{
+	pixel_y = 32
+	},
+/obj/structure/fluff/hedge/opaque,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Ta" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/ship/security)
+"Tv" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/corner/opaque/blue/full,
+/obj/effect/turf_decal/corner/opaque/mauve/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "TH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/stairs{
@@ -3209,9 +3590,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Ub" = (
@@ -3220,44 +3598,51 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Ug" = (
-/obj/machinery/door/airlock/medical{
-	name = "Treatment Center"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "UC" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light/directional/south,
-/obj/structure/chair/sofa/purple/right/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "UH" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/dorm)
 "UY" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
-"Va" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/closet/emcloset/wall/directional/south,
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Va" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "Vc" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/corner/opaque/black/half{
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Vl" = (
@@ -3269,77 +3654,93 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Vo" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/clothing/suit/space/hardsuit/security,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/ship/security)
+/obj/machinery/light/directional/west{
+	light_color = "#e8eaff"
+	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/corner/opaque/blue/full,
+/obj/effect/turf_decal/corner/opaque/mauve/border{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Vp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/closet/wall/orange/directional/east,
+/obj/item/radio/headset/headset_eng,
+/obj/item/radio/headset/headset_eng,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/backpack/industrial,
+/obj/item/clothing/glasses/meson/sunglasses,
+/obj/item/clothing/glasses/meson/sunglasses,
+/obj/item/clothing/under/rank/engineering/engineer/nt,
+/obj/item/clothing/under/rank/engineering/engineer/nt,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Vv" = (
+/obj/structure/chair/sofa/blue/corpo/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#2e211e";
+	dir = 2
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"Wj" = (
+/obj/docking_port/stationary{
+	width = 27;
+	height = 15;
+	dwidth = 10
+	},
+/turf/template_noop,
+/area/template_noop)
+"Wl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner,
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Wr" = (
+/obj/effect/turf_decal/ntspaceworks_big/seven{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/insectguts,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"Vv" = (
-/obj/structure/chair/sofa/blue/corpo/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	color = "2e211e"
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"VG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/black/mono,
-/obj/machinery/computer/arcade{
-	pixel_y = 23;
-	density = 0
-	},
-/turf/open/floor/plasteel,
-/area/ship/hallway/central)
-"Wj" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/light/directional/north,
-/obj/item/toy/plush/lizardplushie{
-	pixel_x = 14
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"Wl" = (
-/obj/structure/railing,
-/obj/structure/rack,
-/obj/item/storage/bag/ore,
-/obj/item/mining_scanner,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
-"Wm" = (
-/turf/open/floor/plasteel/stairs/right{
-	dir = 8
-	},
-/area/ship/engineering)
-"Wr" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/medical)
 "Ww" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/fluff/hedge/opaque,
+/obj/effect/turf_decal/corner/opaque/neutral/full,
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "WC" = (
@@ -3352,6 +3753,29 @@
 /obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
+/area/ship/hallway/central)
+"WI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/palebush,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/ship/dirt,
 /area/ship/hallway/central)
 "WL" = (
 /obj/machinery/airalarm/directional/north,
@@ -3368,12 +3792,13 @@
 /turf/open/floor/wood/bamboo,
 /area/ship/crew/dorm/dormtwo)
 "WZ" = (
-/obj/effect/turf_decal/corner/opaque/blue/border{
-	dir = 1
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
 	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "Xa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -3408,9 +3833,16 @@
 /turf/open/floor/plating,
 /area/ship/medical)
 "Xn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.08
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/cargo)
 "Xt" = (
 /obj/effect/turf_decal/industrial/outline/blue,
 /obj/structure/closet/crate/large{
@@ -3420,11 +3852,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "XD" = (
-/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/half{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "XO" = (
@@ -3436,36 +3870,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "XT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light/directional/west{
-	light_color = "#e8eaff"
-	},
-/obj/structure/table,
-/obj/machinery/button/door{
-	id = "teardrop_eng";
-	name = "Engine Shutters";
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "XY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "Yj" = (
@@ -3481,7 +3899,7 @@
 /area/ship/cargo)
 "Yy" = (
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 1
 	},
 /obj/machinery/jukebox,
@@ -3494,17 +3912,18 @@
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "YK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/holosign/barrier/engineering,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/effect/turf_decal/corner/opaque/neutral/full,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "YP" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/table,
+/obj/machinery/computer/helm/viewscreen/directional/south,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
 "YV" = (
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 5
 	},
 /turf/open/floor/wood/ebony,
@@ -3518,58 +3937,41 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "Zc" = (
-/obj/machinery/holopad/emergency/security,
-/obj/effect/turf_decal/box/white{
-	color = "#e82c2c"
-	},
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/railing{
 	dir = 10
 	},
+/obj/structure/guncase{
+	desc = "A locker that holds weapons.";
+	name = "weapon locker"
+	},
+/obj/item/gun/ballistic/automatic/smg/vector{
+	pixel_y = -13
+	},
+/obj/item/gun/ballistic/automatic/smg/vector{
+	pixel_y = -7
+	},
+/obj/item/gun/ballistic/automatic/smg/vector,
+/obj/item/gun/ballistic/automatic/smg/vector{
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Zm" = (
-/obj/effect/turf_decal/ntspaceworks_big/five,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Zx" = (
-/obj/machinery/power/shieldwallgen/atmos{
-	anchored = 1;
-	dir = 8;
-	id = "teardrop_holo";
-	locked = 1
-	},
-/obj/machinery/door/poddoor{
-	id = "teardrop_cargo";
-	name = "Cargo Bay"
-	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/obj/structure/bed/pod,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "ZC" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
-"ZE" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"ZH" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3577,15 +3979,34 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/cargo)
+/obj/machinery/door/airlock/medical/glass{
+	name = "Treatment Center"
+	},
+/obj/effect/turf_decal/trimline/opaque/bottlegreen/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"ZE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ZH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/black/mono,
+/turf/open/floor/plasteel,
+/area/ship/hallway/central)
 "ZM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "2e211e";
+	color = "#2e211e";
 	dir = 6
 	},
 /turf/open/floor/wood/ebony,
@@ -3596,26 +4017,27 @@ fa
 fa
 fa
 fa
-yz
-jn
-jn
-oI
-sB
-sB
-yz
-sB
-sB
-oI
-jn
-jn
-yz
 fa
+yz
+jn
+jn
+oI
+sB
+sB
+yz
+sB
+sB
+oI
+jn
+jn
+yz
 fa
 fa
 fa
 fa
 "}
 (2,1,1) = {"
+fa
 fa
 fa
 fa
@@ -3637,28 +4059,27 @@ fa
 fa
 fa
 fa
-fa
 "}
 (3,1,1) = {"
 fa
 fa
 fa
+fa
+BD
 yz
-yz
-Sc
 kl
 XT
-rV
-pr
+Sc
+Sd
 QF
 rV
 Sd
 Jk
 Eh
 Va
+it
 yz
-yz
-fa
+BD
 fa
 fa
 fa
@@ -3667,22 +4088,22 @@ fa
 fa
 fa
 fa
+fa
 yz
-eF
 nu
 wI
-cL
+rk
 mo
 Qq
+Rp
 OY
-ja
+eF
 TS
 nh
 Ld
-rk
 jG
+WZ
 yz
-fa
 fa
 fa
 fa
@@ -3690,33 +4111,34 @@ fa
 (5,1,1) = {"
 fa
 fa
-Nt
+fa
+wx
 yz
-ot
+ow
 ov
-px
 tn
+gl
 AU
 ic
 Vl
 yf
-Wm
+AU
 di
 GY
-lV
 So
+MP
 yz
-BD
-fa
+wx
 fa
 fa
 "}
 (6,1,1) = {"
 fa
 fa
+fa
 wx
-ho
 lR
+nB
 ko
 ty
 aK
@@ -3726,23 +4148,23 @@ QQ
 Fn
 DX
 KP
-rk
+AU
 KE
-Ds
 mb
+oX
 wx
-fa
 fa
 fa
 "}
 (7,1,1) = {"
 fa
 fa
+fa
 dP
-mO
+tt
 ut
 lo
-wf
+Vp
 hg
 NX
 Bu
@@ -3753,18 +4175,18 @@ FH
 jV
 Ro
 ot
-zQ
+ZE
 dP
-fa
 fa
 fa
 "}
 (8,1,1) = {"
 fa
 fa
+fa
 dP
-YK
 Is
+nq
 yz
 yz
 yz
@@ -3777,27 +4199,27 @@ yz
 yz
 yz
 zw
-ow
+nO
 dP
-fa
 fa
 fa
 "}
 (9,1,1) = {"
 fa
 fa
+fa
 dP
-ZE
 yZ
+jd
 du
 rp
-wc
 cK
-qV
 PZ
+qV
+WI
 Qg
-tk
 LI
+sH
 xj
 du
 No
@@ -3805,178 +4227,177 @@ DS
 dP
 fa
 fa
-fa
 "}
 (10,1,1) = {"
 fa
 fa
-wx
-ZE
+fa
+Nt
 lI
+Ik
 du
-BR
+sw
 ym
 sC
 Ia
-Vp
+wu
 Ia
 hv
 KQ
 cP
 du
 oO
-Gf
-wx
-fa
+YP
+Nt
 fa
 fa
 "}
 (11,1,1) = {"
 fa
+fa
 mi
 wx
-oU
 fh
+iS
 du
 vx
 ux
 vB
 nl
-Lq
+LE
 WC
 Yy
 by
 Vv
 du
 qn
-ev
+zQ
 wx
-fa
-fa
+mi
 fa
 "}
 (12,1,1) = {"
 fa
+fa
 sy
 lN
-nq
 tM
+wc
 yz
 pP
-sw
+bL
 ZM
 Ia
-Rp
+PV
 Ia
 YV
 ob
 HT
 yz
-SM
 be
-wx
-fa
-fa
+pI
+sN
+Av
 fa
 "}
 (13,1,1) = {"
-vJ
-Gk
-aO
-aO
-aO
-aO
-aO
-aO
-Oo
+fa
+nm
+KX
+Yn
+Yn
+Yn
+Yn
+Yn
+Yn
 kW
 bB
 AY
 Vc
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
-KX
-nm
-fa
+Bw
+aO
+aO
+aO
+aO
+aO
+aO
+Gk
+vJ
 "}
 (14,1,1) = {"
-iz
-tt
+fa
+Aa
 dc
 Fs
-WZ
+JY
 Eg
 UC
-aO
-iS
-SU
-cc
-nA
-dv
+aZ
 Yn
-bL
+SU
+DN
+Nn
+dv
+ho
+aO
 pX
 vf
 dU
 sG
-Xt
-Aa
-fa
+Vo
+Tv
+iz
 "}
 (15,1,1) = {"
-Xj
+fa
 Oc
 nt
 QG
 Ix
 ah
-YP
-aO
-Ik
+mK
+xz
+Yn
 Ou
 CB
 nA
 Oi
-Yn
-nO
-mK
+tk
+aO
+kh
 ft
-Rc
-oX
+RJ
+Zm
 Zm
 nQ
-fa
+Xj
 "}
 (16,1,1) = {"
-iz
-ST
+fa
+sW
 Wr
 ch
-no
+Rc
 nr
-ah
+UC
 Ug
-dv
-CS
+no
+ma
 ma
 Mg
-sH
+ZH
 ZH
 ZC
 IG
 Wl
-JY
+wF
 wF
 PL
 jp
-fa
+iz
 "}
 (17,1,1) = {"
-iz
+Wj
 OP
 NB
 MS
@@ -3985,10 +4406,10 @@ FL
 ee
 zZ
 DY
-lW
-jj
+Xa
+Xa
 Hi
-jd
+nl
 dh
 bV
 pW
@@ -3996,82 +4417,83 @@ UY
 kB
 dK
 ul
-sW
-kh
+gD
+iz
 "}
 (18,1,1) = {"
-Xj
+fa
 Cj
 wm
 BZ
 jh
 Xn
-gl
-aO
-Qb
-DN
+mK
+pr
+Yn
+Sb
 XY
 oc
-Qb
-Yn
-nB
+Eb
+ph
+aO
 nF
 DD
 vV
-it
+GZ
 GZ
 Zx
-fa
+Xj
 "}
 (19,1,1) = {"
-iz
-Qm
-PV
+fa
+Aa
+Xt
 ur
 aD
 wy
 pg
-aO
-ph
+px
+Yn
 XD
 mc
 AS
-Qb
-Yn
-Wj
-mK
+ja
+BR
+aO
+lW
 IT
 Le
 fl
 Fc
-Aa
-fa
+CG
+iz
 "}
 (20,1,1) = {"
-vJ
-iz
-iz
-aO
-aO
-aO
-aO
-aO
-RJ
-bx
-Bw
-DM
-qv
-Yn
-Yn
-Yn
-Yn
-Yn
-Aa
-Aa
-nm
 fa
+nm
+Aa
+Aa
+Yn
+Yn
+Yn
+Yn
+Yn
+bx
+qv
+Bw
+qv
+Ds
+aO
+aO
+aO
+aO
+aO
+iz
+iz
+vJ
 "}
 (21,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4080,11 +4502,11 @@ fI
 bA
 Ow
 RS
-pI
 Ke
 PS
 re
-Qb
+ST
+Sf
 wD
 xY
 tj
@@ -4093,9 +4515,9 @@ Ey
 fa
 fa
 fa
-fa
 "}
 (22,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4104,11 +4526,11 @@ vS
 IB
 yd
 RS
-CG
 Cw
 Sr
 we
 Qb
+ih
 wD
 bq
 QP
@@ -4117,22 +4539,22 @@ CM
 fa
 fa
 fa
-fa
 "}
 (23,1,1) = {"
+fa
 fa
 fa
 fa
 LN
 uH
 yC
-Sb
+ev
 RS
-LE
 ih
 QY
 yL
 dz
+mO
 wD
 AI
 Fd
@@ -4141,9 +4563,9 @@ CM
 fa
 fa
 fa
-fa
 "}
 (24,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4152,11 +4574,11 @@ Li
 NO
 wJ
 yk
-Xa
-Xa
+cc
 BO
 RR
 Nr
+cc
 gz
 Al
 fV
@@ -4165,9 +4587,9 @@ Ey
 fa
 fa
 fa
-fa
 "}
 (25,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4176,11 +4598,11 @@ UH
 cN
 wT
 RS
-VG
-Ia
+YK
 so
 BW
 Gm
+lV
 wD
 mv
 WX
@@ -4189,9 +4611,9 @@ CM
 fa
 fa
 fa
-fa
 "}
 (26,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4200,11 +4622,11 @@ tR
 iC
 ox
 RS
-Sf
 Ww
 Hx
 RA
 Fr
+oU
 wD
 QC
 xH
@@ -4213,9 +4635,9 @@ CM
 fa
 fa
 fa
-fa
 "}
 (27,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4237,7 +4659,6 @@ ve
 fa
 fa
 fa
-fa
 "}
 (28,1,1) = {"
 fa
@@ -4246,16 +4667,16 @@ fa
 fa
 fa
 fa
+fa
 NW
-gD
+jj
 Xe
 tp
 Rv
-Eb
 mq
+CS
 Yj
 NW
-fa
 fa
 fa
 fa
@@ -4270,16 +4691,16 @@ fa
 fa
 fa
 fa
+fa
 NW
-wu
+fq
 Ax
 xN
 TH
 xT
 Dt
-qq
+Dt
 NW
-fa
 fa
 fa
 fa
@@ -4294,16 +4715,16 @@ fa
 fa
 fa
 fa
+fa
 ll
 KW
-fq
+cL
 Sg
 Zc
-aZ
 Ta
 zR
+Lq
 ll
-fa
 fa
 fa
 fa
@@ -4318,16 +4739,16 @@ fa
 fa
 fa
 fa
+fa
 NW
-wu
+fq
 fq
 Sg
 zC
 lL
 Ne
-Vo
+Dt
 NW
-fa
 fa
 fa
 fa
@@ -4342,13 +4763,14 @@ fa
 fa
 fa
 fa
+fa
 NW
-xz
+DM
 Hy
 tp
 Ji
 xT
-MP
+Qm
 vY
 NW
 fa
@@ -4357,9 +4779,9 @@ fa
 fa
 fa
 fa
-fa
 "}
 (33,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4381,9 +4803,9 @@ fa
 fa
 fa
 fa
-fa
 "}
 (34,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4405,9 +4827,9 @@ fa
 fa
 fa
 fa
-fa
 "}
 (35,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4429,9 +4851,9 @@ fa
 fa
 fa
 fa
-fa
 "}
 (36,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4453,9 +4875,9 @@ fa
 fa
 fa
 fa
-fa
 "}
 (37,1,1) = {"
+fa
 fa
 fa
 fa
@@ -4477,7 +4899,6 @@ fa
 fa
 fa
 fa
-fa
 "}
 (38,1,1) = {"
 fa
@@ -4487,14 +4908,14 @@ fa
 fa
 fa
 fa
-Za
-Za
-Za
-Za
-Za
-Za
-Za
 fa
+Za
+Za
+Za
+qq
+Za
+Za
+Za
 fa
 fa
 fa


### PR DESCRIPTION
Ремап TearDrop.

Поменял местами МедБэй и Карго.
Карго немного отличается от прошлого. Проход теперь по середине, а не сбоку, есть дополнительное вооружение и камера перевозки для существ.
Медбэй полностью с нуля построен.

В инже починены провода.
Добавлена труба для откачки воздуха с окружающей местности у корабля.
Немного изменено оформление инжы.  

Коридор теперь не настолько пустой как раньше. 
![image](https://github.com/MysticalFaceLesS/Shiptest/assets/74047915/f9b716f7-3791-4536-b258-2da2c3f992cc)

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
