### PR TITLE
Fix names of ion thrusters

### DIFF
--- a/mod_celadon/balance/code/engine/circuits.dm
+++ b/mod_celadon/balance/code/engine/circuits.dm
@@ -1,17 +1,17 @@
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech1
-	name = "1st Ion Thruster (Machine Board)"
+	name = "1st gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech1
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech2
-	name = "2st Ion Thruster (Machine Board)"
+	name = "2nd gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech2
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech3
-	name = "3st Ion Thruster (Machine Board)"
+	name = "3rd gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech3
 	req_components = list(/obj/item/stock_parts/capacitor = 2,
 		/obj/item/stock_parts/micro_laser = 2)

--- a/mod_celadon/balance/code/engine/enginebalance.dm
+++ b/mod_celadon/balance/code/engine/enginebalance.dm
@@ -1,5 +1,5 @@
 /obj/machinery/power/shuttle/engine/electric/tech1
-	name = "1-st ion thruster"
+	name = "1st gen ion thruster"
 	desc = "A thruster that expels charged particles to generate thrust."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech1
 	icon_state = "tech1"
@@ -10,7 +10,7 @@
 	power_per_burn = 35000
 
 /obj/machinery/power/shuttle/engine/electric/tech2
-	name = "2-st ion thruster"
+	name = "2nd gen ion thruster"
 	desc = "A thruster that expels charged particles to generate thrust."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech2
 	icon_state = "tech2"
@@ -21,7 +21,7 @@
 	power_per_burn = 100000
 
 /obj/machinery/power/shuttle/engine/electric/tech3
-	name = "3-st ion thruster"
+	name = "3rd gen ion thruster"
 	desc = "A thruster that expels charged particles to generate thrust."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech3
 	icon_state = "tech3"


### PR DESCRIPTION
Фикс бага [**[Discord - Ошибка в словообразовании в названии тирных ионных двигателей]**](https://discord.com/channels/1100198143456465067/1240377315381477480)

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я не запускал сервер со своими изменениями локально и ничего не тестировал.
