### PR TITLE
[Add] Support of cyrillic letters when drunk and stuttering

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -111,6 +111,7 @@
 			. += "*"
 	return sanitize(.)
 
+/*			=# CELADON CHANGES => mod_celadon\qol\code\mob_helpers2.dm #=
 /**
  * Makes you speak like you're drunk
  */
@@ -149,7 +150,7 @@
 			else
 				// do nothing
 		. += "[newletter]"
-	return sanitize(.)
+	return sanitize(.)		*/
 
 /// Makes you talk like you got cult stunned, which is slurring but with some dark messages
 /proc/cultslur(phrase) // Inflicted on victims of a stun talisman
@@ -198,6 +199,7 @@
 
 #define CLOCK_CULT_SLUR(phrase) sanitize(text2ratvar(phrase))
 
+/*			=# CELADON CHANGES => mod_celadon\qol\code\mob_helpers2.dm #=
 ///Adds stuttering to the message passed in
 /proc/stutter(phrase)
 	phrase = html_decode(phrase)
@@ -214,7 +216,7 @@
 			else
 				newletter = "[newletter]-[newletter]"
 		. += newletter
-	return sanitize(.)
+	return sanitize(.)		*/
 
 ///Convert a message to derpy speak
 /proc/derpspeech(message, stuttering)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -111,7 +111,7 @@
 			. += "*"
 	return sanitize(.)
 
-/*			=# CELADON CHANGES => mod_celadon\qol\code\mob_helpers2.dm #=
+/* [CELADON REMOVE] - CELADON_QOL - mod_celadon\qol\code\mob_helpers2.dm перенёс т. к. желаю модульность
 /**
  * Makes you speak like you're drunk
  */
@@ -150,7 +150,8 @@
 			else
 				// do nothing
 		. += "[newletter]"
-	return sanitize(.)		*/
+	return sanitize(.)
+	[CELADON REMOVE] */
 
 /// Makes you talk like you got cult stunned, which is slurring but with some dark messages
 /proc/cultslur(phrase) // Inflicted on victims of a stun talisman
@@ -199,7 +200,7 @@
 
 #define CLOCK_CULT_SLUR(phrase) sanitize(text2ratvar(phrase))
 
-/*			=# CELADON CHANGES => mod_celadon\qol\code\mob_helpers2.dm #=
+/* [CELADON REMOVE] - CELADON_QOL - mod_celadon\qol\code\mob_helpers2.dm перенёс т. к. желаю модульность
 ///Adds stuttering to the message passed in
 /proc/stutter(phrase)
 	phrase = html_decode(phrase)
@@ -216,7 +217,8 @@
 			else
 				newletter = "[newletter]-[newletter]"
 		. += newletter
-	return sanitize(.)		*/
+	return sanitize(.)
+	[CELADON REMOVE] */
 
 ///Convert a message to derpy speak
 /proc/derpspeech(message, stuttering)

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -33,6 +33,8 @@ ID мода: CELADON_QOL
 - перемещены технические кнопки во вкладку Special Verbs
 - обновлён функционал Fit Viewport
 - исправлен зависающий пузырик сообщения над головой куклы
+- /stutter теперь не распространяется на русские гласные
+- /slur теперь заменяет символы кириллицы на "пьяный вариант" и пропускает пробел
 <!--
   Что он делает, что добавляет: что, куда, зачем и почему - всё здесь.
   А также любая полезная информация.
@@ -91,6 +93,9 @@ ID мода: CELADON_QOL
 - EDIT `code/game/objects/structures/flora.dm` -> меняем звук падающего дерева с метеоритного на нормальный
 
 - EDIT `code/game/gamemodes/extended/extended.dm` -> меняем начальный репорт
+
+- EDIT `code\modules\mob\mob_helpers.dm`: `/proc/slur`
+- EDIT `code\modules\mob\mob_helpers.dm`: `/proc/stutter`
 
 ООС вкладка	
 - EDIT `code/modules/client/verbs/ooc.dm` -> Убраны неиспользуемые кнопки "Message Of The Day" "Show Policy" со вкладки ООС.Перемещена кнопка "Fit Viewport" со вкладки "ООС" во вкладку "Special Verbs"

--- a/mod_celadon/qol/_qol.dm
+++ b/mod_celadon/qol/_qol.dm
@@ -5,6 +5,8 @@
 Уменьшаем размер разогревочному пакету.
 Добавлена универсальная кнопка FixChat2.
 Добавлена кнопка Refresh TGUI.
-Перемещена и удалена часть кнопок во вкладке ООС"}
-	author = "RalseiDreemuurr, MrCat15352, MysticalFaceLesS, Yata9arasu"
-
+Перемещена и удалена часть кнопок во вкладке ООС.
+Обновлён функционал Fit Viewport.
+Исправлен зависающий индикатор говорения.
+Добавлена поддержка кириллицы для пьяной и запинающейся речи"}
+	author = "RalseiDreemuurr, MrCat15352, MysticalFaceLesS, Yata9arasu, MrRomainzZ"

--- a/mod_celadon/qol/_qol.dme
+++ b/mod_celadon/qol/_qol.dme
@@ -16,5 +16,6 @@
 #include "code/reagent_containers.dm"
 #include "code/fit_viewport2.dm"
 #include "code/mob_say2.dm"
+#include "code/mob_helpers2.dm"
 
 #endif

--- a/mod_celadon/qol/code/mob_helpers2.dm
+++ b/mod_celadon/qol/code/mob_helpers2.dm
@@ -46,6 +46,8 @@
 				newletter = "т"
 			else if(lowerletter == "щ")
 				newletter = "шщ"
+			else if(lowerletter == "и")
+				newletter = "их"
 		if(rand(1, 20) == 20)
 			if(newletter == " ")
 				newletter = "...huuuhhh..."

--- a/mod_celadon/qol/code/mob_helpers2.dm
+++ b/mod_celadon/qol/code/mob_helpers2.dm
@@ -1,0 +1,85 @@
+// Part from "code\modules\mob\mob_helpers.dm"
+
+// Moves proc here to add cyrillic symbols and ignore spaces to not double them
+// Not overriding because of https://www.byond.com/forum/post/2925918
+
+/**
+ * Makes you speak like you're drunk
+ */
+/proc/slur(phrase)
+	phrase = html_decode(phrase)
+	var/leng = length(phrase)
+	. = ""
+	var/newletter = ""
+	var/rawchar = ""
+	for(var/i = 1, i <= leng, i += length(rawchar))
+		rawchar = newletter = phrase[i]
+		if(rand(1, 3) == 3)
+			var/lowerletter = lowertext(newletter)
+			if(lowerletter == "o")
+				newletter = "u"
+			else if(lowerletter == "s")
+				newletter = "ch"
+			else if(lowerletter == "a")
+				newletter = "ah"
+			else if(lowerletter == "u")
+				newletter = "oo"
+			else if(lowerletter == "c")
+				newletter = "k"
+			else if(lowerletter == "о")
+				newletter = "у"
+			else if(lowerletter == "э")
+				newletter = "и"
+			else if(lowerletter == "с")
+				newletter = "сш"
+			else if(lowerletter == "г")
+				newletter = "х"
+			else if(lowerletter == "а")
+				newletter = "ах"
+			else if(lowerletter == "ц")
+				newletter = "сц"
+			else if(lowerletter == "р")
+				newletter = "гх"
+			else if(lowerletter == "б")
+				newletter = "п"
+			else if(lowerletter == "д")
+				newletter = "т"
+			else if(lowerletter == "щ")
+				newletter = "шщ"
+		if(rand(1, 20) == 20)
+			if(newletter == " ")
+				newletter = "...huuuhhh..."
+			else if(newletter == ".")
+				newletter = " *BURP*."
+		if(newletter != " ")
+			switch(rand(1, 20))
+				if(1)
+					newletter += "'"
+				if(10)
+					newletter += "[newletter]"
+				if(20)
+					newletter += "[newletter][newletter]"
+				else
+					// do nothing
+		. += "[newletter]"
+	return sanitize(.)
+
+// Moves proc here to stop stuttering of russian vowels
+
+///Adds stuttering to the message passed in
+/proc/stutter(phrase)
+	phrase = html_decode(phrase)
+	var/leng = length(phrase)
+	. = ""
+	var/newletter = ""
+	var/rawchar = ""
+	var/static/regex/nostutter = regex(@@[aeiouAEIOU "'()[\]{}.!?,:;_`~-ауоиэыяюеёАУОИЭЫЯЮЕЁ]@)
+	for(var/i = 1, i <= leng, i += length(rawchar))
+		rawchar = newletter = phrase[i]
+		if(prob(70) && !nostutter.Find(rawchar))
+			if(prob(25))
+				newletter = "[newletter]-[newletter]-[newletter]"
+			else
+				newletter = "[newletter]-[newletter]"
+		. += newletter
+	return sanitize(.)


### PR DESCRIPTION
Теперь, когда кукла пьяна, кириллические символы будут заменяться на "пьяный" вариант. Убирает создание "лишних" пробелов

Код "запинания" подразумевает игнорирование гласных. Теперь это работает и на кириллице

<details>
<summary>Пример пьяного текста</summary>

Раньше: 
![sluf-before](https://github.com/user-attachments/assets/e8fbde3b-7a88-4278-a555-38ec23f64315)

Сейчас: 
![slur-after](https://github.com/user-attachments/assets/5810354e-b14d-450f-8cce-89261cf8280d)

</details>

<details>
<summary>Пример запинания текста</summary>

Английский:
![stutter-english](https://github.com/user-attachments/assets/48358eef-12ce-4be0-8093-99ae25683db1)

Раньше:
![stutter-before](https://github.com/user-attachments/assets/60ee8faf-95fc-4580-bd87-2cb1feea1fed)

Сейчас:
![stutter-after](https://github.com/user-attachments/assets/171e5499-234b-4693-872b-bb397e6b560b)


</details>

___
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
