### PR TITLE
[Tweak] Moves notifications of TGUI chat to the top

### DIFF
--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,7 +5,7 @@
 
 .Notifications {
   position: absolute;
-  bottom: 1em;
+  top: 1em;
   left: 1em;
   right: 2em;
 }


### PR DESCRIPTION
Насколько знаю, модульный ТГУИ ещё не изобрели, посему делаю так. Более никаких уведомлений поверх последних сообщений

<details>
<summary>Изображения изменений</summary>

| Раньше| Теперь|
|--------|--------|
|![dreamseeker_NTVv2LdXVV](https://github.com/user-attachments/assets/0fe96701-2fa0-481c-a7b5-422dbfe20dea)|![dreamseeker_8GX6EH5D3B](https://github.com/user-attachments/assets/f2d8721c-a1a0-48a8-ac5c-12f3884ed907)|

</details>

___
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.