### PR TITLE
[Fix] Fixes G36 rifle

### DIFF
--- a/mod_celadon/weapons/code/ammo.dm
+++ b/mod_celadon/weapons/code/ammo.dm
@@ -10,21 +10,21 @@
 /datum/supply_pack/ammo/g36_sh
 	name = "Набор магазинов для G36-SH 5.56mm"
 	desc = "Содержит два магазина калибра 5,56 мм для винтовки G36-SH, каждый из которых содержит по 20 патронов."
-	contains = list(/obj/item/ammo_box/magazine/p16/g36sh,
-					/obj/item/ammo_box/magazine/p16/g36sh)
+	contains = list(/obj/item/ammo_box/magazine/g36/sh,
+					/obj/item/ammo_box/magazine/g36/sh)
 	cost = 1400
 
 /datum/supply_pack/ammo/g36
 	name = "Набор магазинов для G36 5.56mm"
 	desc = "Содержит два магазина калибра 5,56 мм для винтовки G36, каждый из которых содержит по 30 патронов."
-	contains = list(/obj/item/ammo_box/magazine/p16/g36,
-					/obj/item/ammo_box/magazine/p16/g36)
+	contains = list(/obj/item/ammo_box/magazine/g36,
+					/obj/item/ammo_box/magazine/g36)
 	cost = 1950
 
 /datum/supply_pack/ammo/g36_drum
 	name = "Барабанный магазин для G36 5.56mm"
 	desc = "Барабанный магазин калибра 5,56 мм для винтовки G36, вмещает до 75 патронов."
-	contains = list(/obj/item/ammo_box/magazine/p16/g36drum)
+	contains = list(/obj/item/ammo_box/magazine/g36/drum)
 	cost = 5000
 
 /datum/supply_pack/ammo/morita_ammo_small

--- a/mod_celadon/weapons/code/guncases.dm
+++ b/mod_celadon/weapons/code/guncases.dm
@@ -1,14 +1,14 @@
 /obj/item/storage/guncase/g36
 /obj/item/storage/guncase/g36/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/assault/p16/g36/no_mag(src)
-	new /obj/item/ammo_box/magazine/p16/g36/empty(src)
-	new /obj/item/ammo_box/magazine/p16/g36/empty(src)
+	new /obj/item/gun/ballistic/automatic/assault/g36/no_mag(src)
+	new /obj/item/ammo_box/magazine/g36/empty(src)
+	new /obj/item/ammo_box/magazine/g36/empty(src)
 
 /obj/item/storage/guncase/g36sh
 /obj/item/storage/guncase/g36sh/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/assault/p16/g36sh/no_mag(src)
-	new /obj/item/ammo_box/magazine/p16/g36sh/empty(src)
-	new /obj/item/ammo_box/magazine/p16/g36sh/empty(src)
+	new /obj/item/gun/ballistic/automatic/assault/g36sh/no_mag(src)
+	new /obj/item/ammo_box/magazine/g36/sh/empty(src)
+	new /obj/item/ammo_box/magazine/g36/sh/empty(src)
 
 /obj/item/storage/guncase/morita1
 /obj/item/storage/guncase/morita1/PopulateContents()

--- a/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -44,52 +44,55 @@
 /obj/item/ammo_box/magazine/morita1/drum/empty
 	start_empty = TRUE
 
-/obj/item/ammo_box/magazine/p16/g36sh
+/obj/item/ammo_box/magazine/g36/sh
 	name = "\improper G36-SH magazine"
 	desc = " Polymer 20-round assault rifle magazine 5.56x45mm."
 	icon = 'mod_celadon/_storge_icons/icons/ammo/ammo.dmi'
 	icon_state = "g36sh_mag"
 	base_icon_state = "g36sh_mag"
 	ammo_type = /obj/item/ammo_casing/a556_45
+	caliber = "5.56x45mm"
 	max_ammo = 20
 
-/obj/item/ammo_box/magazine/p16/g36sh/update_icon_state()
+/obj/item/ammo_box/magazine/g36/sh/update_icon_state()
 	. = ..()
 	icon_state = "g36sh_mag-[!!ammo_count()]"
 
-/obj/item/ammo_box/magazine/p16/g36sh/empty
+/obj/item/ammo_box/magazine/g36/sh/empty
 	start_empty = TRUE
 
-/obj/item/ammo_box/magazine/p16/g36
+/obj/item/ammo_box/magazine/g36
 	name = "\improper G36 magazine"
 	desc = "Polymer standart assault rifle magazine 5.56x45mm."
 	icon = 'mod_celadon/_storge_icons/icons/ammo/ammo.dmi'
 	icon_state = "g36_mag"
 	base_icon_state = "g36_mag"
 	ammo_type = /obj/item/ammo_casing/a556_45
+	caliber = "5.56x45mm"
 	max_ammo = 30
 
-/obj/item/ammo_box/magazine/p16/g36/update_icon_state()
+/obj/item/ammo_box/magazine/g36/update_icon_state()
 	. = ..()
 	icon_state = "g36_mag-[!!ammo_count()]"
 
-/obj/item/ammo_box/magazine/p16/g36/empty
+/obj/item/ammo_box/magazine/g36/empty
 	start_empty = TRUE
 
-/obj/item/ammo_box/magazine/p16/g36drum
+/obj/item/ammo_box/magazine/g36/drum
 	name = "\improper G36 drum magazine"
 	desc = "Polymer high-capacyti assault rifle drum 5.56x45mm."
 	icon = 'mod_celadon/_storge_icons/icons/ammo/ammo.dmi'
 	icon_state = "g36drum_mag"
 	base_icon_state = "g36drum_mag"
 	ammo_type = /obj/item/ammo_casing/a556_45
+	caliber = "5.56x45mm"
 	max_ammo = 75
 
-/obj/item/ammo_box/magazine/p16/g36drum/update_icon_state()
+/obj/item/ammo_box/magazine/g36/drum/update_icon_state()
 	. = ..()
 	icon_state = "g36drum_mag-[!!ammo_count()]"
 
-/obj/item/ammo_box/magazine/p16/g36drum/empty
+/obj/item/ammo_box/magazine/g36/drum/empty
 	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/usp45_standart

--- a/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/assault.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/assault.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/ballistic/automatic/assault/p16/g36sh
+/obj/item/gun/ballistic/automatic/assault/g36sh
 //Описание
 	name = "\improper G36-SH"
 	desc = "Наследие огненной эры Союза Человечества, укороченная версия,  калибра 5.56x45. Технология производства восстановлена минитменами, но ввиду усложненной конструкции продана корпорации InteQ. Используется сотрудниками InteQ по сей день, как оружие для элитных наемников."
@@ -18,18 +18,18 @@
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_NORMAL
 	unique_mag_sprites_for_variants = TRUE
-	mag_type = /obj/item/ammo_box/magazine/p16/g36sh
+	mag_type = /obj/item/ammo_box/magazine/g36/sh
 //Прочее
-	var/obj/item/ammo_box/magazine/p16/g36sh/alternate_magazine
+	var/obj/item/ammo_box/magazine/g36/sh/alternate_magazine
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36sh/Initialize()
+/obj/item/gun/ballistic/automatic/assault/g36sh/Initialize()
 	. = ..()
 	if (!alternate_magazine)
 		alternate_magazine = new mag_type(src)
 	spawnwithmagazine = FALSE
-	mag_type = /obj/item/ammo_box/magazine/p16
+	mag_type = /obj/item/ammo_box/magazine/g36
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36sh/inteq
+/obj/item/gun/ballistic/automatic/assault/g36sh/inteq
 	name = "\improper Moded G36-SH"
 	desc = "Обширная модификация G36-SH, которая входит в стандартную комплектацию вооружения InteQ. Калибр 5,56x45 мм."
 	icon_state = "g36shinteq"
@@ -39,10 +39,10 @@
 	empty_alarm = TRUE
 	zoomable = TRUE
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36sh/no_mag
+/obj/item/gun/ballistic/automatic/assault/g36sh/no_mag
 	spawnwithmagazine = FALSE
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36
+/obj/item/gun/ballistic/automatic/assault/g36
 	name = "\improper G36"
 	desc = "Наследие огненной эры Союза Человечества , калибра 5.56x45 . Технология производства восстановлена минитменами , но ввиду усложненной конструкции продана корпорации InteQ. Используется сотрудниками InteQ по сей день , как оружие для элитных наемников. "
 	icon = 'mod_celadon/_storge_icons/icons/guns/48x32guns.dmi'
@@ -56,20 +56,20 @@
 	wield_delay = 0.5 SECONDS
 	fire_delay = 0.14 SECONDS
 	unique_mag_sprites_for_variants = TRUE
-	mag_type = /obj/item/ammo_box/magazine/p16/g36
-	var/obj/item/ammo_box/magazine/p16/g36/alternate_magazine
+	mag_type = /obj/item/ammo_box/magazine/g36
+	var/obj/item/ammo_box/magazine/g36/alternate_magazine
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36/Initialize()
+/obj/item/gun/ballistic/automatic/assault/g36/Initialize()
 	. = ..()
 	if (!alternate_magazine)
 		alternate_magazine = new mag_type(src)
-		spawnwithmagazine = FALSE
-		mag_type = /obj/item/ammo_box/magazine/p16
+	spawnwithmagazine = FALSE
+	mag_type = /obj/item/ammo_box/magazine/g36
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36/no_mag
+/obj/item/gun/ballistic/automatic/assault/g36/no_mag
 		spawnwithmagazine = FALSE
 
-/obj/item/gun/ballistic/automatic/assault/p16/g36/inteq
+/obj/item/gun/ballistic/automatic/assault/g36/inteq
 	name = "\improper Moded G36"
 	desc = "Обширная модификация G36, которая входит в стандартную комплектацию вооружения InteQ. Калибр 5,56x45 мм."
 	icon_state = "g36inteq"

--- a/mod_celadon/weapons/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -1,5 +1,10 @@
 //5.56x45
 
+/obj/projectile/bullet/a556_45
+	name = "5.56x45mm bullet"
+	damage = 25
+	armour_penetration = 20
+
 /obj/projectile/bullet/a556_45/a856
 	name = "5.56x45mm A856 bullet"
 	damage = 30


### PR DESCRIPTION
ПР делает несколько штук:
1. Отрезает винтовку G36 от P16
2. Перемещает все дополнительные (уменьшенный и барабанный) магазины под основной магазин для G36
3. Дописывает магазинам калибр, что позволяет брать другие пули этого калибра (3 типа помимо основного)
4. Немного правит логику инициализации оружия для идентичности (хотя у меня всё равно остались к ней вопросы)
5. Добавляет "потерявшуюся" пулю и восстанавливает "нормальный" урон

Видео с тестом:

https://github.com/user-attachments/assets/e57e8abd-ff6b-4604-9b95-5a4cbc3fb488

___
- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
