### PR TITLE
FIX: Spawner role outpost

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -34,7 +34,7 @@
 	var/ghost_usable = TRUE
 	/// Weakref to the mob this spawner created - just if you needed to do something with it.
 	var/datum/weakref/spawned_mob_ref
-	var/can_load_appearance = FALSE // [CELADON-EDIT] - CELADON_LOAD_PREF
+	var/can_load_appearance = TRUE // [CELADON-EDIT] - CELADON_LOAD_PREF
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user)

--- a/mod_celadon/ghost_roles/code/outpost/elysium_ice.dm
+++ b/mod_celadon/ghost_roles/code/outpost/elysium_ice.dm
@@ -4,7 +4,7 @@
 	random = FALSE
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "cryopod"
-	mob_species = /datum/species/human
+	// mob_species = /datum/species/human
 
 // Cook
 
@@ -23,8 +23,8 @@
 	new /obj/machinery/cryopod/outpost/cook(drop_location())
 	return ..()
 
-/obj/effect/mob_spawn/human/elysium_outpost/cook/special(mob/living/new_spawn)
-	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
+// /obj/effect/mob_spawn/human/elysium_outpost/cook/special(mob/living/new_spawn)
+// 	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
 
 /obj/effect/mob_spawn/human/elysium_outpost/cook/Initialize()
 	. = ..()
@@ -49,8 +49,8 @@
 	new /obj/machinery/cryopod/outpost/bartender(drop_location())
 	return ..()
 
-/obj/effect/mob_spawn/human/elysium_outpost/bartender/special(mob/living/new_spawn)
-	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
+// /obj/effect/mob_spawn/human/elysium_outpost/bartender/special(mob/living/new_spawn)
+// 	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
 
 /obj/effect/mob_spawn/human/elysium_outpost/bartender/Initialize()
 	. = ..()
@@ -75,8 +75,8 @@
 	new /obj/machinery/cryopod/outpost/maid(drop_location())
 	return ..()
 
-/obj/effect/mob_spawn/human/elysium_outpost/maid/special(mob/living/new_spawn)
-	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
+// /obj/effect/mob_spawn/human/elysium_outpost/maid/special(mob/living/new_spawn)
+// 	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
 
 /obj/effect/mob_spawn/human/elysium_outpost/maid/Initialize()
 	. = ..()
@@ -101,8 +101,8 @@
 	new /obj/machinery/cryopod/outpost/artist(drop_location())
 	return ..()
 
-/obj/effect/mob_spawn/human/elysium_outpost/artist/special(mob/living/new_spawn)
-	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
+// /obj/effect/mob_spawn/human/elysium_outpost/artist/special(mob/living/new_spawn)
+// 	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
 
 /obj/effect/mob_spawn/human/elysium_outpost/artist/Initialize()
 	. = ..()
@@ -129,8 +129,8 @@
 	new /obj/structure/bed/outpost/wagabond(drop_location())
 	return ..()
 
-/obj/effect/mob_spawn/human/elysium_outpost/wagabond/special(mob/living/new_spawn)
-	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
+// /obj/effect/mob_spawn/human/elysium_outpost/wagabond/special(mob/living/new_spawn)
+// 	new_spawn.fully_replace_character_name(null, random_unique_name(gender))
 
 /obj/effect/mob_spawn/human/elysium_outpost/wagabond/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
ПР делает что-то умное он чинит то что нельзя было зайти на гост рольку под своим персонажем. Но теперь из-за офов не работает прыжок к гост рольке.
Как зайти на гост роль?
1. Прыгнуть на аванпост или руинку
2. Найти спавнер, на аванпосту это обоссаный матрас или криокапсула
3. Тыкнуть по нему, согласиться
4. Спросят вас, использовать текущий слот для вхождения?
5. Если хотим играть за своего персонажа соглашаемся, если нет, заспавнит рандомного человека
6. ???
7. PROFIT
![изображение](https://github.com/user-attachments/assets/08bab1c3-b9f5-4261-857f-6f51f1679916)

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
