### PR TITLE
BUGFIX: operating table climbing

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -594,6 +594,7 @@
 	smoothing_groups = null
 	canSmoothWith = null
 	can_buckle = TRUE
+	climbable = FALSE
 	buckle_lying = 90 //I don't see why you wouldn't be lying down while buckled to it
 	buckle_requires_restraints = FALSE
 	can_flip = FALSE

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -594,7 +594,9 @@
 	smoothing_groups = null
 	canSmoothWith = null
 	can_buckle = TRUE
+	// [CELADON-ADD] - CELADON_FIXES - Чиним операционный стол
 	climbable = FALSE
+	// [/CELADON-ADD]
 	buckle_lying = 90 //I don't see why you wouldn't be lying down while buckled to it
 	buckle_requires_restraints = FALSE
 	can_flip = FALSE


### PR DESCRIPTION
Позволяет нормально пристёгиваться к операционному столу без танцев с бубном

Видео ДО/ПОСЛЕ прилагаются

https://github.com/user-attachments/assets/fd5219cd-374b-4daf-9183-189ccac9d82b


https://github.com/user-attachments/assets/a78f1e4d-b684-4bd2-b328-5b958e8a488b



- [Х] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [Х] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [Х] Я запускал сервер со своими изменениями локально и все протестировал.
