### PR TITLE
новый атлас-класс, субшаттл к нему, англофикация элизиум дрипа и экипажа кондора

### DIFF
--- a/_maps/_mod_celadon/configs/elysium_atlas.json
+++ b/_maps/_mod_celadon/configs/elysium_atlas.json
@@ -1,0 +1,37 @@
+{
+	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
+	"map_name": "Atlas-class Drug Production Vessel",
+	"map_short_name": "Atlas",
+	"description": "Корветы класса «Atlas» когда-то использовались Республикой Элизиум, но несколько десятилетий назад были законсервированы. Сегодня корабли используются Сепаратистами Элизиума как корабли снабжения и полевого производства столь необходимых сепаратистам ветвей амброзии. Многие из них выгорели изнутри в плазменных пожарах из-за фатального несоблюдения техники безопасности при транспортировке газообразной плазмы. На них также находятся субшаттлы класса 'Felon', которые теперь используются для быстрой переброски (обычно контрабандных) припасов.",
+	"map_path": "_maps/_mod_celadon/shuttles/elysium/elysium_atlas.dmm",
+	"enabled": true,
+	"limit": 1,
+	"prefix": "EUSM",
+	"faction": "/datum/faction/elysium",
+	"tags": [
+		"RP Focus",
+		"Botany",
+		"Cargo",
+		"Subshuttle"
+	],
+	"namelists": [
+		"WEAPONS",
+		"BEASTS"
+	],
+	"job_slots": {
+		"Caid": {
+			"outfit": "/datum/outfit/job/elysium/captain",
+			"officer": true,
+			"slots": 1
+		},
+		
+		"Mukatell": {
+			"outfit": "/datum/outfit/job/elysium/security",
+			"slots" : 1
+		},
+		"Ahisa`i": {
+			"outfit": "/datum/outfit/job/elysium/assistant",
+			"slots": 5
+		}
+	}
+}

--- a/_maps/_mod_celadon/configs/elysium_kondor.json
+++ b/_maps/_mod_celadon/configs/elysium_kondor.json
@@ -17,18 +17,18 @@
 		"BEASTS"
 	],
 	"job_slots": {
-		"Каид": {
+		"Caid": {
 			"outfit": "/datum/outfit/job/elysium/captain",
 			"officer": true,
 			"slots": 1
 		},
-		"Ахиса'и": {
-			"outfit": "/datum/outfit/job/elysium/assistant",
-			"slots": 1
-		},
-		"Мукатэлл": {
+		"Mukatell": {
 			"outfit": "/datum/outfit/job/elysium/security",
 			"slots" : 2
+		},
+		"Ahisa`i": {
+			"outfit": "/datum/outfit/job/elysium/assistant",
+			"slots": 1
 		}
 	}
 }

--- a/_maps/_mod_celadon/shuttles/elysium/elysium_atlas.dmm
+++ b/_maps/_mod_celadon/shuttles/elysium/elysium_atlas.dmm
@@ -1,0 +1,5616 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"af" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"aw" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"aC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"aI" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/crew)
+"aS" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"aX" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"aY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/green/half,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"bn" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"bF" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4,
+/turf/open/floor/plating/airless,
+/area/ship/engineering)
+"bK" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"bQ" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"bS" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"cc" = (
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"cm" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"cN" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central3{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"cV" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"cY" = (
+/obj/effect/turf_decal/corner/transparent/blue/border{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/closet/wall/chem/directional/south{
+	name = "plant datadisks closet"
+	},
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"da" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"di" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_dorms"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew)
+"dw" = (
+/obj/effect/turf_decal/elysium_logo/three_three{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"dV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"ec" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"em" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ship/hangar)
+"ev" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/ship/hallway/central)
+"eB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
+	name = "Bathroom";
+	locked = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"eH" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "hydro";
+	name = "caid's locker";
+	req_access_txt = "20"
+	},
+/obj/item/clothing/under/utility,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/belt/security/webbing/elysium/unload_vest_green,
+/obj/item/clothing/head/helmet/m10_elysium,
+/obj/item/gun/ballistic/automatic/smg/skm_carbine,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/clothing/suit/armor/vest/security,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"eJ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"eK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hangar)
+"eW" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"fc" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"fd" = (
+/obj/structure/railing{
+	layer = 3.31
+	},
+/obj/effect/turf_decal/box/corners{
+	color = "#75A2BB"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8;
+	color = "#75A2BB"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"fg" = (
+/obj/machinery/light_switch{
+	pixel_y = 20;
+	pixel_x = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"fi" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"fj" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	layer = 2.456;
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"fs" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sign/poster/elysium/sonofelysium{
+	pixel_x = 31;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"fF" = (
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/light/small/directional/east,
+/obj/item/circuitboard/computer/operating,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"fL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/ship/hangar)
+"fM" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"fR" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/crew)
+"gk" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hangar)
+"gu" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"gw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/plasma,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating,
+/area/ship/medical)
+"gy" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/airalarm/directional/north,
+/obj/item/storage/belt/medical/paramedic,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"gA" = (
+/obj/effect/turf_decal/elysium_logo/two_two{
+	color = "#758967"
+	},
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"gE" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"gF" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/elysium_logo/three_two{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"gH" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	layer = 2.456
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"gR" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_fo"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
+"gT" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/security)
+"gU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"hg" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"hq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"hL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"hQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"hR" = (
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/structure/sign/poster/contraband/have_a_puff{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"ia" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"is" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating{
+	initial_gas_mix = "plasma=300;TEMP=293.15"
+	},
+/area/ship/hallway/central)
+"iw" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"ix" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.456
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"iN" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/catwalk/over,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"iO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/clip{
+	pixel_y = 7
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/corner/transparent/green/three_quarters{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"iQ" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"iW" = (
+/obj/structure/bed,
+/obj/item/bedsheet/elysium,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"jb" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"jc" = (
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3);
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"jp" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"js" = (
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"jL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"jQ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"jR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/catwalk/over,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"jY" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"jZ" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"kd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/item/banner/elysium/mundane{
+	pixel_x = 3;
+	pixel_y = 0;
+	anchored = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"kt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"kv" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"kx" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"kE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"kG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"kH" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"kL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"kS" = (
+/obj/machinery/door/poddoor{
+	id = "atlas_cargo"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "atlas_holo"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"kX" = (
+/obj/effect/turf_decal/corner/transparent/blue/border{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/closet/wall/chem/directional/south{
+	name = "plant datadisks closet"
+	},
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/ambrosia/deus,
+/obj/item/seeds/ambrosia/deus,
+/obj/item/seeds/ambrosia/gaia,
+/obj/item/seeds/ambrosia/gaia,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/obj/item/seeds/cannabis,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"lc" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"le" = (
+/obj/effect/turf_decal/industrial/loading{
+	icon_state = "loadingarea_stripes"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"lw" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/radio/intercom/wideband/directional/south,
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -33;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"lJ" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = 11
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew)
+"lY" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"mf" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/structure/closet/wall/directional/east,
+/obj/item/clothing/suit/apparel/black,
+/obj/item/clothing/suit/apparel/black,
+/obj/item/clothing/suit/apparel/green,
+/obj/item/clothing/suit/apparel/green,
+/obj/item/clothing/suit/apparel/white,
+/obj/item/clothing/suit/apparel/white,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/head/bandana/elysium/green,
+/obj/item/clothing/head/bandana/elysium/green,
+/obj/item/clothing/head/bandana/elysium/black,
+/obj/item/clothing/head/bandana/elysium/black,
+/obj/item/clothing/head/bandana/elysium/white,
+/obj/item/clothing/head/bandana/elysium/white,
+/obj/item/clothing/head/shemag/white,
+/obj/item/clothing/head/shemag/white,
+/obj/item/clothing/head/shemag/green,
+/obj/item/clothing/head/shemag/green,
+/obj/item/clothing/head/shemag/black,
+/obj/item/clothing/head/shemag/black,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"mh" = (
+/obj/machinery/button/door{
+	pixel_y = 23;
+	id = "atlas_fo";
+	name = "private windows button"
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/elysium,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"ms" = (
+/obj/docking_port/mobile{
+	dir = 2;
+	launch_status = 0;
+	port_direction = 8;
+	preferred_direction = 4;
+	name = "atlas dock"
+	},
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"mw" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"mK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"mS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"nm" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"ny" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/guncloset,
+/obj/item/gun/ballistic/rifle/illestren/factory{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/gun/ballistic/rifle/illestren/factory{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/gun/ballistic/rifle/illestren/factory{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"nO" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"nP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/metal,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"nQ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"nS" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"nU" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"nW" = (
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ship/hangar)
+"nX" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"nY" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"oa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/crew)
+"of" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/secure_closet{
+	icon_state = "med";
+	name = "chemical products locker"
+	},
+/obj/item/storage/pill_bottle/psicodine{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/storage/pill_bottle/lsd{
+	pixel_y = -8;
+	pixel_x = 3
+	},
+/obj/item/storage/pill_bottle/psicodine{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/storage/pill_bottle/lsd{
+	pixel_x = -2;
+	pixel_y = -8
+	},
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/pillbottles,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"ov" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"oJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"oX" = (
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Captain's Quarters";
+	req_access_txt = "20"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"oY" = (
+/obj/structure/toilet{
+	dir = 1;
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/bodypart/head/lizard{
+	pixel_x = -5;
+	pixel_y = -14
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/bodypart/l_arm/lizard{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"pi" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"pn" = (
+/obj/structure/rack,
+/obj/item/toy/plush/celadon/separ,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"pp" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_engi_lockdown"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"pq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"ps" = (
+/turf/template_noop,
+/area/template_noop)
+"pE" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8;
+	layer = 2.456
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "plasma=300;TEMP=293.15"
+	},
+/area/ship/hallway/central)
+"qb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/green/half,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"qc" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_bridge"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"qn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"qp" = (
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"qr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/elysium_logo/one_three{
+	color = "#758967"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"qA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"qG" = (
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"qP" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/elysium_logo/two_three{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"qR" = (
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/security)
+"qS" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"rk" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"rr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ship/hangar)
+"ry" = (
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/elysm/EVA_armored,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"rz" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"rO" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"rR" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 23
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"sh" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20
+	},
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi';
+	dir = 1
+	},
+/area/ship/engineering)
+"si" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"sl" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_y = -20;
+	dir = 1
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "hydro";
+	name = "sergeant's locker";
+	req_access_txt = "1"
+	},
+/obj/item/storage/belt/security/webbing/elysium/unload_vest_green{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/m10_elysium,
+/obj/item/clothing/under/utility,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/color/black,
+/obj/item/melee/knife/survival,
+/obj/item/gun/ballistic/shotgun/automatic/m11/empty,
+/obj/item/storage/box/ammo/a12g_slug,
+/obj/item/storage/box/ammo/a12g_slug,
+/obj/item/attachment/sling,
+/obj/item/clothing/suit/armor/vest/alt,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"sA" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"sB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"sD" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering)
+"sF" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/machinery/blackbox_recorder{
+	empty = 1
+	},
+/obj/machinery/door/window/brigdoor/northleft,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"sI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Armory";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"sL" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"sP" = (
+/obj/machinery/computer/cryopod/directional/west,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew)
+"tc" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_cap"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew/crewthree)
+"tq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/structure/holosign/barrier/atmos,
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"tA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"tF" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"tP" = (
+/obj/structure/table,
+/obj/item/stamp{
+	pixel_x = 9;
+	pixel_y = 13
+	},
+/obj/item/clipboard,
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/item/binoculars{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"tW" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hangar)
+"us" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/table,
+/obj/item/melee/knife/kitchen{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"ux" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/elysium_logo/two_one{
+	color = "#758967"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"uC" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "atlas_bridge_lockdown";
+	dir = 1;
+	pixel_y = 4;
+	name = "bridge lockdown";
+	pixel_x = -6
+	},
+/obj/machinery/button/door{
+	id = "atlas_bridge";
+	dir = 1;
+	pixel_x = 7;
+	pixel_y = 4;
+	name = "bridge shutters"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/jukebox/boombox{
+	pixel_x = 0;
+	pixel_y = -10
+	},
+/obj/effect/turf_decal/corner/transparent/green/half,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"uG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"uH" = (
+/obj/machinery/computer/helm/viewscreen/directional/south,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/elysm/EVA_armored,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/security)
+"uO" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/machinery/biogenerator,
+/turf/open/floor/plating,
+/area/ship/medical)
+"uQ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"uX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/holosign/barrier/atmos,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"uY" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"vd" = (
+/obj/structure/catwalk/over,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"vo" = (
+/obj/structure/railing,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 9;
+	pixel_x = 2
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/cell_charger,
+/obj/structure/table,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"vw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"vT" = (
+/obj/structure/janitorialcart{
+	dir = 8
+	},
+/obj/item/mop{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/crew)
+"vW" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"vZ" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_engi_lockdown"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"wc" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"wd" = (
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = -28
+	},
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"we" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wi" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/techfloor/orange,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"wu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/turretid/ship{
+	pixel_x = -28;
+	pixel_y = -3;
+	id = "atlas"
+	},
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"wy" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/item/paper/crumpled{
+	pixel_x = 5;
+	pixel_y = -8;
+	default_raw_text = "Завозившие нам припасы братья случайно выронили плату редчайшего ботанического диспенсера в туалете, а сейчас он оккупирован агрессивными тараканами... Не стоит суваться туда, пока что."
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"wJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"wU" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/industrial,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"wW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"xi" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-203"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/ship/external/dark)
+"xz" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/structure/closet/crate,
+/obj/structure/crate_shelf/built,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"xU" = (
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"yi" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"yn" = (
+/obj/structure/frame/computer{
+	dir = 4;
+	anchored = 1
+	},
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"yo" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"yx" = (
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"yB" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.456
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"yC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/holopad/emergency/counselor,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"yI" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -20
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"yL" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"yO" = (
+/obj/machinery/computer/helm/viewscreen/directional/north,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"yR" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/ship/medical)
+"yT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"yZ" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/clothing/under/utility{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/clothing/under/utility{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/clothing/under/utility{
+	pixel_x = -13;
+	pixel_y = 8
+	},
+/obj/item/clothing/under/utility{
+	pixel_x = 16;
+	pixel_y = 9
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = 12;
+	pixel_y = -3
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = -14;
+	pixel_y = -4
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/item/clothing/under/utility{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_x = 11;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"zc" = (
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/smartfridge/disks,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"zf" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 26
+	},
+/obj/structure/closet/emcloset/wall/directional/south,
+/obj/item/clothing/head/space/elysm/space_helm{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/item/clothing/head/space/elysm/space_helm{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/suit/space/eva{
+	pixel_x = 14;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/space/eva{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering)
+"zl" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/closet/crate{
+	name = "spare engine parts crate"
+	},
+/obj/item/storage/box/stockparts/basic,
+/obj/item/storage/box/stockparts/basic,
+/obj/item/storage/box/stockparts/basic,
+/obj/item/storage/box/stockparts/basic,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/obj/item/circuitboard/machine/shuttle/engine/electric,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hangar)
+"zq" = (
+/obj/machinery/door/poddoor{
+	id = "atlas_cargo"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "atlas_holo"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"zt" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"zx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"zE" = (
+/obj/machinery/button/door{
+	id = "atlas_dorms";
+	name = "private windows button";
+	pixel_x = -23;
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/bedsheetbin,
+/turf/open/floor/plating,
+/area/ship/crew)
+"zQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"An" = (
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/plating,
+/area/ship/crew)
+"Av" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/west,
+/obj/item/reagent_containers/glass/filter{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/glass/filter{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/glass/filter{
+	pixel_x = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Ay" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"AH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"AP" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Bc" = (
+/obj/effect/turf_decal/industrial/loading{
+	icon_state = "loadingarea_stripes"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/storage/bag/plants,
+/obj/item/storage/bag/plants,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/gun/energy/floragun,
+/obj/item/hatchet/wooden,
+/obj/item/hatchet/wooden,
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Bm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_engi_lockdown"
+	},
+/obj/machinery/power/shuttle/engine/electric,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Bx" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/electropack{
+	pixel_x = -7;
+	pixel_y = -3;
+	frequency = 1448;
+	name = "xeno scum electropack";
+	desc = "Dance my riols! DANCE!!!"
+	},
+/obj/item/stack/sticky_tape/pointy{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/storage/box/zipties{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = -4;
+	frequency = 1448
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/security)
+"BH" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"BL" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/effect/turf_decal/industrial,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"BN" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"BW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"Cc" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1;
+	color = "#75A2BB"
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4;
+	color = "#75A2BB"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8;
+	piping_layer = 2
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"Cn" = (
+/obj/item/cigbutt{
+	anchored = 1;
+	color = "#808080";
+	layer = 2;
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/effect/decal/fakelattice,
+/obj/structure/railing,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/ship/hallway/central)
+"Cq" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Cr" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-9"
+	},
+/obj/item/circuitboard/machine/pacman/super,
+/obj/item/stock_parts/capacitor{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"CM" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/beaker/plastic{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/plastic{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/pill/three_eye{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"CO" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/medical)
+"CX" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/button/door{
+	pixel_y = -23;
+	id = "atlas_med";
+	dir = 1;
+	name = "medbay shutters"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/closet/crate/hydroponics{
+	name = "hydroponics machinery crate"
+	},
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/turf/open/floor/plating,
+/area/ship/medical)
+"CZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/sign/poster/elysium/protest{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Da" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Do" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Dq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/circuitboard/machine/plantgenes,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/ship/medical)
+"DL" = (
+/obj/machinery/photocopier,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"Ea" = (
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"Ej" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Eo" = (
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/machinery/light/directional/west,
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/metal/twenty,
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Es" = (
+/obj/structure/curtain/cloth/grey,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Ey" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-23"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/ship/external/dark)
+"EB" = (
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/dresser,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"ED" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-02";
+	pixel_x = -7
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/green/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"EH" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"EJ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/item/banner/elysium/mundane{
+	pixel_x = 3;
+	pixel_y = 0;
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"EW" = (
+/obj/machinery/porta_turret/ship/elysium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"EZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4
+	},
+/obj/structure/holosign/barrier/atmos,
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi';
+	dir = 4
+	},
+/area/ship/bridge)
+"Fu" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-21"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/ship/external/dark)
+"Fv" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ship/hangar)
+"FN" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewthree)
+"FO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/holosign/barrier/atmos,
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi';
+	dir = 4
+	},
+/area/ship/bridge)
+"FQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Gi" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/item/organ/tail/lizard{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Gj" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/item/banner/elysium/mundane{
+	pixel_x = 3;
+	pixel_y = 0;
+	anchored = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hangar)
+"Gt" = (
+/obj/item/bedsheet/elysium,
+/obj/structure/bed,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"GH" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"Hf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/rollingpapers{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/storage/fancy/rollingpapers{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/storage/fancy/rollingpapers{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Hg" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Hh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "atlas_engi_lockdown";
+	dir = 4;
+	pixel_y = 2;
+	name = "engineering shutters";
+	pixel_x = -24
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Hl" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/directional/west,
+/obj/structure/window/plasma/reinforced/spawner/north,
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"Hu" = (
+/obj/machinery/door/poddoor{
+	id = "atlas_cargo"
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"HW" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew)
+"HX" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/hallway/central)
+"Ig" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Il" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Ir" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/elysium_logo/one_two{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"IK" = (
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty,
+/obj/structure/crate_shelf/built,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"IP" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"IR" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/item/banner/elysium/mundane{
+	pixel_x = 3;
+	pixel_y = 0;
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"Jb" = (
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_bridge_lockdown"
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(1,19)
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Je" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"JL" = (
+/obj/machinery/holopad/emergency/medical,
+/obj/structure/fluff/clockwork/alloy_shards,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"JR" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"JU" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"JV" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-02";
+	pixel_y = 16;
+	pixel_x = -6
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/railing,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/green/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Kf" = (
+/obj/effect/decal/cleanable/confetti,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 8
+	},
+/obj/structure/catwalk/over,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Km" = (
+/obj/machinery/computer/helm/viewscreen/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewtwo)
+"KB" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Ld" = (
+/obj/effect/decal/cleanable/oil/slippery{
+	icon_state = "floor5";
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/obj/item/crowbar/large{
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/item/wirecutters{
+	pixel_x = -5;
+	pixel_y = -15
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Ln" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris{
+	pixel_x = 0;
+	pixel_y = -34
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"Lp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/south,
+/obj/item/elysm_manual{
+	pixel_y = -4;
+	pixel_x = -9
+	},
+/obj/item/storage/book/bible/koran{
+	name = "Терик-аль-Шаед";
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/syndicatedetonator{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/corner/transparent/green/three_quarters,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Lw" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	id = "atlas_cargo";
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 6;
+	name = "cargo bay control"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	pixel_y = -4;
+	pixel_x = -20;
+	id = "atlas_holo"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"LE" = (
+/obj/structure/grille,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external/dark)
+"LH" = (
+/obj/structure/filingcabinet/double/grey{
+	pixel_y = 14
+	},
+/obj/item/folder,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder/white,
+/obj/item/folder/yellow,
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"LM" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"Ml" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear/white,
+/obj/machinery/light/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"Mq" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 11;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"Mu" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5-6"
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"My" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"MC" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"MH" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable/yellow,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"MO" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating{
+	initial_gas_mix = "plasma=300;TEMP=293.15"
+	},
+/area/ship/hallway/central)
+"MQ" = (
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Ni" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/holosign/barrier/atmos,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"No" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"NE" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"NF" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"NY" = (
+/obj/structure/chair/comfy/blue{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"Ob" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Oj" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/decal/cleanable/plasma,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Ot" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"OA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"OV" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/stack/ore/salvage/scrapsilver{
+	pixel_x = 4;
+	pixel_y = -8
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/box/corners{
+	dir = 1;
+	color = "#75A2BB"
+	},
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"OW" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/elevatorshaft,
+/area/ship/hallway/central)
+"Pd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Pi" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"Pk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/elysium_logo/three_one{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Pn" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew/crewthree)
+"Py" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	populate = 0
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/obj/item/storage/belt/utility/full,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -1;
+	pixel_y = -8
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"PD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 4
+	},
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 1;
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/floordetail/pryhole,
+/obj/machinery/light/small/directional/east,
+/mob/living/simple_animal/hostile/asteroid/roach/fuhrer{
+	health = 250;
+	name = "Strengthened Fuhrer Roach"
+	},
+/obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter{
+	name = "Botanical Dispenser (Machine Board)"
+	},
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/item/organ/tail/riol,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/riol,
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/riol,
+/turf/open/floor/plastic,
+/area/ship/crew)
+"PG" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"PT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"PU" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"PV" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/door_assembly/door_assembly_grunge{
+	dir = 4;
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"PX" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Qa" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Qb" = (
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/crew)
+"Qg" = (
+/obj/item/cigbutt{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/structure/catwalk/over,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Qj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/obj/structure/mirror{
+	pixel_x = -28;
+	pixel_y = 7
+	},
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/mob/living/simple_animal/hostile/asteroid/roach/tank,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/item/organ/ears/riol,
+/obj/item/bodypart/leg/left/riol{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/turf/open/floor/plastic,
+/area/ship/crew)
+"Qu" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering)
+"Qv" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 1
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"Qw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/elysium_logo/one_one{
+	color = "#758967"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Qx" = (
+/obj/item/bedsheet/elysium,
+/obj/structure/bed/pod,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Qz" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"QC" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"QG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/hallway/central)
+"QM" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"QS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Rf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/grunge{
+	name = "Cryogenics"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"Rt" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"Rv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Rz" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/clothing/head/helmet/m10_elysium{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/m10_elysium{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/m10_elysium{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/armor/vest/alt{
+	pixel_x = 4;
+	pixel_y = -8
+	},
+/obj/item/clothing/suit/armor/vest/alt{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/armor/vest/alt{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"RL" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_x = 10
+	},
+/obj/item/lighter{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewthree)
+"RM" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"RQ" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"RU" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/computer/crew/syndie{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Sb" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/landmark/subship{
+	subship_template = /datum/map_template/shuttle/subshuttles/elysium_felon
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Sp" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_cap"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew/crewthree)
+"Ss" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Sw" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/storage/toolbox/ammo/a850r,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Sz" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"SB" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/security)
+"SI" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"ST" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3)
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"SW" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_press,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Td" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/item/mecha_parts/chassis/ripley,
+/obj/item/mecha_parts/part/ripley_left_arm,
+/obj/item/mecha_parts/part/ripley_left_leg,
+/obj/item/mecha_parts/part/ripley_right_arm,
+/obj/item/mecha_parts/part/ripley_right_leg,
+/obj/item/mecha_parts/part/ripley_torso,
+/obj/item/circuitboard/mecha/ripley/main,
+/obj/item/circuitboard/mecha/ripley/peripherals,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/structure/closet/crate/large{
+	name = "Ripley MK1 crate"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Ti" = (
+/obj/machinery/light/directional/west,
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"Tx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"Ty" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"TA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/rods/fifty,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"TE" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/cargo)
+"TK" = (
+/obj/structure/dresser{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	pixel_y = -23;
+	id = "atlas_cap";
+	dir = 1;
+	name = "private windows button"
+	},
+/obj/item/blackmarket_uplink{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ship/crew/crewthree)
+"TT" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Uh" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/belt/security/webbing/elysium/unload_vest_green{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/storage/belt/security/webbing/elysium/unload_vest_green{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/storage/belt/security/webbing/elysium/unload_vest_green{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Um" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/space/elysm/space_helm,
+/turf/open/floor/pod/dark,
+/area/ship/hangar)
+"Us" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/crew)
+"UC" = (
+/obj/effect/turf_decal/corner/transparent/blue/border{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/ship/medical)
+"UG" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 0;
+	pixel_y = -29
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"UK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew)
+"UP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/frame/computer{
+	dir = 1;
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"US" = (
+/obj/machinery/computer/cargo{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"UY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/catwalk/over,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Vk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access = list(3)
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/radio/intercom/table{
+	pixel_y = -3;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Vl" = (
+/obj/effect/turf_decal/corner/transparent/blue/border{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/blue/mono,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 19;
+	pixel_x = 7
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/mono/white,
+/area/ship/medical)
+"Vo" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "atlas_med"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/medical)
+"Vq" = (
+/obj/structure/rack,
+/obj/machinery/light/directional/north,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/melee/knife/survival{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/attachment/sling,
+/obj/item/attachment/sling,
+/obj/item/attachment/sling,
+/obj/item/melee/baton/cattleprod/loaded{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/melee/baton/cattleprod/loaded{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Vw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"VG" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ship/bridge)
+"VK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/space_heater,
+/turf/open/floor/engine/hull/interior,
+/area/ship/engineering)
+"VQ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi'
+	},
+/area/ship/engineering)
+"VR" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security)
+"VT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"VV" = (
+/obj/machinery/porta_turret/ship/elysium{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/security)
+"VW" = (
+/obj/effect/decal/fakelattice{
+	icon_state = "lattice-6"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/ship/external/dark)
+"We" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Wg" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1;
+	layer = 2.456
+	},
+/turf/open/floor/plating,
+/area/ship/hallway/central)
+"Wk" = (
+/obj/effect/turf_decal/corner/transparent/blue{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/door_assembly/door_assembly_med{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Wr" = (
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "First Officer's Quarters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"Wx" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_bridge_lockdown"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/item/shard/plastitanium{
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/obj/item/shard/plastitanium{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/stack/rods,
+/obj/item/stack/rods,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"WO" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/crew)
+"WQ" = (
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plasteel/dark,
+/area/ship/engineering)
+"WR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plating,
+/area/ship/crew)
+"WZ" = (
+/obj/structure/catwalk/over,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Xc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"Xg" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating{
+	initial_gas_mix = "plasma=300;TEMP=293.15"
+	},
+/area/ship/hallway/central)
+"Xl" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light_switch{
+	pixel_y = 23;
+	pixel_x = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Xp" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/fluff/clockwork/alloy_shards,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"XT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/security)
+"Ya" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/tech,
+/area/ship/hangar)
+"Yt" = (
+/obj/docking_port/stationary{
+	width = 30;
+	height = 15;
+	dwidth = 15
+	},
+/turf/template_noop,
+/area/template_noop)
+"Yu" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating{
+	initial_gas_mix = "plasma=300;TEMP=293.15"
+	},
+/area/ship/engineering)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/door_assembly/door_assembly_min{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/cargo)
+"Yx" = (
+/obj/effect/decal/fakelattice,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/effect/spawner/random/trash/botanical_waste,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/ship/hallway/central)
+"YG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"YK" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm/directional/south,
+/obj/item/broken_bottle,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewthree)
+"YM" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_fo"
+	},
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
+"YO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/circuitboard/computer/mech_bay_power_console{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/shard{
+	pixel_x = -11;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
+"YU" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central3{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Zd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ship/hangar)
+"Ze" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate{
+	name = "janitorial crate"
+	},
+/obj/item/mop,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/toy/plush/celadon/hampter/janitor,
+/obj/effect/spawner/random/trash/soap,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/hangar)
+"Zo" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/pen{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/papercutter{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Zs" = (
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "atlas_bridge_lockdown"
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Bridge";
+	req_one_access = list(1,19)
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"ZE" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/dresser,
+/obj/machinery/jukebox/boombox{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/crewtwo)
+"ZG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash/large{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/structure/sign/poster/elysium/logo{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"ZM" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"ZU" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel/dark,
+/area/ship/hallway/central)
+"ZZ" = (
+/obj/machinery/computer/helm{
+	dir = 8;
+	icon_state = "computer-middle"
+	},
+/obj/effect/turf_decal/corner/transparent/green/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+
+(1,1,1) = {"
+ps
+ps
+ps
+ps
+ms
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+ps
+BN
+ps
+ps
+"}
+(2,1,1) = {"
+ps
+ps
+ps
+ps
+PU
+PU
+Bm
+Bm
+PU
+ps
+ps
+PU
+sD
+PU
+ps
+ps
+PU
+Bm
+Bm
+PU
+PU
+ps
+ps
+"}
+(3,1,1) = {"
+ps
+ps
+ps
+ps
+PU
+Ti
+yL
+af
+PU
+Bm
+Bm
+PU
+zf
+PU
+Bm
+Bm
+PU
+cN
+YU
+Hl
+PU
+ps
+ps
+"}
+(4,1,1) = {"
+ps
+ps
+ps
+ps
+pp
+eW
+My
+Il
+PU
+fc
+jY
+PU
+Qu
+PU
+fc
+jY
+PU
+bK
+JR
+TA
+pp
+ps
+ps
+"}
+(5,1,1) = {"
+ps
+ps
+ps
+ps
+pp
+Py
+Yu
+fM
+vo
+wc
+mw
+Hh
+Qg
+wd
+kx
+ZM
+Eo
+Rv
+Mu
+MH
+pp
+ps
+ps
+"}
+(6,1,1) = {"
+ps
+ps
+ps
+bF
+vZ
+VK
+Kf
+jR
+iN
+sh
+vw
+UY
+OA
+vd
+WZ
+VQ
+PX
+mK
+Xp
+Cr
+pp
+ps
+ps
+"}
+(7,1,1) = {"
+ps
+ps
+ps
+ps
+PU
+PU
+Cc
+qS
+fd
+PU
+WQ
+PU
+PU
+PU
+PU
+PU
+BL
+qG
+wU
+PU
+PU
+ps
+ps
+"}
+(8,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+Qv
+PU
+PU
+PU
+tW
+eK
+tW
+Ze
+fL
+Gj
+tW
+PU
+PU
+PU
+EW
+ps
+ps
+ps
+"}
+(9,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+gT
+Qx
+Gi
+oY
+tW
+em
+tW
+zl
+Ya
+gk
+tW
+LE
+LE
+LE
+ps
+ps
+ps
+ps
+"}
+(10,1,1) = {"
+ps
+ps
+ps
+ps
+gT
+gT
+jc
+XT
+gT
+tW
+VT
+Pd
+kt
+YG
+gU
+tW
+HW
+HW
+HW
+HW
+HW
+ps
+ps
+"}
+(11,1,1) = {"
+ps
+ps
+ps
+gT
+gT
+kd
+gE
+Bx
+gT
+kE
+nS
+nW
+Fv
+Fv
+Sb
+nQ
+HW
+WR
+us
+An
+HW
+HW
+ps
+"}
+(12,1,1) = {"
+ps
+ps
+ps
+gT
+Vq
+Sw
+QS
+SB
+Vk
+Ig
+nW
+Fv
+nW
+nW
+rr
+nY
+HW
+ZG
+fR
+oa
+zE
+di
+ps
+"}
+(13,1,1) = {"
+ps
+ps
+ps
+gT
+ny
+VR
+aX
+qR
+ST
+Ig
+rr
+Fv
+Fv
+nW
+nW
+nY
+HW
+fg
+wJ
+UK
+vT
+di
+ps
+"}
+(14,1,1) = {"
+ps
+ps
+ps
+gT
+Rz
+Uh
+dV
+uH
+gT
+Ig
+Fv
+nW
+rr
+rr
+nW
+cm
+Rf
+Ej
+yi
+aI
+Qb
+di
+ps
+"}
+(15,1,1) = {"
+ps
+ps
+ps
+gT
+yo
+fs
+QC
+sl
+gT
+Xl
+nW
+rr
+rr
+nW
+Fv
+hg
+HW
+HW
+Es
+HW
+HW
+HW
+ps
+"}
+(16,1,1) = {"
+ps
+ps
+ps
+gT
+bQ
+gT
+sI
+gT
+gT
+CZ
+nW
+rr
+nW
+nW
+rr
+kv
+NE
+HW
+lJ
+sP
+wi
+HW
+ps
+"}
+(17,1,1) = {"
+ps
+ps
+ps
+gT
+yZ
+gT
+zQ
+PT
+Um
+Cq
+nW
+nW
+rr
+rr
+Fv
+Qz
+nU
+HW
+WO
+mf
+nO
+HW
+ps
+"}
+(18,1,1) = {"
+ps
+ps
+ps
+VV
+gT
+gT
+Zd
+sL
+We
+Ob
+rr
+Fv
+nW
+rr
+nW
+KB
+HW
+HW
+HW
+HW
+HW
+Us
+ps
+"}
+(19,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+gT
+MC
+Pi
+sA
+eJ
+RM
+gu
+Ss
+bS
+Ss
+wy
+eB
+Qj
+PD
+HW
+ps
+ps
+ps
+"}
+(20,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+TE
+TE
+TE
+TE
+TE
+HX
+jp
+HX
+PV
+HX
+CO
+CO
+CO
+CO
+HW
+ps
+ps
+ps
+"}
+(21,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+ps
+TE
+OV
+No
+TE
+ev
+sB
+Ot
+ia
+Yx
+CO
+gy
+zc
+CO
+ps
+ps
+ps
+ps
+"}
+(22,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+TE
+TE
+Ld
+yn
+TE
+TE
+zt
+tF
+Ty
+CO
+CO
+UC
+cY
+CO
+CO
+ps
+ps
+ps
+"}
+(23,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+zq
+Lw
+le
+YO
+Hg
+Yw
+TT
+hL
+TT
+gw
+aC
+FQ
+mS
+CX
+CO
+ps
+ps
+ps
+"}
+(24,1,1) = {"
+ps
+ps
+ps
+ps
+Yt
+Hu
+NF
+Td
+jZ
+yI
+TE
+hQ
+rk
+Ln
+CO
+Dq
+aa
+JL
+Oj
+Vo
+ps
+ps
+ps
+"}
+(25,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+Hu
+nX
+Do
+tA
+UP
+TE
+wW
+rk
+JU
+CO
+we
+uO
+qp
+yR
+Vo
+ps
+ps
+ps
+"}
+(26,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+kS
+Ml
+Bc
+Da
+SI
+nP
+yB
+ix
+yB
+Wk
+zx
+AH
+qA
+xU
+CO
+ps
+ps
+ps
+"}
+(27,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+TE
+TE
+nm
+ov
+TE
+TE
+yT
+ec
+uY
+CO
+CO
+Vl
+kX
+CO
+CO
+ps
+ps
+ps
+"}
+(28,1,1) = {"
+ps
+ps
+ps
+ps
+ps
+ps
+TE
+IK
+xz
+TE
+MO
+uQ
+pE
+uQ
+si
+CO
+fF
+UG
+CO
+ps
+ps
+ps
+ps
+"}
+(29,1,1) = {"
+ps
+ps
+bn
+VW
+Ey
+Fu
+TE
+TE
+TE
+TE
+kG
+kL
+pi
+BW
+jb
+CO
+CO
+CO
+CO
+VW
+Ey
+Fu
+GH
+"}
+(30,1,1) = {"
+ps
+ps
+FN
+FN
+xi
+HX
+HX
+EJ
+aS
+uY
+is
+Xg
+lY
+oJ
+Sz
+uY
+iQ
+IR
+HX
+HX
+xi
+da
+da
+"}
+(31,1,1) = {"
+ps
+ps
+FN
+FN
+FN
+FN
+Cn
+lc
+gH
+QG
+Wg
+fi
+jL
+AP
+gH
+QG
+fj
+RQ
+OW
+da
+da
+da
+da
+"}
+(32,1,1) = {"
+ps
+ps
+Sp
+jQ
+hR
+FN
+FN
+oX
+FN
+FN
+rR
+BH
+Qa
+pq
+ZU
+da
+da
+Wr
+da
+da
+SW
+Av
+gR
+"}
+(33,1,1) = {"
+ps
+ps
+Sp
+rz
+NY
+hq
+Xc
+uX
+sF
+LM
+LM
+Jb
+Wx
+Zs
+LM
+LM
+rO
+Ni
+Tx
+iw
+MQ
+CM
+gR
+"}
+(34,1,1) = {"
+ps
+ps
+Sp
+RL
+cc
+yC
+Vw
+YK
+LM
+LM
+JV
+FO
+tq
+EZ
+ED
+LM
+LM
+of
+Ay
+aw
+Hf
+EH
+gR
+"}
+(35,1,1) = {"
+ps
+ps
+FN
+FN
+LH
+uG
+ry
+LM
+LM
+Mq
+qn
+Qw
+ux
+Pk
+qb
+pn
+LM
+LM
+ZE
+Rt
+IP
+da
+da
+"}
+(36,1,1) = {"
+ps
+ps
+ps
+FN
+FN
+vW
+TK
+LM
+wu
+Ea
+js
+Ir
+gA
+gF
+aY
+Ea
+lw
+LM
+mh
+cV
+da
+da
+ps
+"}
+(37,1,1) = {"
+ps
+ps
+ps
+Je
+FN
+yO
+PG
+LM
+tP
+DL
+Zo
+qr
+qP
+dw
+uC
+QM
+VG
+LM
+EB
+Km
+da
+Je
+ps
+"}
+(38,1,1) = {"
+ps
+ps
+ps
+Je
+FN
+Gt
+eH
+LM
+qc
+LM
+iO
+RU
+ZZ
+US
+Lp
+LM
+qc
+LM
+iW
+yx
+da
+Je
+ps
+"}
+(39,1,1) = {"
+ps
+ps
+ps
+ps
+Pn
+tc
+tc
+LM
+ps
+LM
+qc
+qc
+qc
+qc
+qc
+LM
+ps
+LM
+YM
+YM
+kH
+ps
+ps
+"}

--- a/_maps/_mod_celadon/shuttles/subshuttles/elysium_felon.dmm
+++ b/_maps/_mod_celadon/shuttles/subshuttles/elysium_felon.dmm
@@ -1,0 +1,372 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/machinery/holopad/emergency/command,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"c" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_doors"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/oil/slippery{
+	icon_state = "floor5";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/docking_port/mobile{
+	can_move_docking_ports = 1;
+	dir = 4;
+	port_direction = 2;
+	preferred_direction = 4;
+	name = "felon"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"e" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/power/shuttle/engine/electric,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_thr"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"h" = (
+/obj/structure/crate_shelf/built,
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"i" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"k" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"o" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west{
+	dir = 2
+	},
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/structure/window/plasma/reinforced/spawner/north,
+/obj/machinery/power/shuttle/engine/electric,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_thr"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"u" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/floor,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -16
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"w" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/structure/window/plasma/reinforced/spawner/north,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_thr"
+	},
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"x" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"y" = (
+/obj/machinery/turretid{
+	pixel_x = -7;
+	pixel_y = -30;
+	id = "ntrider"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"z" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/brigdoor/eastright,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_thr"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"F" = (
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"H" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/airalarm/directional/north{
+	pixel_x = 0;
+	pixel_y = 38
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"I" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"L" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = 5;
+	pixel_y = 31
+	},
+/obj/machinery/button/door{
+	pixel_x = -9;
+	pixel_y = 24;
+	name = "window shutters";
+	id = "felon_window"
+	},
+/obj/machinery/button/door{
+	pixel_x = -11;
+	pixel_y = -22;
+	id = "felon_doors";
+	dir = 1;
+	name = "door shutters"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"O" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/closet/crate/hydroponics{
+	name = "bulk ambrosia crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
+/obj/machinery/button/door{
+	pixel_x = -7;
+	pixel_y = -21;
+	id = "felon_doors";
+	dir = 1;
+	name = "door shutters"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"Q" = (
+/obj/item/radio/intercom/wideband/directional{
+	pixel_x = 36;
+	pixel_y = -31
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"R" = (
+/turf/template_noop,
+/area/template_noop)
+"S" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/closet/wall/blue/directional/north{
+	icon_state = "emergency_wall"
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"T" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/closet/crate/hydroponics{
+	name = "bulk cannabis crate"
+	},
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/obj/machinery/button/door{
+	pixel_x = -7;
+	pixel_y = 21;
+	name = "thrusters shutters";
+	id = "felon_thr"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"U" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/jukebox/boombox{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/bridge)
+"W" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "felon_window"
+	},
+/turf/open/floor/plasteel/lightdark,
+/area/ship/bridge)
+
+(1,1,1) = {"
+R
+e
+c
+o
+R
+"}
+(2,1,1) = {"
+I
+z
+i
+w
+I
+"}
+(3,1,1) = {"
+I
+T
+x
+O
+I
+"}
+(4,1,1) = {"
+I
+U
+F
+h
+I
+"}
+(5,1,1) = {"
+I
+H
+b
+u
+k
+"}
+(6,1,1) = {"
+I
+S
+Q
+y
+I
+"}
+(7,1,1) = {"
+I
+I
+L
+I
+I
+"}
+(8,1,1) = {"
+R
+I
+W
+I
+R
+"}

--- a/_maps/_mod_celadon/shuttles/subshuttles/elysium_felon.dmm
+++ b/_maps/_mod_celadon/shuttles/subshuttles/elysium_felon.dmm
@@ -51,6 +51,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/closet/crate/hydroponics{
+	name = "bulk cannabis crate"
+	},
+/obj/structure/closet/crate/hydroponics{
+	name = "bulk ambrosia crate"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
 "i" = (
@@ -202,22 +208,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/closet/crate/hydroponics{
-	name = "bulk ambrosia crate"
-	},
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/gaia,
 /obj/machinery/button/door{
 	pixel_x = -7;
 	pixel_y = -21;
@@ -266,24 +256,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/structure/closet/crate/hydroponics{
-	name = "bulk cannabis crate"
-	},
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
-/obj/item/reagent_containers/food/snacks/grown/cannabis,
 /obj/machinery/button/door{
 	pixel_x = -7;
 	pixel_y = 21;

--- a/mod_celadon/maps/code/subshuttles.dm
+++ b/mod_celadon/maps/code/subshuttles.dm
@@ -110,3 +110,8 @@
 	file_name = "solfed_vespa"
 	name = "Vespa Expeditionary Dropship"
 	prefix = "sSFSV"
+
+/datum/map_template/shuttle/subshuttles/elysium_felon
+	file_name = "elysium_felon"
+	name = "Felon Drug Carrier"
+	prefix = "sEUSV"

--- a/mod_celadon/outfit/code/elysium/armor.dm
+++ b/mod_celadon/outfit/code/elysium/armor.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/suit/armor/vest/elysium
-	name = "Кустарная броня"
-	desc = "Самодельная защита сваренная из кусков брони, скрепленных кожей. Просто, но надежно."
+	name = "makeshift armor vest"
+	desc = "A makeshift armor vest composed of armor plates held together with leather. It is simple and reliable enough for YOU to use it, separatist."
 	icon = 'mod_celadon/_storge_icons/icons/obj/accessories.dmi'
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/accessories.dmi'
 	icon_state = "armor_plate"

--- a/mod_celadon/outfit/code/elysium/belt.dm
+++ b/mod_celadon/outfit/code/elysium/belt.dm
@@ -10,25 +10,25 @@
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
 
 /obj/item/storage/belt/security/webbing/elysium/vest_black
-	name = "Полная разгрузка, черная."
-	desc = "Удобный комплект для ношения всего необходимого: боеприпасов, мелкого оружия и аксессуаров. Легкий, практичный и обеспечивает свободу движения в бою.Черного цвета."
+	name = "black full webbing"
+	desc = "A handy webbing for carrying all the separatism necessities, this one is colored black."
 	icon_state = "vest_black"
 	item_state = "vest_black"
 
 /obj/item/storage/belt/security/webbing/elysium/green
-	name = "Полная разгрузка, зеленая."
-	desc = "Удобный комплект для ношения всего необходимого: боеприпасов, мелкого оружия и аксессуаров. Легкий, практичный и обеспечивает свободу движения в бою.Зеленого цвета"
+	name = "green full webbing"
+	desc = "A handy webbing for carrying all the separatism necessities, this one is colored green."
 	icon_state = "vest_green"
 	item_state = "vest_green"
 
 /obj/item/storage/belt/security/webbing/elysium/unload_vest_black
-	name = "Тактическая сбруя, черная."
-	desc = " Удобный пояс с карманами для боеприпасов и мелкого оружия, обеспечивает легкий доступ и свободу движения в бою. Черного цвета."
+	name = "black unload belt"
+	desc = "A handy unload belt for carrying all the separatism necessities, this one is colored black."
 	icon_state = "unload_vest_black"
 	item_state = "unload_vest_black"
 
 /obj/item/storage/belt/security/webbing/elysium/unload_vest_green
-	name = "Тактическая сбруя, зеленая."
-	desc = " Удобный пояс с карманами для боеприпасов и мелкого оружия, обеспечивает легкий доступ и свободу движения в бою. Зеленого цвета."
+	name = "green unload belt"
+	desc = "A handy unload belt for carrying all the separatism necessities, this one is colored green."
 	icon_state = "unload_vest_green"
 	item_state = "unload_vest_green"

--- a/mod_celadon/outfit/code/elysium/head.dm
+++ b/mod_celadon/outfit/code/elysium/head.dm
@@ -1,66 +1,66 @@
 /obj/item/clothing/head/bandana/elysium
-	name = "Пустотная бандана"
-	desc = "Бандана с патриотической надписью \"Слава Республике!\" на ней. Расспространённый среди различных слоёв населения патриотический головной убор."
+	name = "void bandana"
+	desc = "This is a simple bandana with a patriotic inscription \"Glory to the Republic!\" on it."
 	icon = 'mod_celadon/_storge_icons/icons/obj/hats.dmi'
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/elysium_head.dmi'
 
 /obj/item/clothing/head/bandana/elysium/black
-	name = "Чёрная бандана"
+	name = "black bandana"
 	icon_state = "bandana_black_elysium"
 	mob_overlay_state = "bandana_black_elysium"
 
 /obj/item/clothing/head/bandana/elysium/white
-	name = "Белая бандана"
+	name = "white bandana"
 	icon_state = "bandana_white_elysium"
 	mob_overlay_state = "bandana_white_elysium"
 
 /obj/item/clothing/head/bandana/elysium/green
-	name = "Зелёная бандана"
+	name = "green bandana"
 	icon_state = "bandana_green_elysium"
 	mob_overlay_state = "bandana_green_elysium"
 
 /obj/item/clothing/head/turban
-	name = "Пустой тюрбан"
-	desc = "Очень популярный традиционный головной убор в Республике Элизиум. Очень часто можно увидеть в повседневной жизни на территории Республики. Традиционно носится исключительно мужчинами."
+	name = "void turban"
+	desc = "This is a very popular traditional headwear from the Republic of Elysium, and may be seen often in daily life within its' borders. It is traditionally worn only by men."
 	icon = 'mod_celadon/_storge_icons/icons/obj/hats.dmi'
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/elysium_head.dmi'
 
 /obj/item/clothing/head/turban/black
-	name = "Чёрный тюрбан"
+	name = "black turban"
 	icon_state = "turban_black"
 	mob_overlay_state = "turban_black"
 
 /obj/item/clothing/head/turban/white
-	name = "Белый тюрбан"
+	name = "white turban"
 	icon_state = "turban_white"
 	mob_overlay_state = "turban_white"
 
 /obj/item/clothing/head/helmet/m10_elysium
-	name = "Шлем М10"
-	desc = "Расспрастранённый защитный головной убор разработанный для правоохранительных органов Республики. Но со временем стал общедоступным шлемом для всех граждан Республики. На этом шлеме виднеется зелёная повязка со слоганом Республики Элизиум: \"Сила в единстве, мудрость в вере\""
+	name = "M10 pattern helmet"
+	desc = "A widespread protective helmet initally designed for Republic of Elysium's law enforcement, but with time it has found use by its' civilans. There is a handband on it with an inscription that reads: \"Power in unity, wisdom in faith.\""
 	icon = 'mod_celadon/_storge_icons/icons/obj/hats.dmi'
 	icon_state = "m10helm_elysium"
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/elysium_head.dmi'
 	mob_overlay_state = "m10helm_elysium"
 
 /obj/item/clothing/head/shemag
-	name = "Пустотный шемаг"
-	desc = "Распрастронённый традиционный пустынный головной убор на территории Республики Элизиум. Отлично подходит для защиты лица от песчаных бурь Старбула."
+	name = "void shemagh"
+	desc = "This is a popular piece of headwear from the Republic of Elysium, and it is perfect for protecting one from the Starbull's dust storms."
 	icon = 'mod_celadon/_storge_icons/icons/obj/hats.dmi'
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/elysium_head.dmi'
 
 /obj/item/clothing/head/shemag/black
-	name = "Чёрный шемаг"
+	name = "black shemagh"
 	icon_state = "shemag_black"
 	mob_overlay_state = "shemag_black"
 
 /obj/item/clothing/head/shemag/green
-	name = "Зелёный шемаг"
+	name = "green shemagh"
 	icon_state = "shemag_green"
 	mob_overlay_state = "shemag_green"
 
 /obj/item/clothing/head/shemag/white
-	name = "Белый шемаг"
+	name = "white shemagh"
 	icon_state = "shemag_white"
 	mob_overlay_state = "shemag_white"
 
@@ -84,7 +84,7 @@
 
 /obj/item/clothing/head/space/elysm/space_helm
 	name = "Elysium EVA Helmet"
-	desc = "Довольно добротно сделанный шлем с маркировками сепаратистов Элизиума"
+	desc = "A pretty nicely made helmet with Elysium Separatists markings."
 	icon = 'mod_celadon/_storge_icons/icons/obj/hats.dmi'
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/space.dmi'
 	icon_state = "space_elysium"

--- a/mod_celadon/outfit/code/elysium/outfit_ship/elysium.dm
+++ b/mod_celadon/outfit/code/elysium/outfit_ship/elysium.dm
@@ -72,12 +72,12 @@
 	jobtype = /datum/job/captain
 
 	backpack = /obj/item/storage/backpack/satchel/leather
-	gloves = /obj/item/clothing/gloves/fingerless
+	gloves = /obj/item/clothing/gloves/color/black
 	back = /obj/item/storage/backpack/satchel/leather
 	uniform = /obj/item/clothing/under/color/darkgreen
-	shoes = /obj/item/clothing/shoes/sneakers/sandals
+	shoes = /obj/item/clothing/shoes/jackboots
 	mask = /obj/item/clothing/mask/bandana/green
-	ears = /obj/item/radio/headset/heads/captain
+	ears = /obj/item/radio/headset/heads/captain/alt
 	id = /obj/item/card/id/elysium/captain
 
 /datum/outfit/job/elysium/captain/post_equip(mob/living/carbon/human/H)
@@ -89,13 +89,14 @@
 	job_icon = "securityofficer"
 	jobtype = /datum/job/officer
 
-	suit = /obj/item/clothing/suit/armor/vest/elysium
-	gloves = /obj/item/clothing/gloves/fingerless
+	suit = /obj/item/clothing/suit/armor/vest
+	gloves = /obj/item/clothing/gloves/color/black
 	mask = /obj/item/clothing/mask/bandana/green
-	backpack = /obj/item/storage/backpack/satchel/sec
+	backpack = /obj/item/storage/backpack/satchel
 	uniform = /obj/item/clothing/under/utility
-	shoes = /obj/item/clothing/shoes/sneakers/black
+	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/helmet/m10_elysium
+	ears = /obj/item/radio/headset/alt
 	backpack_contents = list(/obj/item/melee/knife/switchblade)
 	id = /obj/item/card/id/elysium/security
 
@@ -110,10 +111,10 @@
 
 	suit = /obj/item/clothing/suit/apparel/black
 	gloves = /obj/item/clothing/gloves/fingerless
-	head = /obj/item/clothing/head/shemag/white
+	head = /obj/item/clothing/head/shemag/black
 	backpack = /obj/item/storage/backpack/satchel
 	uniform = /obj/item/clothing/under/utility
-	shoes = /obj/item/clothing/shoes/sneakers/black
+	shoes = /obj/item/clothing/shoes/jackboots
 	id = /obj/item/card/id/elysium/assistant
 
 /datum/outfit/job/elysium/assistant/post_equip(mob/living/carbon/human/H)

--- a/mod_celadon/outfit/code/elysium/suits.dm
+++ b/mod_celadon/outfit/code/elysium/suits.dm
@@ -5,36 +5,36 @@
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/mob/elysium_suit.dmi'
 
 /obj/item/clothing/suit/apparel/black
-	name = "Чёрная накидка"
-	desc = "Распространённая на территории Республики Элизиум накидка, являющаяся частью традиционной повседневной одежды."
+	name = "black cape"
+	desc = "Common in the territory of the Elysium Republic, this cape is a traditional casual wear out there."
 	icon_state = "apparel_black"
 	mob_overlay_state = "apparel_black"
 	allowed = list(/obj/item/melee/skimitar)
 
 /obj/item/clothing/suit/apparel/white
-	name = "Белая накидка"
-	desc = "Распространённая на территории Республики Элизиум накидка, являющаяся частью традиционной повседневной одежды."
+	name = "white cape"
+	desc = "Common in the territory of the Elysium Republic, this cape is a traditional casual wear out there."
 	icon_state = "apparel_white"
 	mob_overlay_state = "apparel_white"
 	allowed = list(/obj/item/melee/skimitar)
 
 /obj/item/clothing/suit/apparel/green
-	name = "Зелёная накидка"
-	desc = "Распространённая на территории Республики Элизиум накидка, являющаяся частью традиционной повседневной одежды."
+	name = "green cape"
+	desc = "Common in the territory of the Elysium Republic, this cape is a traditional casual wear out there."
 	icon_state = "apparel_green"
 	mob_overlay_state = "apparel_green"
 	allowed = list(/obj/item/melee/skimitar)
 
 /obj/item/clothing/suit/apparel/black/long
-	name = "Чёрная длинная накидка"
-	desc = "Распространённая на территории Республики Элизиум накидка, являющаяся частью традиционной повседневной одежды."
+	name = "black long cape"
+	desc = "Common in the territory of the Elysium Republic, this cape is a traditional casual wear out there."
 	icon_state = "long_apparel_black"
 	mob_overlay_state = "long_apparel_black"
 	allowed = list(/obj/item/melee/skimitar)
 
 /obj/item/clothing/suit/apparel/white/long
-	name = "Белая длинная накидка"
-	desc = "Распространённая на территории Республики Элизиум накидка, являющаяся частью традиционной повседневной одежды."
+	name = "white long cape"
+	desc = "Common in the territory of the Elysium Republic, this cape is a traditional casual wear out there."
 	icon_state = "long_apparel_white"
 	mob_overlay_state = "long_apparel_white"
 	allowed = list(/obj/item/melee/skimitar)
@@ -59,7 +59,7 @@
 
 /obj/item/clothing/suit/space/elysm/junk
 	name = "Junk EVA Suit"
-	desc = "Скафандр состоящий из нескольких скреплённых частей других скафандров. Является кустарным аналогом обычного и в стандарте делается лишь в случае крайней необходимости или недостатка материалов.. Надевая его вы можете чувствовать некоторые болезненные ощущения. Возможно не стоило надевать такой хлам"
+	desc = "This EVA suit is composed of some other, more unfortunate space suits, and it looks and works like a piece of junk. It stings and cuts your body if you wear it, and you get a feeling that using a firesuit with some coffee would be a lot better decision..."
 	icon_state = "space_junk"
 	mob_overlay_state = "space_junk"
 	armor = list("melee" = -10, "bullet" = -10, "laser" = 0, "energy" = 0, "bomb" = -20, "bio" = 50, "rad" = 60, "fire" = 0, "acid" = 0)
@@ -68,12 +68,12 @@
 
 /obj/item/clothing/suit/space/elysm/EVA_armored
 	name = "Elysium EVA Suit"
-	desc = "Укреплённый EVA скафандр с присоеденённым к нему бронежелетом. Имеет множество потёртостей и мест с которых слезла краска, что свидетельствует о том что этот скафандр повидал уже многое. На левой руке и ноге имеется традиционная зелёная повязка, символизирующая флаг Республики Элизиум."
+	desc = "A reinforced EVA space suits with an armor vest attached to it. It has lots of abrasion marks and places where the paint has peeled off, this space suit has definetly seen much. It has Republic of Elysium flag armbands on the left arm and leg."
 	icon_state = "space_elysium"
 	mob_overlay_state = "space_elysium"
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 30, "energy" = 30, "bomb" = 20, "bio" = 50, "rad" = 60, "fire" = 60, "acid" = 75)
 	slowdown = 0.5
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/melee/skimitar)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/melee/skimitar, /obj/item/gun)
 
 /obj/item/clothing/under/rank/avanpost
 	icon = 'mod_celadon/_storge_icons/icons/obj/elysium_commander.dmi'


### PR DESCRIPTION
### ПР, собственно, делает что-то умное, а именно:

1. Добавляет новый корабль сепаратистов с субшаттлом, скрины и названия в галерее ниже

2. Переводит весь элизиум дрип с русского на английский, долой такое если это не полная русификация билда.

3. Переводит названия должностей на Кондоре на английский. Стоит задуматься.

4. Чуточку меняет раундстарт лодауты сепарам, вкратце - теперь они спавнятся не в тапках, а в берцах, сбуха и капитан получили черные (а не отсутствующие или беспальцевые) перчатки, бронежилет у сбухи заменен на обычный армор вест ибо спрайт нашего никак не подходит к утилити униформе и вообще, почему у него всё ещё статы обычного?
Все ревертается, кстати.

### Пикчи смешные:

Атлас-класс:

![image](https://github.com/user-attachments/assets/0d8590c9-5037-45ca-b85b-b221167e4b5a)

Фелон-класс:

![image](https://github.com/user-attachments/assets/46d02b97-4f94-45ef-96b4-e25e6c04d9e3)

На нем лежит сразу три пустых ящика для продукции Атласа(на крейт шелфе)

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал.
