### PR TITLE
Две новые руинки

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_cultbaroncrash.dmm
+++ b/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_cultbaroncrash.dmm
@@ -1,0 +1,1476 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/turf/closed/wall/mineral/wood,
+/area/overmap_encounter/planetoid/cave/explored)
+"aE" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"aL" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"bw" = (
+/obj/item/paper/crumpled/ruins/snowdin/dontdeadopeninside{
+	default_raw_text = "If you're reading this: GET OUT! The Cold made Baron mad, he performed some kind of pact but it backfired, If you find my body, please bury it\tkeeping the rest of us on lockdown and I swear to god I keep hearing strange noises outside the walls at night. The gateway link has gone dead and without a supply of resources from Central, we're left\tfor dead here. We haven't heard anything back from the mining squad either, so I can only assume whatever the fuck they unearthed got them first before coming for us. I don't want to die here..."
+	},
+/obj/effect/decal/cleanable/blood/squirt,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"cg" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"cm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"co" = (
+/turf/closed/wall/mineral/iron,
+/area/overmap_encounter/planetoid/cave/explored)
+"dI" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"dQ" = (
+/mob/living/simple_animal/hostile/cult_demon{
+	name = "Daemonic servant"
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"fX" = (
+/obj/machinery/door/airlock/wood/glass,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"gV" = (
+/obj/structure/fluff/iced_abductor,
+/obj/item/clothing/mask/frog,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"hl" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"hQ" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"ia" = (
+/obj/machinery/atmospherics/pipe/simple/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"iM" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden/snowed,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"iR" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"ji" = (
+/turf/closed/wall/ice,
+/area/overmap_encounter/planetoid/cave/explored)
+"kx" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"kO" = (
+/obj/structure/sign/poster/official/fruit_bowl,
+/turf/closed/wall/mineral/wood,
+/area/overmap_encounter/planetoid/cave/explored)
+"ln" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"ly" = (
+/obj/item/trash/can/food,
+/obj/item/trash/boritos,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"nr" = (
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"nP" = (
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"nV" = (
+/obj/effect/decal/cleanable/blood/squirt,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"ov" = (
+/obj/structure/table/wood/fancy/red_gold,
+/obj/item/melee/energy/axe{
+	active_force = 30;
+	active_heat = 40;
+	armour_penetration = 20
+	},
+/obj/item/clothing/suit/armor/riot/knight/greyscale,
+/obj/item/clothing/head/helmet/knight/greyscale,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"pa" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/wood/glass,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"rA" = (
+/obj/machinery/conveyor_switch,
+/obj/item/shard,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"rX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"uI" = (
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"vp" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"wa" = (
+/obj/item/clothing/suit/armor/bone,
+/turf/open/floor/wood/cold,
+/area/overmap_encounter/planetoid/cave/explored)
+"wk" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"wH" = (
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"xc" = (
+/obj/machinery/atmospherics/pipe/simple/brown{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"xy" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"xL" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/space)
+"yY" = (
+/turf/closed/mineral/random/snow,
+/area/overmap_encounter/planetoid/cave/explored)
+"zg" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"zk" = (
+/obj/item/trash/sosjerky,
+/obj/item/trash/sosjerky,
+/obj/item/trash/raisins,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ai" = (
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"An" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ao" = (
+/obj/effect/decal/cleanable/blood/squirt,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Az" = (
+/obj/item/clothing/head/bearpelt,
+/turf/open/floor/wood/cold,
+/area/overmap_encounter/planetoid/cave/explored)
+"AK" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/cult_demon{
+	name = "Kutscher"
+	},
+/obj/item/gun/ballistic/bow/ashen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Bk" = (
+/mob/living/simple_animal/hostile/cult_demon{
+	name = "Daemonic servant"
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Bl" = (
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/space)
+"CT" = (
+/obj/machinery/conveyor_switch,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Dg" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
+/obj/item/trash/tray,
+/obj/item/trash/can/food,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Dx" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
+/obj/item/trash/raisins,
+/obj/item/trash/boritos,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"DR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ek" = (
+/turf/closed/wall/rust,
+/area/overmap_encounter/planetoid/cave/explored)
+"Fc" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"FK" = (
+/obj/structure/bonfire/prelit,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"FO" = (
+/turf/template_noop,
+/area/template_noop)
+"Gn" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Gw" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/effect/turf_decal/weather/snow,
+/obj/effect/turf_decal/weather/snow/surround,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ht" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"HO" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/reagent_containers/food/snacks/salad/aesirsalad,
+/obj/item/kitchen/fork,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"In" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/brown,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"It" = (
+/obj/effect/decal/cleanable/blood/squirt,
+/obj/effect/decal/cleanable/blood/squirt,
+/obj/effect/decal/cleanable/blood/squirt,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Iw" = (
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"IZ" = (
+/obj/machinery/atmospherics/pipe/simple/brown{
+	dir = 9
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/ice_demon,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Js" = (
+/obj/item/shard,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Kb" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Kg" = (
+/obj/structure/railing/wood{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ks" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Kt" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"KT" = (
+/mob/living/simple_animal/hostile/asteroid/old_demon{
+	name = "Baron Von Shnitz"
+	},
+/obj/structure/chair/wood/wings,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"LA" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"LN" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mx" = (
+/mob/living/simple_animal/hostile/asteroid/ice_demon,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"ME" = (
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/space/basic,
+/area/overmap_encounter/planetoid/cave/explored)
+"Nx" = (
+/mob/living/simple_animal/hostile/asteroid/ice_demon,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"NM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"NS" = (
+/obj/item/shard,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"OR" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Py" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"PI" = (
+/obj/item/trash/sosjerky,
+/obj/item/trash/sosjerky,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"QJ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"RT" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ss" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/closed/mineral/snowmountain/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"St" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Th" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/gem/bloodstone,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ux" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ve" = (
+/obj/structure/sign/poster/solgov/terra,
+/turf/closed/wall/mineral/iron,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vv" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"VY" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xq" = (
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xt" = (
+/obj/structure/bed,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/wood/cold,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ym" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yp" = (
+/obj/machinery/atmospherics/pipe/simple/brown{
+	dir = 10
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut,
+/area/overmap_encounter/planetoid/cave/explored)
+"YP" = (
+/obj/item/trash/can/food,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"YV" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/snow/under,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zd" = (
+/obj/structure/table/wood,
+/obj/item/trash/candle,
+/obj/item/trash/can/food/beans,
+/obj/item/gun/ballistic/rifle/illestren,
+/obj/item/melee/knife/bone,
+/turf/open/floor/wood/cold,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zm" = (
+/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
+/obj/item/trash/raisins,
+/obj/item/trash/can/food,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zv" = (
+/obj/structure/closet/crate/grave,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/overmap_encounter/planetoid/cave/explored)
+
+(1,1,1) = {"
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+ln
+ln
+ln
+ln
+ln
+ln
+ln
+Ai
+ln
+Ai
+Ai
+LN
+ln
+FO
+FO
+"}
+(2,1,1) = {"
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+ln
+ln
+ln
+ln
+ln
+LN
+ln
+Ai
+ln
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+FO
+FO
+"}
+(3,1,1) = {"
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+ln
+ln
+ln
+Iw
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+LN
+Ai
+yY
+yY
+ln
+FO
+"}
+(4,1,1) = {"
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+ln
+ln
+ln
+Iw
+Ai
+Ai
+Ai
+Ai
+Mx
+Ai
+Ai
+Ai
+LN
+yY
+yY
+yY
+yY
+FO
+"}
+(5,1,1) = {"
+FO
+FO
+ln
+FO
+FO
+yY
+yY
+FO
+yY
+ln
+ln
+ln
+ln
+ln
+yY
+LN
+Ai
+LN
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+yY
+yY
+yY
+yY
+yY
+ln
+"}
+(6,1,1) = {"
+FO
+FO
+ln
+yY
+yY
+yY
+gV
+yY
+yY
+yY
+ln
+ln
+yY
+yY
+ji
+LN
+LN
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+LN
+yY
+yY
+yY
+yY
+yY
+ln
+"}
+(7,1,1) = {"
+FO
+ln
+yY
+yY
+yY
+yY
+yY
+yY
+yY
+yY
+ln
+ln
+ln
+yY
+LN
+LN
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+yY
+yY
+yY
+yY
+yY
+yY
+"}
+(8,1,1) = {"
+FO
+ln
+yY
+yY
+yY
+yY
+yY
+yY
+yY
+yY
+ln
+ln
+yY
+LN
+Ai
+Ht
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+ln
+yY
+yY
+yY
+yY
+yY
+"}
+(9,1,1) = {"
+FO
+ln
+ln
+ln
+Ym
+ln
+LN
+Ai
+yY
+yY
+ln
+ln
+Ai
+ln
+ln
+Ai
+ln
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+dI
+ln
+ln
+ln
+yY
+yY
+"}
+(10,1,1) = {"
+ln
+ln
+ln
+Iw
+ln
+ln
+ln
+Ai
+Ai
+Ai
+Ai
+Ai
+YV
+Ai
+Ai
+Ai
+ln
+Ai
+Ai
+Ai
+ln
+ln
+ln
+ln
+ln
+ln
+ln
+ln
+ln
+ln
+"}
+(11,1,1) = {"
+ln
+ln
+yY
+ln
+ln
+ln
+ln
+Vv
+ln
+ln
+ln
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+Ai
+ln
+ln
+ln
+ln
+ln
+FO
+FO
+FO
+"}
+(12,1,1) = {"
+ln
+yY
+yY
+ln
+ln
+ln
+Iw
+LN
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+LN
+ln
+ln
+ln
+ln
+ln
+FO
+FO
+"}
+(13,1,1) = {"
+ln
+yY
+Ai
+ln
+ln
+Ai
+LN
+co
+ln
+ln
+co
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+Ai
+ln
+ln
+ln
+dI
+yY
+ln
+ln
+FO
+FO
+"}
+(14,1,1) = {"
+ln
+yY
+Ai
+ln
+Vv
+co
+Bk
+co
+ln
+ln
+co
+Ai
+co
+Ai
+Ai
+ln
+Ai
+Ai
+Ai
+ln
+ln
+ln
+Ai
+Iw
+yY
+yY
+FK
+ln
+ln
+ln
+"}
+(15,1,1) = {"
+yY
+yY
+St
+St
+cm
+co
+Ek
+co
+co
+Ek
+Ek
+Ek
+co
+Ai
+Ai
+Ai
+Ai
+Ai
+ln
+ln
+ln
+ln
+Ai
+Iw
+yY
+yY
+Iw
+wH
+YP
+ly
+"}
+(16,1,1) = {"
+yY
+yY
+Ai
+St
+cm
+co
+aL
+Ek
+OR
+OR
+co
+aL
+co
+Ai
+ln
+dQ
+Ai
+Ai
+ln
+ln
+LN
+ln
+Ai
+Ai
+yY
+yY
+Iw
+zk
+Dx
+Dg
+"}
+(17,1,1) = {"
+LN
+yY
+St
+cm
+rX
+Ek
+Yp
+xc
+Xq
+Xq
+ia
+IZ
+co
+ln
+Ai
+Ai
+Ao
+Ai
+ln
+Iw
+Ai
+ln
+Iw
+Ai
+yY
+YP
+Iw
+aj
+aj
+Zm
+"}
+(18,1,1) = {"
+LN
+Ai
+Ai
+cm
+cm
+Ve
+cg
+Ks
+aj
+aj
+wk
+nr
+co
+St
+Kb
+bw
+ln
+hQ
+Ao
+Iw
+Py
+It
+nV
+ln
+Fc
+ln
+aj
+Az
+Xt
+aj
+"}
+(19,1,1) = {"
+Ai
+ln
+ln
+St
+NM
+co
+Nx
+aj
+ov
+DR
+aj
+nr
+co
+Ai
+vp
+ln
+ln
+Ai
+Iw
+yY
+Ai
+An
+xy
+Ai
+hQ
+Iw
+iM
+wa
+Zd
+aj
+"}
+(20,1,1) = {"
+Ai
+Ai
+Ai
+NM
+Ai
+pa
+nr
+kO
+Th
+KT
+ME
+cg
+pa
+kx
+RT
+ln
+ln
+Ai
+yY
+yY
+LN
+Iw
+ln
+ln
+VY
+ln
+aj
+aj
+aj
+PI
+"}
+(21,1,1) = {"
+ln
+ln
+ln
+Vv
+ln
+pa
+nr
+aj
+In
+HO
+aj
+nr
+pa
+Ai
+ln
+ln
+Ai
+Iw
+yY
+yY
+Iw
+Iw
+ln
+ln
+Kg
+Iw
+LA
+LA
+Iw
+FO
+"}
+(22,1,1) = {"
+Ai
+Ai
+Ai
+Ai
+ln
+co
+fX
+aj
+aj
+aj
+aj
+fX
+co
+ln
+Ai
+ln
+Ai
+Iw
+yY
+yY
+Iw
+LN
+ln
+ln
+Iw
+ln
+ln
+Iw
+ln
+FO
+"}
+(23,1,1) = {"
+Ai
+Ht
+ln
+Ai
+ln
+co
+Gn
+NS
+AK
+zg
+iR
+nr
+co
+ln
+Ai
+Ai
+Ai
+Ai
+yY
+yY
+Iw
+Ai
+ln
+ln
+Iw
+Ai
+ln
+ln
+ln
+ln
+"}
+(24,1,1) = {"
+LN
+Ai
+Ai
+Ai
+ln
+co
+uI
+Ux
+CT
+rA
+Ux
+Ux
+Ek
+ln
+YV
+ln
+ln
+LN
+yY
+Iw
+Iw
+LN
+Iw
+Ss
+ln
+Ss
+LN
+yY
+FO
+FO
+"}
+(25,1,1) = {"
+dI
+yY
+Ai
+Ai
+dQ
+co
+Kt
+Ux
+Ux
+hl
+Ux
+Iw
+Ek
+Ai
+Iw
+Bk
+ln
+Ym
+ln
+Iw
+Iw
+ln
+Iw
+yY
+yY
+ln
+yY
+yY
+yY
+FO
+"}
+(26,1,1) = {"
+yY
+yY
+yY
+Ai
+aE
+Gw
+QJ
+Ai
+ln
+nP
+Js
+Ai
+co
+Ai
+Iw
+ln
+ln
+ln
+Iw
+Iw
+Iw
+Iw
+ln
+yY
+yY
+Zv
+yY
+yY
+yY
+yY
+"}
+(27,1,1) = {"
+Ai
+Iw
+Ai
+Ai
+ln
+Ai
+Iw
+ln
+Js
+Ai
+Js
+ln
+Ai
+Ai
+ln
+ln
+ln
+ln
+Iw
+Iw
+Iw
+ln
+ln
+Iw
+yY
+yY
+yY
+yY
+yY
+yY
+"}
+(28,1,1) = {"
+LN
+Ai
+ln
+Ht
+Ai
+Ai
+ln
+Ai
+Ai
+Ai
+Ai
+ln
+Ai
+ln
+yY
+ln
+ln
+ln
+ln
+yY
+ln
+ln
+ln
+ln
+ln
+yY
+yY
+yY
+ln
+FO
+"}
+(29,1,1) = {"
+FO
+FO
+FO
+xL
+Bl
+Iw
+Ai
+Ai
+Ht
+Ai
+Iw
+Ai
+yY
+yY
+yY
+yY
+ln
+ln
+yY
+ln
+ln
+ln
+Iw
+ln
+Iw
+Iw
+ln
+ln
+ln
+FO
+"}
+(30,1,1) = {"
+FO
+FO
+FO
+FO
+FO
+Ai
+LN
+Ai
+Ai
+Iw
+Iw
+LN
+yY
+yY
+yY
+yY
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+"}

--- a/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_cultbaroncrash.dmm
+++ b/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_cultbaroncrash.dmm
@@ -384,7 +384,7 @@
 "ME" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/space/basic,
+/turf/open/floor/wood/walnut,
 /area/overmap_encounter/planetoid/cave/explored)
 "Nx" = (
 /mob/living/simple_animal/hostile/asteroid/ice_demon,

--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_observatory.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_observatory.dmm
@@ -1,0 +1,1893 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aT" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"bm" = (
+/turf/closed/indestructible/rock,
+/area/science/misc_lab)
+"bQ" = (
+/obj/machinery/power/solar_control{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"ce" = (
+/obj/structure/chair/comfy/purple/directional/north,
+/obj/item/radio/intercom/wideband/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"dm" = (
+/obj/item/screwdriver,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"dO" = (
+/turf/open/floor/plasteel/stairs,
+/area/science/misc_lab)
+"fc" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"fd" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"fm" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/spacevine,
+/obj/item/clothing/mask/frog,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"fX" = (
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 8
+	},
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/science/misc_lab)
+"ge" = (
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/multitool/ai_detect,
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"gH" = (
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"hr" = (
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"hA" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"hK" = (
+/obj/structure/sign/poster/contraband/space_cola,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"iy" = (
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"iC" = (
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 8
+	},
+/obj/structure/salvageable/safe_server,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/science/misc_lab)
+"iG" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"iO" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/burger/appendix,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"iU" = (
+/obj/effect/mob_spawn/human/oldstation/oldsci,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"jb" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"jv" = (
+/obj/machinery/light/directional/north,
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"jH" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"kb" = (
+/obj/structure/railing,
+/turf/open/water/jungle,
+/area/ruin/jungle)
+"kr" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"kC" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"lV" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"mb" = (
+/turf/open/floor/wood/mahogany,
+/area/science/misc_lab)
+"mo" = (
+/obj/structure/showcase/machinery/tv,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"mO" = (
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 8
+	},
+/obj/machinery/telecomms/server/presets/nanotrasen,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/science/misc_lab)
+"mW" = (
+/turf/open/water/jungle,
+/area/science/misc_lab)
+"no" = (
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"nw" = (
+/obj/structure/filingcabinet/double,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"nL" = (
+/obj/structure/window,
+/obj/machinery/computer/camera_advanced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"nU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"oc" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"oe" = (
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 8
+	},
+/obj/machinery/telecomms/message_server,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/science/misc_lab)
+"oj" = (
+/obj/machinery/light/directional/south,
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"oT" = (
+/obj/machinery/power/tracker,
+/turf/open/floor/mineral/plastitanium,
+/area/science/misc_lab)
+"oU" = (
+/obj/structure/sign/poster/official/miners,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"pa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"pl" = (
+/mob/living/simple_animal/hostile/retaliate/poison/snake,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"pK" = (
+/obj/structure/table/wood,
+/obj/item/disk/design_disk,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"qp" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/obj/structure/spacevine,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"qK" = (
+/mob/living/simple_animal/hostile/retaliate/poison/snake,
+/turf/open/water/jungle,
+/area/ruin/jungle)
+"rb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"ri" = (
+/obj/item/circuitboard/computer/rdconsole,
+/obj/machinery/holopad/emergency,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"rr" = (
+/obj/structure/filingcabinet/double,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"rP" = (
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/circuitboard/machine/circuit_imprinter/department/basic,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"se" = (
+/obj/effect/spawner/structure/window/hollow,
+/turf/open/floor/mineral/titanium/white,
+/area/science/misc_lab)
+"sH" = (
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"sM" = (
+/obj/structure/chair/comfy/orange/old/directional/north,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"sT" = (
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"tS" = (
+/obj/structure/chair/comfy/grey,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"tY" = (
+/obj/structure/filingcabinet/double,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"ug" = (
+/turf/open/floor/plasteel/stairs/wood{
+	dir = 8
+	},
+/area/science/misc_lab)
+"uh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/comfy/blue/corpo{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"uv" = (
+/obj/machinery/door/airlock/silver{
+	name = "Telescope Accesss"
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"uR" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 19;
+	dir = 8;
+	pixel_y = 11
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/item/storage/box/donkpockets/donkpocketgondola,
+/obj/item/storage/box/donkpockets/donkpockethonk,
+/obj/item/storage/box/donkpockets/donkpocketpizza,
+/obj/item/storage/box/donkpockets/donkpocketspicy,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"vJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/bong/lungbuster,
+/obj/item/reagent_containers/food/snacks/grown/cannabis,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"wl" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"wx" = (
+/obj/machinery/camera/autoname{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"wG" = (
+/obj/structure/sign/poster/contraband/backdoor_xeno_babes_6,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"xc" = (
+/obj/structure/railing/wood,
+/turf/open/water/jungle,
+/area/ruin/jungle)
+"xA" = (
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"xJ" = (
+/obj/structure/railing/wood,
+/turf/open/floor/plasteel/stairs/wood{
+	dir = 8
+	},
+/area/science/misc_lab)
+"xK" = (
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"xY" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/flora/bigplant,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"yS" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"yZ" = (
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"zh" = (
+/obj/item/rack_parts/shelf,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"zq" = (
+/obj/machinery/light/directional/west,
+/obj/item/stack/sheet/glass/twenty,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"zM" = (
+/obj/structure/closet/crate/solarpanel_small,
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"AA" = (
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/mineral/titanium/white,
+/area/science/misc_lab)
+"AQ" = (
+/obj/effect/mob_spawn/human/oldstation/oldsci,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"AT" = (
+/obj/structure/railing,
+/obj/machinery/camera/autoname,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"Bd" = (
+/obj/structure/spacevine,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"BN" = (
+/obj/machinery/autolathe,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"BP" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"BZ" = (
+/obj/item/stock_parts/cell/super,
+/obj/item/storage/backpack/duffelbag/mining_conscript,
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"CB" = (
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"CS" = (
+/obj/structure/closet/wardrobe/science_white,
+/obj/item/gun/energy/disabler,
+/obj/item/clothing/head/helmet/m10_elysium,
+/obj/item/clothing/under/solfed/elysium,
+/obj/item/clothing/suit/armor/vest,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"Da" = (
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/machinery/rnd/production/protolathe/department/science,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"Dk" = (
+/obj/item/rack_parts/shelf,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"Ez" = (
+/obj/item/stock_parts/subspace/filter,
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"EU" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/science/misc_lab)
+"FD" = (
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"Gc" = (
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 8
+	},
+/obj/machinery/telecomms/server/presets/solgov,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/science/misc_lab)
+"GG" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"GX" = (
+/obj/structure/reflector/single{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/science/misc_lab)
+"HB" = (
+/obj/structure/sign/poster/contraband/masked_men,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"HX" = (
+/turf/closed/indestructible/rock,
+/area/ruin/jungle)
+"Js" = (
+/obj/structure/sign/poster/solfed/elysium,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"JJ" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"Kc" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/venus_human_trap,
+/obj/structure/spacevine,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"Kr" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"Lg" = (
+/obj/item/rack_parts/shelf,
+/obj/machinery/door/window{
+	icon_state = "left";
+	dir = 1
+	},
+/obj/item/stack/cable_coil/red,
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"Mo" = (
+/turf/open/floor/circuit,
+/area/science/misc_lab)
+"MT" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/science/misc_lab)
+"Na" = (
+/turf/open/water/jungle,
+/area/ruin/jungle)
+"NM" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"NZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd,
+/obj/structure/curtain/cloth/elysium,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"Pf" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/recharger{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"Pi" = (
+/obj/structure/reflector/single{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/science/misc_lab)
+"Pw" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"PR" = (
+/obj/structure/closet/crate/medical,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/science/misc_lab)
+"Qm" = (
+/obj/machinery/suit_storage_unit/rd,
+/obj/structure/sign/flag/elysium/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"Rf" = (
+/obj/effect/mob_spawn/human/corpse/syndicatesoldier,
+/obj/item/pickaxe/mini,
+/obj/item/grenade/syndieminibomb,
+/obj/item/camera,
+/obj/item/camera_bug,
+/obj/item/spy_bug,
+/obj/structure/spacevine,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"Ri" = (
+/obj/structure/railing/wood,
+/turf/open/floor/wood/mahogany,
+/area/science/misc_lab)
+"RX" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/spacevine/dense,
+/obj/item/storage/guncase/pistol/pc76,
+/turf/open/floor/plating/dirt/jungle,
+/area/ruin/jungle)
+"Sa" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"Si" = (
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/mineral/plastitanium,
+/area/science/misc_lab)
+"SK" = (
+/obj/machinery/door/airlock/survival_pod/glass{
+	name = "Observatory NT-RF-23445";
+	req_ship_access = 0
+	},
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"Tn" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"To" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/water/jungle,
+/area/ruin/jungle)
+"TC" = (
+/turf/open/floor/mineral/plastitanium,
+/area/science/misc_lab)
+"TQ" = (
+/obj/item/kirbyplants/photosynthetic{
+	pixel_y = 25
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/gun/energy/e_gun/plasmapistol_fire{
+	pixel_y = 2;
+	pixel_x = 4
+	},
+/obj/item/stamp/elysium/republic,
+/obj/item/clothing/head/helmet/solfedm11/elysium_wraps,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"TS" = (
+/obj/item/stock_parts/capacitor/super,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"TU" = (
+/obj/machinery/door/airlock/research{
+	req_ship_access = 0
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"Ui" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/research{
+	req_ship_access = 0
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/science/misc_lab)
+"VY" = (
+/obj/item/card/id/elysium,
+/turf/closed/indestructible/rock,
+/area/ruin/jungle)
+"Wn" = (
+/obj/effect/spawner/structure/window/hollow,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"WY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/science/misc_lab)
+"Xm" = (
+/obj/machinery/power/solar,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+"Yf" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/mineral/titanium/purple,
+/area/science/misc_lab)
+"Yt" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/turf/open/floor/mineral/titanium/white,
+/area/science/misc_lab)
+"ZT" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/table/wood/reinforced,
+/obj/item/cultivator/rake,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/seeds/ambrosia/deus,
+/obj/item/seeds/potato,
+/obj/item/seeds/onion,
+/turf/open/floor/concrete/slab_4,
+/area/science/misc_lab)
+
+(1,1,1) = {"
+iy
+iy
+iy
+iy
+HX
+iy
+HX
+iy
+HX
+iy
+iy
+iy
+iy
+pl
+HX
+iy
+HX
+iy
+HX
+HX
+iy
+iy
+iy
+HX
+HX
+HX
+iy
+iy
+HX
+HX
+HX
+HX
+HX
+"}
+(2,1,1) = {"
+iy
+iy
+iy
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+iy
+iy
+iy
+HX
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+iy
+iy
+iy
+HX
+iy
+iy
+HX
+"}
+(3,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+iy
+iy
+"}
+(4,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+"}
+(5,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+"}
+(6,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+"}
+(7,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+Na
+Na
+xc
+ug
+xJ
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+HX
+HX
+HX
+HX
+HX
+iy
+iy
+"}
+(8,1,1) = {"
+iy
+HX
+HX
+HX
+iy
+HX
+HX
+Na
+Na
+Na
+xc
+mb
+Ri
+Na
+Na
+Xm
+Xm
+Na
+Na
+qK
+Na
+Na
+Na
+Na
+Na
+Na
+Na
+HX
+HX
+HX
+HX
+HX
+iy
+"}
+(9,1,1) = {"
+iy
+HX
+HX
+HX
+iy
+HX
+Na
+Na
+Na
+Na
+xc
+mb
+Ri
+jb
+jb
+Xm
+Xm
+Na
+Na
+Na
+se
+se
+se
+se
+se
+Na
+Na
+Na
+HX
+HX
+HX
+iy
+iy
+"}
+(10,1,1) = {"
+iy
+HX
+HX
+HX
+iy
+HX
+Na
+Na
+Na
+Na
+xc
+mb
+Ri
+CB
+bm
+CB
+Na
+Na
+Na
+se
+Mo
+TC
+TC
+TC
+Mo
+se
+Na
+Na
+Na
+HX
+HX
+HX
+HX
+"}
+(11,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+kb
+jb
+jb
+jb
+jb
+aT
+mb
+mb
+wl
+CB
+ZT
+Na
+Na
+se
+Mo
+Yt
+TC
+TC
+TC
+Yt
+Mo
+se
+Na
+Na
+HX
+HX
+HX
+HX
+"}
+(12,1,1) = {"
+iy
+iy
+HX
+HX
+HX
+kb
+CB
+Pw
+Pw
+Pw
+Pw
+SK
+SK
+Pw
+lV
+To
+Na
+Na
+se
+TC
+TC
+Pi
+TC
+GX
+TC
+TC
+se
+Na
+Na
+HX
+HX
+HX
+iy
+"}
+(13,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+kb
+CB
+Pw
+AQ
+iU
+Pw
+jv
+oj
+Pw
+lV
+To
+Na
+Na
+se
+TC
+TC
+TC
+oT
+TC
+TC
+TC
+se
+Na
+qK
+Na
+HX
+HX
+HX
+"}
+(14,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+kb
+CB
+Pw
+AQ
+gH
+TU
+hr
+hr
+Pw
+lV
+To
+To
+To
+se
+TC
+TC
+GX
+TC
+Pi
+TC
+TC
+se
+Na
+Na
+Na
+HX
+HX
+HX
+"}
+(15,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+kb
+CB
+Pw
+Pw
+Pw
+Pw
+BP
+hr
+Pw
+CB
+jb
+jb
+jb
+se
+Mo
+Yt
+TC
+TC
+TC
+Yt
+Mo
+se
+Na
+Na
+Na
+HX
+HX
+iy
+"}
+(16,1,1) = {"
+HX
+iy
+HX
+HX
+HX
+kb
+CB
+wG
+hA
+gH
+TU
+hr
+Tn
+Pw
+Js
+Pw
+Pw
+CB
+lV
+se
+Mo
+TC
+TC
+TC
+Mo
+se
+CB
+lV
+Na
+HX
+HX
+HX
+iy
+"}
+(17,1,1) = {"
+HX
+iy
+HX
+HX
+HX
+kb
+CB
+Pw
+kr
+oc
+HB
+hr
+hr
+PR
+CS
+CS
+Pw
+Pw
+lV
+mW
+se
+se
+AA
+se
+se
+Pw
+Pw
+AT
+Na
+Na
+HX
+HX
+HX
+"}
+(18,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+kb
+CB
+Pw
+Pw
+Pw
+Pw
+fc
+hr
+Lg
+ge
+zh
+Da
+Pw
+lV
+mW
+mW
+Wn
+dO
+dO
+dO
+xK
+Pw
+lV
+HX
+Na
+HX
+HX
+HX
+"}
+(19,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+kb
+CB
+Pw
+hA
+gH
+TU
+hr
+hr
+rr
+ri
+BZ
+rP
+Pw
+CB
+jb
+jb
+Wn
+Wn
+Pw
+Pw
+xK
+Pw
+lV
+Na
+HX
+HX
+HX
+iy
+"}
+(20,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+kb
+wx
+Pw
+kr
+oc
+Js
+hr
+hr
+nw
+Ez
+sH
+Dk
+oU
+Pw
+Js
+hK
+Pw
+Pw
+Pw
+Pw
+uv
+Pw
+lV
+Na
+HX
+HX
+HX
+HX
+"}
+(21,1,1) = {"
+iy
+iy
+HX
+HX
+HX
+kb
+CB
+Pw
+Pw
+Pw
+Pw
+iG
+hr
+hr
+hr
+hr
+hr
+sT
+yS
+xK
+xK
+zq
+xK
+xK
+xK
+xK
+Pw
+lV
+Na
+Na
+HX
+HX
+HX
+"}
+(22,1,1) = {"
+HX
+iy
+HX
+HX
+HX
+kb
+CB
+Si
+NZ
+kC
+Ui
+nU
+nU
+uh
+nU
+nU
+xY
+Pf
+pK
+JJ
+tY
+xK
+bQ
+bQ
+xK
+BN
+Pw
+lV
+Na
+HX
+HX
+HX
+iy
+"}
+(23,1,1) = {"
+HX
+iy
+HX
+HX
+HX
+kb
+CB
+Pw
+Qm
+pa
+Pw
+hr
+yZ
+vJ
+sM
+hr
+WY
+FD
+fd
+xK
+xK
+xK
+Sa
+Sa
+xK
+zM
+Pw
+lV
+Na
+Na
+HX
+HX
+HX
+"}
+(24,1,1) = {"
+iy
+iy
+HX
+HX
+HX
+kb
+CB
+Pw
+Pw
+TQ
+Pw
+mo
+tS
+iO
+ce
+jH
+uR
+Yf
+xA
+nL
+fX
+iC
+oe
+Gc
+mO
+Pw
+Pw
+lV
+Na
+HX
+HX
+iy
+HX
+"}
+(25,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+kb
+CB
+CB
+Pw
+rb
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+Pw
+CB
+bm
+HX
+HX
+HX
+HX
+HX
+"}
+(26,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+CB
+GG
+NM
+CB
+bm
+CB
+CB
+CB
+bm
+CB
+CB
+CB
+CB
+CB
+CB
+CB
+CB
+CB
+bm
+Na
+HX
+HX
+HX
+HX
+HX
+iy
+"}
+(27,1,1) = {"
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+CB
+Kr
+MT
+no
+HX
+HX
+HX
+HX
+HX
+Na
+Na
+Na
+HX
+qK
+Na
+Na
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+"}
+(28,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+CB
+dm
+EU
+TS
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+"}
+(29,1,1) = {"
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+Bd
+fm
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+"}
+(30,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+qp
+Kc
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+"}
+(31,1,1) = {"
+HX
+HX
+HX
+iy
+iy
+VY
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+HX
+RX
+Rf
+HX
+HX
+HX
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+HX
+"}
+(32,1,1) = {"
+iy
+HX
+HX
+HX
+HX
+iy
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+HX
+HX
+HX
+HX
+HX
+iy
+HX
+iy
+HX
+HX
+HX
+iy
+HX
+HX
+iy
+HX
+iy
+HX
+"}
+(33,1,1) = {"
+HX
+iy
+HX
+HX
+iy
+HX
+HX
+HX
+iy
+iy
+iy
+iy
+HX
+HX
+iy
+iy
+HX
+iy
+iy
+iy
+HX
+HX
+HX
+HX
+iy
+HX
+iy
+iy
+iy
+HX
+HX
+iy
+HX
+"}

--- a/_maps/_mod_celadon/map_catalogue.txt
+++ b/_maps/_mod_celadon/map_catalogue.txt
@@ -2,6 +2,10 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 
 
 	IceRuins:
+			File Name = _maps\RandomRuins\IceRuins\icemoon_cultbaroncrash.dmm
+		Size = (x = 30)(y = 30)(z = 1)
+		Tags = "High Loot", "High Combat Challenge", "Antag_Gear", "Shelter"
+
 		File Name = _maps\RandomRuins\IceRuins\icemoon_hydroponics_lab.dmm
 		Size = (x = 33)(y = 33)(z = 1)
 		Tags = "Medium Loot", "Medium Combat Challenge", "Antag_Gear", "Shelter"
@@ -47,6 +51,10 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 		Tags = "Boss Combat Challenge", "Major Loot", "Shelter"
 
 	JungleRuins:
+		File Name = "_maps\RandomRuins\JungleRuins\jungle_observatory.dmm"
+		Size = (x = 33)(y = 33)(z = 1)
+		Tags = "No Combat", "Medium Loot", "Liveable", "Antag Gear"
+
 		File Name = "_maps\RandomRuins\JungleRuins\jungle_syndicate.dmm"
 		Size = (x = 15)(y = 15)(z = 1)
 		Tags = "Medium Combat Challenge", "Medium Loot", "Liveable", "Antag Gear"

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -71,6 +71,12 @@
 //							///
 //		Icemoon ruin		///
 //							///
+/datum/map_template/ruin/icemoon/cultbaroncrash
+	name = "Cult Baron Crashsite"
+	id = "cultbaroncrash"
+	description = "Crashed shuttle of occult nobility"
+	suffix = "icemoon_cultbaroncrash.dmm"
+
 /datum/map_template/ruin/icemoon/hydroponicslab
 	name = "Hydroponics Lab"
 	id = "hydroponicslab"
@@ -141,6 +147,12 @@
 //							///
 //		Jungle ruin			///
 //							///
+/datum/map_template/ruin/jungle/oldntobservatory
+	name = "Elysium Reclaimed Observatory"
+	id = "oldntobservatory"
+	description = "Old NT Observatory, not owned by Elysium Pseudoscientists."
+	suffix = "jungle_observatory.dmm"
+
 /datum/map_template/ruin/jungle/syndicate
 	name = "Jungle Syndicate Bunker"
 	id = "syndicatebunkerjungle"


### PR DESCRIPTION
Две новые руинки средних размеров:
Старая обсерватория НТ перешедшая под владение СолФеда, они же, как жест доброй воли и сотрудничества, передали ее под командование лоялистов Элизиума, которые работают на благо всеми известной бригады элизиума. Имеет спавнеры для 3 членов обсерватории, оборудование и немного научного потенциала.

Место крушения оккультного барона, небольшая средне-боевая руинка. 
Основной лут - топляк, остатки корабля, немного оружия и брони.


- [ ] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить. (Как бы да, но нет, думаю будут либо вопросики либо замечания)
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.
