### PR TITLE
Добавляем в конфиг кораблей новую переменную для задания максимальной силы сенсоров

### DIFF
--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -28,7 +28,7 @@
 		"sensor_range":{
 			"title": "Sensor Range",
 			"type": "number",
-			"description": "A definition of a ships' maximum sensor range.",
+			"description": "A definition of a ships' maximum sensor range."
 		},
 
 

--- a/_maps/ship_config_schema.json
+++ b/_maps/ship_config_schema.json
@@ -23,6 +23,15 @@
 			"description": "A description of the ship class, currently only shown to admins on the shuttle manipulator, but will likely be shown to players before ship purchase in the future.",
 			"minLength": 250
 		},
+
+
+		"sensor_range":{
+			"title": "Sensor Range",
+			"type": "number",
+			"description": "A definition of a ships' maximum sensor range.",
+		},
+
+
 		"tags": {
 			"title": "Ship Tags",
 			"type": "array",

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -210,6 +210,11 @@ SUBSYSTEM_DEF(mapping)
 		else
 			S.short_name = copytext(S.name, 1, 20)
 
+		// [CELADON-ADD] - OVERMAP SENSORS
+		if(isnum(data["sensor_range"]))
+			S.def_sensor_range = data["sensor_range"]
+		// [/CELADON-ADD]
+
 		if(istext(data["prefix"]))
 			S.prefix = data["prefix"]
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -15,6 +15,11 @@
 	var/limit = 2
 	var/enabled
 	var/short_name
+
+	// [CELADON-ADD] - OVERMAP SENSORS
+	var/def_sensor_range = 4
+	// [/CELADON-ADD]
+
 	var/list/job_slots = list()
 	var/list/name_categories = list("GENERAL")
 	/// The prefix of the ship's name.

--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -302,7 +302,9 @@
 	switch(action) // Universal topics
 		// [CELADON-ADD] - OVERMAP STUFF - Это вагабонд насрал
 		if("sensor_increase")
-			current_ship.sensor_range = min(5, current_ship.sensor_range+1)
+			// [CELADON-EDIT] - OVERMAP SENSORS
+			current_ship.sensor_range = min(current_ship.default_sensor_range, current_ship.sensor_range+1)
+			// [/CELADON-EDIT]
 			update_static_data(usr, ui)
 			current_ship.token.update_screen()
 			return

--- a/code/modules/overmap/helm.dm
+++ b/code/modules/overmap/helm.dm
@@ -302,9 +302,9 @@
 	switch(action) // Universal topics
 		// [CELADON-ADD] - OVERMAP STUFF - Это вагабонд насрал
 		if("sensor_increase")
-			// [CELADON-EDIT] - OVERMAP SENSORS
+			//овермап сенсорс максимальная дальность апдейт
 			current_ship.sensor_range = min(current_ship.default_sensor_range, current_ship.sensor_range+1)
-			// [/CELADON-EDIT]
+			//овермап сенсорс максимальная дальность апдейт конец
 			update_static_data(usr, ui)
 			current_ship.token.update_screen()
 			return

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -9,6 +9,10 @@
 	token_type = /obj/overmap/rendered
 	dock_time = 10 SECONDS
 
+	// [CELADON-ADD] - OVERMAP SENSORS
+	var/default_sensor_range = 4
+	// [/CELADON-ADD]
+
 	///Vessel estimated thrust per full burn
 	var/est_thrust
 	///Average fuel fullness percentage
@@ -112,6 +116,7 @@
 				Dock(position, TRUE)
 
 			refresh_engines()
+		default_sensor_range = source_template.def_sensor_range
 		ship_account = new(name, source_template.starting_funds)
 		faction_datum = source_template.faction_datum
 


### PR DESCRIPTION
### ПР делает что-то умное, а именно:

### Добавляет в конфиг кораблей новую переменную, которая по дефолту равна _**ЧЕТЫРЁМ**_ - "sensor_range" , которая обозначает максимальную дальность сенсоров соответствующего конфигу корабля.

### Не ставьте значение выше 8, все равно (по идее) код тгуи больше не даст.

### Скрин ПРИМЕРА установки переменной в конфиге.

![image](https://github.com/user-attachments/assets/d2c1070f-6ad9-4cda-a575-92bd9aea0d8c)

![image](https://github.com/user-attachments/assets/aa6529be-bed2-4471-8b2d-2e7be04b9a2f)


почему у хроникла фракция интеков...

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.

### ПР НЕ ДОБАВЛЯЕТ ЭТУ ПЕРЕМЕННУЮ НИ НА ОДИН КОРАБЛЬ, ЭТО ДОЛЖНЫ СДЕЛАТЬ МАППЕРЫ