### PR TITLE
botanical_dispenser for everyone!!!

### DIFF
--- a/mod_celadon/balance/_balance.dme
+++ b/mod_celadon/balance/_balance.dme
@@ -22,6 +22,7 @@
 #include "code/hostile_mobs.dm"
 #include "code/ionrifle.dm"
 #include "code/items.dm"
+#include "code/mutagensalpetredispenser.dm"
 #include "code/missions.dm"
 #include "code/structures.dm"
 #include "code/suit.dm"

--- a/mod_celadon/balance/code/mutagensalpetredispenser.dm
+++ b/mod_celadon/balance/code/mutagensalpetredispenser.dm
@@ -48,5 +48,6 @@
 	component_parts += new /obj/item/stock_parts/capacitor(null)
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stack/ore/bluespace_crystal/refined(null)
 	component_parts += new /obj/item/stock_parts/cell/upgraded(null)
 	RefreshParts()

--- a/mod_celadon/balance/code/mutagensalpetredispenser.dm
+++ b/mod_celadon/balance/code/mutagensalpetredispenser.dm
@@ -1,0 +1,52 @@
+/obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
+	name = "Botanical Dispenser (Machine Board)"
+	icon_state = "service"
+	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/capacitor = 2,
+		/obj/item/stock_parts/manipulator = 2,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stack/ore/bluespace_crystal/refined = 1,
+		/obj/item/stock_parts/cell = 1,
+	)
+
+/datum/design/board/chem_dispenser/botanical
+	name = "Machine Design (Botanical Portable Chem Dispenser Board)"
+	desc = "The circuit board for a portable botanical chem dispenser."
+	id = "botan_dispenser"
+	build_path = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Service Machinery")
+
+/datum/techweb_node/botany
+	design_ids = list("diskplantgene", "portaseeder", "flora_gun", "hydro_tray", "biogenerator", "plantgenes", "seed_extractor", "botan_dispenser")
+
+/obj/machinery/chem_dispenser/mutagensaltpeter
+	flags_1 = null
+
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
+
+	dispensable_reagents = list(
+		/datum/reagent/toxin/mutagen,
+		/datum/reagent/saltpetre,
+		/datum/reagent/ammonia,
+		/datum/reagent/ash,
+		/datum/reagent/diethylamine,
+		/datum/reagent/toxin/pestkiller,
+		/datum/reagent/toxin/plantbgone/weedkiller,
+		/datum/reagent/plantnutriment/eznutriment,
+		/datum/reagent/plantnutriment/left4zednutriment,
+		/datum/reagent/plantnutriment/robustharvestnutriment
+	)
+
+/obj/machinery/chem_dispenser/mutagensaltpeter/Initialize()
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/capacitor(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stock_parts/cell/upgraded(null)
+	RefreshParts()

--- a/mod_celadon/balance/code/mutagensalpetredispenser.dm
+++ b/mod_celadon/balance/code/mutagensalpetredispenser.dm
@@ -16,7 +16,7 @@
 	desc = "The circuit board for a portable botanical chem dispenser."
 	id = "botan_dispenser"
 	build_path = /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_MEDICAL
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 	category = list ("Service Machinery")
 
 /datum/techweb_node/botany


### PR DESCRIPTION
ПР делает что-то умное, а именно:

### Ботанический диспенсер теперь можно разобрать.

### Ботанический диспенсер теперь спавнится с т1 деталями(через мапы или гейм панель), сборка теперь требует деталей любого качества.

### Плата ботанического диспенсера добавлена в технологию Botanical Engineering, она же получила новое название, описание и сервисный иконстейт.

### Чуть занерфлено содержимое ботанического диспенсера(вода, криоксадон, что-то ещё бесполезное - убрал)

### Атлас теперь сможет собрать диспенсер без т4 деталей...


- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.
