### PR TITLE
Tweak: Elysium EVA Suit no longer can hold skimitar

### DIFF
--- a/mod_celadon/outfit/code/elysium/suits.dm
+++ b/mod_celadon/outfit/code/elysium/suits.dm
@@ -73,7 +73,7 @@
 	mob_overlay_state = "space_elysium"
 	armor = list("melee" = 30, "bullet" = 20, "laser" = 30, "energy" = 30, "bomb" = 20, "bio" = 50, "rad" = 60, "fire" = 60, "acid" = 75)
 	slowdown = 0.5
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/melee/skimitar, /obj/item/gun)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/gun)
 
 /obj/item/clothing/under/rank/avanpost
 	icon = 'mod_celadon/_storge_icons/icons/obj/elysium_commander.dmi'


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
ПР делает что-то умное. Делает предложку, что запрещает хранить скимитар на Элизиумской еве

https://discord.com/channels/1100198143456465067/1311685571894054953

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.
