### PR TITLE
nanotrasen early space warning ship + skybreaker fixes

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_slasher.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_slasher.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
+	"map_name": "Slasher-class ESW Vessel",
+	"map_short_name": "Slasher",
+	"description": "'Skybreaker', передовое боевое судно Нанотрейзен, создано для достижения превосходства в оспариваемых регионах космоса. Название судно получило за свою обтекаемую форму и инновационное расположение стыковочного шлюза, позволяющее с максимальной тягой отдаляться от стремительно разрушающихся объектов Синдиката. Корабль полностью оснащен энергетическим оружием. Конкретно эта версия судна принадлежит Тактическому Штурмовому Отряду Нанотрейзен.",
+	"map_path": "_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_slasher.dmm",
+	"sensor_range": 8,
+	"enabled": true,
+	"limit": 1,
+	"prefix": "NTBSV",
+	"faction": "/datum/faction/nt",
+	"tags": [
+		"Early Space Warning",
+		"Command",
+		"Engineering"
+	],
+	"namelists": [
+		"NANOTRASEN",
+		"BRITISH_NAVY"
+	],
+	"job_slots": {
+		"Intelligence Officer": {
+			"outfit": "/datum/outfit/job/nanotrasen/intel/captain",
+			"officer": true,
+			"slots": 1
+		},
+		"Security Operative": {
+			"outfit": "/datum/outfit/job/nanotrasen/intel/operative",
+			"slots": 1
+		},
+		"Medical Technician": {
+			"outfit": "/datum/outfit/job/nanotrasen/intel/medic",
+			"slots": 1
+		},
+		"Engineering Technician": {
+			"outfit": "/datum/outfit/job/nanotrasen/intel/engineer",
+			"slots": 1
+		}
+	}
+}

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -551,6 +551,7 @@
 	dir = 4
 	},
 /obj/structure/table/optable,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "gS" = (
@@ -3812,8 +3813,13 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/border{
 	dir = 6
 	},
-/obj/structure/table/reinforced/titaniumglass,
-/obj/machinery/recharger,
+/obj/machinery/telecomms/relay{
+	freq_listening = list(1351);
+	id = "Nanotrasen Relay";
+	name = "Nanotrasen relay";
+	network = "nt_commnet";
+	layer = 3.1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "YE" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_slasher.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_slasher.dmm
@@ -1,0 +1,5204 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"af" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"ak" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"ao" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 6
+	},
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/paper_bin,
+/obj/item/stamp{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/obj/item/stamp/denied{
+	pixel_y = 1;
+	pixel_x = 11
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"ar" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"aF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"aH" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/thinplating/light,
+/obj/effect/turf_decal/siding/thinplating/light/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"aJ" = (
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/light/corner,
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "surgical supplies locker"
+	},
+/obj/item/storage/case/surgery,
+/obj/item/reagent_containers/glass/bottle/formaldehyde,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bc" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/banner/nanotrasen/mundane{
+	anchored = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"bv" = (
+/obj/machinery/power/tracker{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"bB" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"bH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"bN" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/machinery/light/directional/south,
+/obj/structure/closet/secure_closet{
+	icon_state = "tac";
+	name = "ammunition locker";
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"bS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/end{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"cb" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"cj" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"cP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/item/banner/nanotrasen/mundane{
+	anchored = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dc" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"de" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -16
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/table/reinforced/titaniumglass,
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"dx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dA" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"dF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"dW" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"dX" = (
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 6
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/cmo,
+/obj/structure/curtain/cloth,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"ea" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/power/smes{
+	charge = 3e006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"ed" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/machinery/power/shuttle/engine/electric/premium,
+/turf/open/floor/plating,
+/area/ship/external)
+"ei" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"ek" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/guncloset{
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun/smg{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/item/gun/energy/e_gun/iot{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/advtaser{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"ex" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"eP" = (
+/obj/docking_port/mobile{
+	dir = 4;
+	name = "hunter shuttle";
+	port_direction = 2;
+	preferred_direction = 4
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"eQ" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"eR" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/helm{
+	dir = 8;
+	icon_state = "computer-middle"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"fx" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/external)
+"fC" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"fH" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"fP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"gm" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"gt" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"gv" = (
+/turf/open/floor/engine/hull,
+/area/space)
+"gA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"gH" = (
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"gN" = (
+/obj/structure/closet/crate/secure{
+	anchored = 1;
+	name = "MRE supply crate"
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white,
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"he" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/door/window/westright,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"ht" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"hK" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/closet/secure_closet/wall/directional/east{
+	name = "janitorial supplies closet";
+	req_ship_access = 1
+	},
+/obj/item/soap/nanotrasen,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/toy/plush/celadon/hampter/janitor,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"hM" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "slasher_bridge"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"hX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"hZ" = (
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "brig_phys";
+	name = "medical technician's locker";
+	anchored = 1
+	},
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/storage/backpack/ert/medical,
+/obj/item/radio/headset/nanotrasen/alt,
+/obj/item/binoculars,
+/obj/item/gps,
+/obj/item/melee/knife/combat,
+/obj/item/sensor_device,
+/obj/item/pinpointer/crew,
+/obj/item/storage/belt/medical/surgery,
+/obj/item/defibrillator/compact/loaded,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/glasses/hud/health/sunglasses,
+/obj/item/flashlight/seclite,
+/obj/item/clothing/under/rank/medical/paramedic/skirt/lp,
+/obj/item/clothing/under/rank/medical/paramedic/lp,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"ih" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"iq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"iM" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning,
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Bridge"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"iU" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"jg" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/power/smes{
+	charge = 3e006
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"jn" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"jz" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 6
+	},
+/obj/machinery/computer/camera_advanced{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"jX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"ko" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"kz" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_x = 23;
+	pixel_y = 5;
+	id = "slasher_port";
+	name = "port shutters";
+	dir = 8
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = -4;
+	id = "slasher_port_holo"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"kD" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"lg" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plating,
+/area/ship/external)
+"lu" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/medical)
+"lw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"lx" = (
+/obj/structure/cable,
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"lA" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"lH" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"lQ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"lR" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 10
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/ert/lp/med{
+	name = "Medical Technician Hardsuit"
+	},
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"lU" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"lV" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"ma" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = 0;
+	id = "slasher_bridge";
+	name = "bridge shutters"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"mt" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"mJ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"mQ" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"mW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"nk" = (
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"nF" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/general/engineering)
+"ow" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"oK" = (
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"oT" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/power/smes{
+	charge = 3e006
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"pa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"pf" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"pl" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning,
+/obj/machinery/door/window/brigdoor/westleft,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"py" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"pB" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"pG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"pV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/command/glass{
+	name = "Cryogenics"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"qb" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"qd" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"qi" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"qx" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_x = 32;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"qX" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"re" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "armory";
+	name = "security operative's locker";
+	anchored = 1
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/radio/headset/nanotrasen/alt,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/storage/belt/security/webbing,
+/obj/item/melee/baton{
+	cell = null/obj/item/stock_parts/cell/high/plus
+	},
+/obj/item/storage/backpack/ert/security,
+/obj/item/melee/knife/combat,
+/obj/item/binoculars,
+/obj/item/assembly/flash,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/gps,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/restraints/legcuffs/bola/energy,
+/obj/item/restraints/legcuffs/bola/energy,
+/obj/item/gun/energy/e_gun/advtaser,
+/obj/item/flashlight/seclite,
+/obj/item/gun/energy/e_gun,
+/obj/item/clothing/under/rank/security/head_of_security/alt/skirt,
+/obj/item/clothing/under/rank/security/head_of_security/alt,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"rg" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/power/smes{
+	charge = 3e006
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"ro" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"rw" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -13;
+	pixel_y = 2
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ship/crew/cryo)
+"ry" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"rz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"rF" = (
+/obj/docking_port/stationary{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"rJ" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"rX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"ss" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/command/glass{
+	name = "Officer's Quarters"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"sV" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 1
+	},
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"sW" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"tl" = (
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/circuitboard/machine/cell_charger,
+/obj/item/storage/toolbox/electrical,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/box/white,
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"tp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/general/engineering)
+"tT" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"uU" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/space)
+"uW" = (
+/obj/item/radio/intercom/wideband/directional/east,
+/obj/machinery/computer/crew{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 5
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"vi" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "eng_secure";
+	name = "ship engineer's locker";
+	anchored = 1
+	},
+/obj/item/storage/backpack/ert/engineer,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/radio/headset/nanotrasen/alt,
+/obj/item/gps,
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
+/obj/item/storage/toolbox/electrical,
+/obj/item/flashlight/seclite,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/obj/item/holosign_creator/atmos,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/under/rank/engineering/engineer/nt/skirt/lp,
+/obj/item/clothing/under/rank/engineering/engineer/nt/lp,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"vm" = (
+/turf/template_noop,
+/area/template_noop)
+"vs" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"vx" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ship/crew/cryo)
+"vA" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"vJ" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"vM" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/door/window/brigdoor/westright,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"vP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/obj/machinery/light/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"vY" = (
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"wi" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/external)
+"wk" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"wo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"wu" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"ww" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"wU" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"xe" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"xh" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"xl" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"xq" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"xy" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"xD" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"yr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"yu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"yx" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"yz" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/security/glass/seclock{
+	name = "Armory"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"yD" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -16
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/table/reinforced/titaniumglass,
+/obj/machinery/microwave{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"yJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	piping_layer = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"yX" = (
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"zd" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"zs" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/brigdoor/eastright,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"zy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light/corner{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/wall/directional/east{
+	name = "blood pack freezer"
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/synthetic,
+/obj/item/reagent_containers/blood/synthetic,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/lizard,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"zJ" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 8;
+	name = "Engineering"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"zX" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Af" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"As" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"AA" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/crew/cryo)
+"AF" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "helm shuttle chair"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"AQ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"AS" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/plating,
+/area/ship/external)
+"Be" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Bn" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner,
+/obj/effect/turf_decal/trimline/opaque/ntblue/corner,
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Bv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"BU" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 5
+	},
+/obj/structure/table/reinforced/titaniumglass,
+/obj/machinery/fax/nanotrasen,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Ci" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Cz" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"CK" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/captain{
+	dir = 4
+	},
+/obj/structure/curtain/bounty,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"Df" = (
+/obj/machinery/power/shieldwallgen/atmos{
+	dir = 4;
+	id = "slasher_port_holo";
+	anchored = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "slasher_port"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull,
+/area/ship/hallway/central)
+"Dh" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/brigdoor/eastleft,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Dq" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"DA" = (
+/obj/machinery/power/shieldwallgen/atmos{
+	dir = 8;
+	id = "slasher_port_holo";
+	anchored = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "slasher_port"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull,
+/area/ship/hallway/central)
+"DC" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet{
+	name = "intelligence officer's locker";
+	icon_state = "blueshield";
+	anchored = 1
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/storage/belt/military/assault,
+/obj/item/melee/baton{
+	cell = /obj/item/stock_parts/cell/high/plus
+	},
+/obj/item/melee/knife/combat,
+/obj/item/binoculars,
+/obj/item/assembly/flash,
+/obj/item/reagent_containers/spray/pepper,
+/obj/item/gps,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/legcuffs/bola/energy,
+/obj/item/restraints/legcuffs/bola/energy,
+/obj/item/storage/backpack/ert,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/flashlight/seclite,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/radio/headset/nanotrasen/alt/captain,
+/obj/item/clothing/suit/armor/nanotrasen/captain/parade,
+/obj/item/clothing/suit/armor/nanotrasen/captain,
+/obj/item/clothing/under/nanotrasen/captain,
+/obj/item/clothing/under/nanotrasen/captain/skirt,
+/obj/item/clothing/head/nanotrasen/captain/peaked,
+/obj/item/clothing/suit/hooded/wintercoat/captain,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"DR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Ej" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Et" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"EI" = (
+/obj/machinery/power/tracker{
+	color = "#283674"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"EU" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 10
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Fx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"FC" = (
+/obj/effect/turf_decal/siding/thinplating/light{
+	dir = 9
+	},
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"FT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = -5;
+	id = "slasher_starboard";
+	name = "starboard shutters"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 4;
+	id = "slasher_starboard_holo"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"FW" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Ga" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Gj" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Gk" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/security/armory)
+"Gm" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Gu" = (
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Gz" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Hc" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"He" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -16
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Hv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"HF" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"HL" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/ert/lp{
+	name = "NT Intelligence Officer Hardsuit"
+	},
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"HZ" = (
+/obj/docking_port/stationary{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Ir" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/crew/dorm/captain)
+"It" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/crew/dorm/captain)
+"Iz" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"IQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/nanotrasen{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"IU" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Ju" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"JB" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"JI" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"JV" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Kf" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	icon_state = "hop";
+	name = "secure clothes locker"
+	},
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"KL" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"KM" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"KP" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"LI" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/machinery/airalarm/directional/south{
+	pixel_x = 0;
+	pixel_y = -27
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/ert/lp/engi{
+	name = "Engineering Technician Hardsuit"
+	},
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/mask/gas/atmos,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Mg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/ert/lp/sec{
+	name = "Security Operative Hardsuit"
+	},
+/obj/item/tank/internals/oxygen/red,
+/obj/item/clothing/mask/gas/vigilitas,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"Mh" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Mp" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"MC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"MG" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/crew/cryo)
+"MM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/power/solar_control{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"MS" = (
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"NO" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ship/crew/cryo)
+"Os" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/security/armory)
+"OC" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"OJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/ntspaceworks_small/left,
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"OP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"OW" = (
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/paper_bin,
+/obj/item/toy/plush/celadon/hampter/captain/old{
+	pixel_x = 12;
+	pixel_y = -5;
+	name = "hampter the first Intelligence Officer"
+	},
+/obj/item/stamp/nanotrasen{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/item/pen/fountain/captain,
+/obj/item/stamp/nanotrasen/captain{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/stamp/nanotrasen/officer{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"OZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Pb" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Pd" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Pn" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Pw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"PL" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/medical)
+"PW" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Qx" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/general/engineering)
+"QG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"QJ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"QL" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"QS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Rk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/autolathe/hacked,
+/obj/structure/closet/secure_closet/wall/directional/east{
+	icon_state = "sec_wall";
+	name = "autolathe supplies locker"
+	},
+/obj/item/stack/sheet/metal/twenty{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/glass/twenty{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"Rn" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Rr" = (
+/obj/machinery/power/shieldwallgen/atmos{
+	dir = 4;
+	id = "slasher_starboard_holo";
+	anchored = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "slasher_starboard"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/hallway/central)
+"Ru" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/end{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Sn" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"SF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/ntspaceworks_small/right,
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"SK" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/box/white,
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/effect/spawner/random/trash/botanical_waste,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/effect/spawner/random/trash/janitor_supplies,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"SQ" = (
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"TA" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull,
+/area/space)
+"TM" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"TP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/ntspaceworks_small,
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Ue" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"Ui" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/machinery/light/directional/south,
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Uk" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ship/crew/cryo)
+"Ur" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/computer/cryopod/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/cryo)
+"Uv" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Ux" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"UB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"UR" = (
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"UY" = (
+/obj/machinery/power/shieldwallgen/atmos{
+	dir = 8;
+	id = "slasher_starboard_holo";
+	anchored = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "slasher_starboard"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/hallway/central)
+"Ve" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/machinery/power/shuttle/engine/electric/premium,
+/turf/open/floor/plating,
+/area/ship/general/engineering)
+"Vy" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/thinplating/light/end{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet{
+	name = "field medicine locker";
+	icon_state = "med_secure"
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/brute,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"VJ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"VL" = (
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"VQ" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_x = 32;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"VU" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Wx" = (
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/bridge)
+"WP" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"Xe" = (
+/obj/machinery/holopad/emergency/command,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Xw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm/captain)
+"XC" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/telecomms/relay{
+	freq_listening = list(1351);
+	id = "Nanotrasen Relay";
+	name = "Nanotrasen relay";
+	network = "nt_commnet";
+	layer = 3.1
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"XQ" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/exterior,
+/area/ship/bridge)
+"Yb" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+"Yx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/wall/directional/west{
+	icon_state = "cargo_wall";
+	name = "emergency extraction closet"
+	},
+/obj/item/pickaxe/emergency,
+/obj/item/pickaxe/emergency,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/tech,
+/area/ship/hallway/central)
+"YR" = (
+/obj/machinery/mission_scanner{
+	anchored = 1;
+	name = "advanced sensor array";
+	density = 1
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"YS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
+"YU" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"YW" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/plasteel/tech,
+/area/ship/security/armory)
+"Zb" = (
+/obj/effect/turf_decal/solarpanel{
+	color = "#283674"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/solar{
+	color = "#283674"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
+"Zq" = (
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/light,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Zt" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/general/engineering)
+
+(1,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(2,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(3,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(4,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(5,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+fx
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+fx
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(6,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+wi
+ed
+nF
+vm
+vm
+vm
+eP
+vm
+vm
+vm
+nF
+ed
+wi
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(7,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+wi
+AS
+nF
+vm
+nF
+nF
+tp
+nF
+nF
+vm
+nF
+lg
+wi
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(8,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+mt
+vm
+vm
+vm
+gv
+uU
+nF
+Ve
+nF
+MM
+yJ
+Zt
+nF
+Ve
+nF
+TA
+gv
+vm
+vm
+vm
+mt
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(9,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+TM
+lH
+Af
+vm
+SQ
+SQ
+Ju
+nF
+Dh
+nF
+PW
+rz
+OC
+nF
+zs
+nF
+Ju
+SQ
+SQ
+vm
+fC
+mJ
+YR
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(10,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+KM
+VJ
+Af
+SQ
+vm
+tT
+FW
+VQ
+gA
+Yb
+gm
+VL
+gA
+qx
+FW
+ei
+vm
+SQ
+fC
+JB
+Ga
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(11,1,1) = {"
+vm
+vY
+qX
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+KM
+VJ
+Af
+vm
+Ju
+Qx
+nF
+nF
+vi
+wk
+LI
+nF
+nF
+Qx
+OJ
+vm
+fC
+JB
+Ga
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+YS
+yX
+"}
+(12,1,1) = {"
+vm
+gH
+dc
+xD
+SQ
+SQ
+vm
+SQ
+SQ
+SQ
+SQ
+SQ
+KM
+VJ
+pa
+OP
+SQ
+nF
+rg
+Sn
+MC
+Gz
+ea
+nF
+SQ
+TP
+rX
+Cz
+Ga
+SQ
+SQ
+SQ
+SQ
+SQ
+vm
+SQ
+SQ
+fC
+mW
+gH
+"}
+(13,1,1) = {"
+vm
+bv
+KP
+vA
+xD
+SQ
+SQ
+SQ
+gH
+vm
+vm
+SQ
+SQ
+KM
+AQ
+Ju
+gH
+nF
+jg
+ex
+mQ
+fH
+oT
+nF
+gH
+SF
+YU
+YU
+SQ
+SQ
+vm
+vm
+gH
+SQ
+SQ
+SQ
+fC
+As
+wu
+EI
+"}
+(14,1,1) = {"
+vm
+vm
+YU
+dc
+vA
+xD
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+SQ
+Ju
+nF
+nF
+nF
+nF
+zJ
+nF
+nF
+nF
+nF
+Pd
+qX
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+fC
+As
+mW
+YU
+vm
+"}
+(15,1,1) = {"
+vm
+vm
+vm
+YU
+dc
+vA
+xD
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+YS
+Hv
+PL
+hZ
+lR
+PL
+WP
+AA
+rw
+NO
+AA
+SQ
+Ju
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+fC
+As
+mW
+YU
+vm
+vm
+"}
+(16,1,1) = {"
+vm
+vm
+vm
+vm
+YU
+dc
+vA
+xD
+vm
+vm
+vm
+vm
+vm
+vm
+Ju
+PL
+PL
+aJ
+dX
+PL
+VU
+AA
+Uk
+vx
+AA
+AA
+Ju
+vm
+vm
+vm
+vm
+vm
+vm
+fC
+As
+mW
+YU
+vm
+vm
+vm
+"}
+(17,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+YU
+dc
+vA
+xD
+vm
+vm
+vm
+vm
+YS
+Hv
+PL
+FC
+aH
+PL
+PL
+ih
+AA
+AA
+he
+Kf
+AA
+Pd
+qX
+vm
+vm
+vm
+vm
+fC
+As
+mW
+YU
+vm
+vm
+vm
+vm
+"}
+(18,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+gH
+YU
+dc
+vA
+xD
+vm
+vm
+SQ
+Ju
+PL
+PL
+sV
+Zq
+PL
+Yx
+qi
+SK
+AA
+OZ
+yD
+AA
+AA
+Ju
+SQ
+vm
+vm
+fC
+As
+mW
+YU
+gH
+vm
+vm
+vm
+vm
+"}
+(19,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+YU
+dc
+vA
+xD
+vm
+YS
+Gu
+PL
+Vy
+zy
+py
+Ej
+iU
+dx
+gt
+pV
+hK
+Ur
+Ui
+AA
+qd
+qX
+vm
+fC
+As
+mW
+YU
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(20,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+YU
+lQ
+QJ
+lw
+ro
+lu
+PL
+PL
+PL
+PL
+PL
+UB
+ww
+bc
+AA
+AA
+AA
+AA
+AA
+MG
+QL
+lw
+ht
+mJ
+YU
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(21,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+lV
+SQ
+Ju
+Rr
+ry
+FT
+dF
+hX
+xq
+JI
+bS
+Iz
+Fx
+cb
+xh
+fP
+bH
+Df
+Ju
+SQ
+yu
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(22,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+dW
+SQ
+Ju
+UY
+vs
+KL
+jX
+Pw
+wo
+Uv
+Ru
+lU
+lA
+ow
+Ci
+kz
+Ux
+DA
+Ju
+SQ
+iq
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(23,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+mt
+IU
+pB
+lw
+Pn
+It
+Ir
+Ir
+Ir
+Ir
+Ir
+cP
+DR
+wU
+Gk
+Gk
+Gk
+Gk
+Gk
+Os
+af
+lw
+Bv
+Af
+mt
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(24,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+mt
+HF
+Gj
+AQ
+vm
+Pd
+nk
+Ir
+OW
+xe
+Dq
+ss
+jn
+dx
+bB
+yz
+QG
+xy
+bN
+Gk
+oK
+Hv
+vm
+xl
+ak
+QS
+mt
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(25,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+gH
+mt
+HF
+Gj
+AQ
+vm
+vm
+SQ
+Ju
+Ir
+Ir
+aF
+qb
+Ir
+gN
+Hc
+tl
+Gk
+cj
+de
+Gk
+Gk
+Ju
+SQ
+vm
+vm
+lQ
+ak
+QS
+mt
+gH
+vm
+vm
+vm
+vm
+"}
+(26,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+mt
+HF
+Gj
+AQ
+vm
+vm
+vm
+vm
+Pd
+qX
+Ir
+ek
+Mp
+Ir
+Ir
+pG
+Gk
+Gk
+kD
+Rk
+Gk
+YS
+Hv
+vm
+vm
+vm
+vm
+zd
+ak
+QS
+mt
+vm
+vm
+vm
+vm
+"}
+(27,1,1) = {"
+vm
+vm
+vm
+vm
+mt
+HF
+Gj
+AQ
+vm
+vm
+vm
+vm
+vm
+vm
+Ju
+Ir
+Ir
+Xw
+CK
+Ir
+vP
+Gk
+IQ
+YW
+Gk
+Gk
+Ju
+vm
+vm
+vm
+vm
+vm
+vm
+zd
+ak
+QS
+mt
+vm
+vm
+vm
+"}
+(28,1,1) = {"
+vm
+vm
+vm
+mt
+HF
+Gj
+AQ
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+Pd
+qX
+Ir
+DC
+HL
+Ir
+sW
+Gk
+Mg
+re
+Gk
+YS
+Hv
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+zd
+ak
+QS
+mt
+vm
+vm
+"}
+(29,1,1) = {"
+vm
+vm
+mt
+HF
+Gj
+AQ
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+SQ
+Ju
+Wx
+Wx
+Wx
+Wx
+iM
+Wx
+Wx
+Wx
+Wx
+Ju
+SQ
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+zd
+ak
+QS
+mt
+vm
+"}
+(30,1,1) = {"
+vm
+bv
+dA
+Gj
+AQ
+SQ
+SQ
+SQ
+gH
+vm
+vm
+SQ
+SQ
+Pb
+zX
+Hv
+gH
+hM
+XC
+ma
+JV
+Mh
+EU
+hM
+gH
+Pd
+eQ
+rJ
+SQ
+SQ
+vm
+vm
+gH
+SQ
+SQ
+SQ
+zd
+ak
+Gm
+EI
+"}
+(31,1,1) = {"
+vm
+gH
+HF
+AQ
+SQ
+SQ
+vm
+SQ
+SQ
+SQ
+SQ
+SQ
+Be
+Zb
+ar
+SQ
+SQ
+hM
+BU
+pf
+yr
+Bn
+ao
+hM
+SQ
+SQ
+yx
+eQ
+rJ
+SQ
+SQ
+SQ
+SQ
+SQ
+vm
+SQ
+SQ
+zd
+QS
+gH
+"}
+(32,1,1) = {"
+vm
+UR
+HZ
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+Be
+Zb
+ar
+vm
+SQ
+SQ
+XQ
+Wx
+Et
+Xe
+He
+Wx
+XQ
+SQ
+SQ
+vm
+yx
+eQ
+rJ
+SQ
+SQ
+vm
+vm
+vm
+vm
+SQ
+SQ
+rF
+yX
+"}
+(33,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+Be
+Zb
+ar
+SQ
+vm
+SQ
+SQ
+SQ
+hM
+vM
+MS
+pl
+hM
+SQ
+SQ
+SQ
+vm
+SQ
+yx
+eQ
+rJ
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(34,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+Ue
+Zb
+ar
+vm
+SQ
+SQ
+SQ
+SQ
+SQ
+hM
+Rn
+AF
+ko
+hM
+SQ
+SQ
+SQ
+SQ
+SQ
+vm
+yx
+eQ
+lx
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(35,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+vJ
+vm
+vm
+vm
+SQ
+SQ
+vm
+SQ
+Wx
+uW
+eR
+jz
+Wx
+SQ
+vm
+SQ
+SQ
+vm
+vm
+vm
+vJ
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(36,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+wi
+SQ
+vm
+vm
+Wx
+Wx
+Wx
+Wx
+Wx
+vm
+vm
+SQ
+wi
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(37,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+wi
+vm
+vm
+vm
+vm
+vm
+gH
+vm
+vm
+vm
+vm
+vm
+wi
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(38,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+fx
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+fx
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(39,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+gH
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(40,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}
+(41,1,1) = {"
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+vm
+"}

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_slasher.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_slasher.dmm
@@ -1229,10 +1229,8 @@
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external)
-"re" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/effect/turf_decal/siding/thinplating/dark
 	dir = 6
-	},
 /obj/structure/closet/secure_closet{
 	icon_state = "armory";
 	name = "security operative's locker";
@@ -1243,7 +1241,7 @@
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/storage/belt/security/webbing,
 /obj/item/melee/baton{
-	cell = null/obj/item/stock_parts/cell/high/plus
+	cell = /obj/item/stock_parts/cell/high/plus
 	},
 /obj/item/storage/backpack/ert/security,
 /obj/item/melee/knife/combat,

--- a/mod_celadon/outfit/code/nanotrasen/nt_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/nt_outfit.dm
@@ -278,7 +278,7 @@
 	backpack = /obj/item/storage/backpack/ert
 	id = /obj/item/card/id/ert
 	ears = /obj/item/radio/headset/nanotrasen/alt/captain
-	backpack_contents = list(/obj/item/radio)
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic)
 	box = /obj/item/storage/box/survival/nanotrasen
 
 
@@ -295,7 +295,7 @@
 	backpack = /obj/item/storage/backpack/ert/security
 	id = /obj/item/card/id/ert/security
 	ears = /obj/item/radio/headset/nanotrasen/alt
-	backpack_contents = list(/obj/item/radio)
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic)
 
 	box = /obj/item/storage/box/survival/nanotrasen
 
@@ -312,7 +312,7 @@
 	backpack = /obj/item/storage/backpack/ert/medical
 	id = /obj/item/card/id/ert/medical
 	ears = /obj/item/radio/headset/nanotrasen/alt
-	backpack_contents = list(/obj/item/radio)
+	backpack_contents = list(/obj/item/storage/firstaid/medical)
 
 	box = /obj/item/storage/box/survival/nanotrasen
 
@@ -320,7 +320,7 @@
 	//Nanotrasen Tactical Assault Team инженер
 
 /datum/outfit/job/nanotrasen/ntas/engineer
-	name = "NTAS Medical Operative"
+	name = "NTAS Engineering Operative"
 	jobtype = /datum/job/chief_engineer
 	job_icon = "chiefengineer"
 	implants = list(/obj/item/implant/mindshield)
@@ -330,7 +330,6 @@
 	backpack = /obj/item/storage/backpack/ert/engineer
 	id = /obj/item/card/id/ert/engineer
 	ears = /obj/item/radio/headset/nanotrasen/alt
-	backpack_contents = list(/obj/item/radio)
 
 	box = /obj/item/storage/box/survival/nanotrasen
 
@@ -347,7 +346,81 @@
 	backpack = /obj/item/storage/backpack/ert/janitor
 	id = /obj/item/card/id/ert/janitor
 	ears = /obj/item/radio/headset/nanotrasen/alt
-	backpack_contents = list(/obj/item/radio)
 
 	box = /obj/item/storage/box/survival/nanotrasen
+
+
+/datum/outfit/job/nanotrasen/intel/captain
+	name = "Intelligence Officer"
+	jobtype = /datum/job/captain
+	job_icon = "captain"
+	implants = list(/obj/item/implant/mindshield)
+	uniform = /obj/item/clothing/under/nanotrasen/captain
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	backpack = /obj/item/storage/backpack/satchel/leather
+	suit = /obj/item/clothing/suit/armor/nanotrasen/captain/parade
+	suit_store = /obj/item/gun/ballistic/revolver/mateba
+	head = /obj/item/clothing/head/nanotrasen/captain/peaked
+	id = /obj/item/card/id/centcom
+	glasses = /obj/item/clothing/glasses/sunglasses
+	ears = /obj/item/radio/headset/nanotrasen/alt/captain
+	backpack_contents = list(/obj/item/ammo_box/a357, /obj/item/ammo_box/a357, /obj/item/melee/classic_baton/telescopic)
+	box = /obj/item/storage/box/survival/nanotrasen
+
+/datum/outfit/job/nanotrasen/intel/operative
+	name = "Security Operative"
+	jobtype = /datum/job/hos
+	job_icon = "headofsecurity"
+	implants = list(/obj/item/implant/mindshield)
+	uniform = /obj/item/clothing/under/rank/security/head_of_security/alt/lp
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	backpack = /obj/item/storage/backpack/ert/security
+	suit = /obj/item/clothing/suit/armor/nanotrasen
+	head = /obj/item/clothing/head/nanotrasen/beret/security/command
+	id = /obj/item/card/id/lpsec
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	ears = /obj/item/radio/headset/nanotrasen/alt
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic)
+
+	box = /obj/item/storage/box/survival/nanotrasen
+
+/datum/outfit/job/nanotrasen/intel/medic
+	name = "Medical Technician"
+	jobtype = /datum/job/cmo
+	job_icon = "chiefmedicalofficer"
+	implants = list(/obj/item/implant/mindshield)
+	uniform = /obj/item/clothing/under/rank/medical/paramedic/lp
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	backpack = /obj/item/storage/backpack/ert/medical
+	head = /obj/item/clothing/head/soft/paramedic
+	id = /obj/item/card/id/lpmed
+	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
+	ears = /obj/item/radio/headset/nanotrasen/alt
+	backpack_contents = list(/obj/item/storage/firstaid/medical)
+
+	box = /obj/item/storage/box/survival/nanotrasen
+
+/datum/outfit/job/nanotrasen/intel/engineer
+	name = "Engineering Technician"
+	jobtype = /datum/job/chief_engineer
+	job_icon = "chiefengineer"
+	implants = list(/obj/item/implant/mindshield)
+	uniform = /obj/item/clothing/under/rank/engineering/engineer/nt/lp
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	head = /obj/item/clothing/head/beret/eng/hazard
+	backpack = /obj/item/storage/backpack/ert/engineer
+	glasses = /obj/item/clothing/glasses/meson/engine
+	belt = /obj/item/storage/belt/utility/full/engi
+	id = /obj/item/card/id/lpengie
+	ears = /obj/item/radio/headset/nanotrasen/alt
+	backpack_contents = list(/obj/item/construction/rcd/loaded)
+
+
+
+
+
 


### PR DESCRIPTION
ПР делает что-то умное, а именно:

### Даёт НТ шип раннего космического предупреждения, уродскую смешную каракатицу(пока не щитспавн, я его зря балансил или что?), скрин:

![image](https://github.com/user-attachments/assets/590c43f6-9a46-48ba-ab40-71c100ee16d6)

### Дает на скайбрейкер КАПЕЛЬНИЦУ и телескопички. Всё.

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.
