### PR TITLE
Ядра МОДов в карго, ребеланс либртата и краинг сан

### DIFF
--- a/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
@@ -764,17 +764,21 @@
 /obj/structure/rack,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/corner/opaque/neutral/full,
-/obj/item/stock_parts/cell/gun{
-	pixel_x = 0;
-	pixel_y = -7
+/obj/item/stock_parts/cell/gun/kalix{
+	pixel_x = 5;
+	pixel_y = -6
 	},
-/obj/item/gun/energy/laser/retro{
-	pixel_x = 0;
-	pixel_y = -2
+/obj/item/stock_parts/cell/gun/kalix{
+	pixel_x = -1;
+	pixel_y = -5
 	},
-/obj/item/gun/energy/laser/retro{
+/obj/item/gun/energy/kalix/pistol{
 	pixel_x = -4;
-	pixel_y = 3
+	pixel_y = 7
+	},
+/obj/item/gun/energy/kalix/pistol{
+	pixel_x = -5;
+	pixel_y = 2
 	},
 /turf/open/floor/vault,
 /area/ship/security/armory)
@@ -2184,20 +2188,36 @@
 	pixel_x = 13
 	},
 /obj/item/grenade/smokebomb{
-	pixel_y = -4;
-	pixel_x = 3
-	},
-/obj/item/grenade/smokebomb{
 	pixel_y = -5;
 	pixel_x = 13
 	},
-/obj/item/grenade/smokebomb{
-	pixel_x = 8;
-	pixel_y = -6
-	},
 /obj/item/grenade/c4,
 /obj/item/grenade/c4{
-	pixel_x = -7;
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/grenade/iedcasing/spawned{
+	pixel_x = -13;
+	pixel_y = -6
+	},
+/obj/item/grenade/iedcasing/spawned{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/grenade/iedcasing/spawned{
+	pixel_x = -12;
+	pixel_y = 0
+	},
+/obj/item/grenade/iedcasing/spawned{
+	pixel_x = -12;
+	pixel_y = -11
+	},
+/obj/item/grenade/stingbang{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/grenade/stingbang{
+	pixel_x = 8;
 	pixel_y = -5
 	},
 /turf/open/floor/vault,
@@ -5033,10 +5053,6 @@
 	pixel_x = 5;
 	pixel_y = 0
 	},
-/obj/item/flashlight/seclite{
-	pixel_x = 5;
-	pixel_y = -3
-	},
 /obj/item/gps{
 	pixel_x = -10;
 	pixel_y = 9
@@ -5053,14 +5069,14 @@
 	pixel_x = -10;
 	pixel_y = 3
 	},
-/obj/item/gps{
-	pixel_x = -10;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/industrial/traffic/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/neutral/full,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/open/floor/vault,
 /area/ship/security/armory)
 "Qq" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -154,7 +154,7 @@
 /area/ship/security)
 "fR" = (
 /obj/effect/turf_decal/box,
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "hb" = (
@@ -185,8 +185,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/frame,
 /obj/item/stack/ore/bluespace_crystal,
+/obj/structure/frame/machine,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "kK" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -69,14 +69,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 10
-	},
-/obj/item/stack/sheet/glass/twenty,
-/obj/item/stack/sheet/metal/twenty{
-	pixel_x = 3;
-	pixel_y = 0
 	},
 /obj/machinery/light_switch{
 	dir = 1;
@@ -551,10 +545,6 @@
 	},
 /obj/item/storage/box/ammo/c9mm_rubber{
 	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/item/storage/box/ammo/c9mm_rubber{
-	pixel_x = 8;
 	pixel_y = 10
 	},
 /obj/item/storage/box/ammo/c9mm_rubber{
@@ -568,10 +558,6 @@
 /obj/item/storage/box/ammo/c9mm_rubber{
 	pixel_x = 8;
 	pixel_y = 4
-	},
-/obj/item/storage/box/ammo/c9mm_rubber{
-	pixel_x = 8;
-	pixel_y = 2
 	},
 /obj/item/gun/ballistic/automatic/smg/vector/no_mag,
 /obj/item/gun/ballistic/automatic/smg/skm_carbine/saber/no_mag{

--- a/mod_celadon/inteq_vendor/code/inteq_MODsuit.dm
+++ b/mod_celadon/inteq_vendor/code/inteq_MODsuit.dm
@@ -105,7 +105,7 @@
 	theme = /datum/mod_theme/inteq
 	applied_cell = /obj/item/stock_parts/cell
 	initial_modules = list(
-		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/storage,
 		/obj/item/mod/module/flashlight_inteq,
 		/obj/item/mod/module/magnetic_harness,
 	)
@@ -114,7 +114,7 @@
 	theme = /datum/mod_theme/inteq/elite
 	applied_cell = /obj/item/stock_parts/cell
 	initial_modules = list(
-		/obj/item/mod/module/storage/syndicate,
+		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/magnetic_harness,
 		/obj/item/mod/module/flashlight_inteq,
 		/obj/item/mod/module/dna_lock,

--- a/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
@@ -62,8 +62,8 @@
 
 /datum/supply_pack/science/mod_core_plasma
 	name = "MOD Plasma Core Crate"
-	desc = "One MODsuit core specialized plasmamen, used when creating mods."
-	cost = 6000
+	desc = "One MODsuit core used in MOD construction. This core is designed to be charged from solid plasma."
+	cost = 5000
 	contains = list(/obj/item/mod/core/plasma)
 	crate_name = "MOD core crate"
 	crate_type = /obj/structure/closet/crate/secure/science

--- a/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
@@ -69,8 +69,8 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 
 /datum/supply_pack/science/mod_core_ethereal
-	name = "MOD Ethereal Core Crate"
-	desc = "One MODsuit core specialized for etherials, used when creating mods."
+	name = "MOD Elzous Core Crate"
+	desc = "One MODsuit core specialized for elzous, used when creating mods."
 	cost = 6000
 	contains = list(/obj/item/mod/core/ethereal)
 	crate_name = "MOD core crate"

--- a/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/spacesuit_armor.dm
@@ -59,3 +59,19 @@
 	contains = list(/obj/item/mod/core/standard)
 	crate_name = "MOD core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/mod_core_plasma
+	name = "MOD Plasma Core Crate"
+	desc = "One MODsuit core specialized plasmamen, used when creating mods."
+	cost = 6000
+	contains = list(/obj/item/mod/core/plasma)
+	crate_name = "MOD core crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/mod_core_ethereal
+	name = "MOD Ethereal Core Crate"
+	desc = "One MODsuit core specialized for etherials, used when creating mods."
+	cost = 6000
+	contains = list(/obj/item/mod/core/ethereal)
+	crate_name = "MOD core crate"
+	crate_type = /obj/structure/closet/crate/secure/science


### PR DESCRIPTION
<!-- ЗДЕСЬ должно быть **подробное описание** того, что происходит в PR и зачем это нужно. PR не должен содержать изменений, о которых здесь ничего не сказано. -->
Либертата - удаление автолата и двух пачек резины (с 6 до 4)
Краинг сан - ретро лазеры заменены на каликс пистолеты, смок гранаты заменили на IED и две гранаты с резиной.
В карго добавлены ядра МОДов - Этериал (для Эльзоусов) и Плазма (Зарядки не от батарейки, а от плазмы).
Интек МОДы получили уменьшенные сторадж модули.

<!--
  Честно заполняем галочки. Чем больше галочек, тем быстрее проверять Pull Request, соответственно он быстрее будет принят.
  Чтобы отметить - ставим `x` (икс) внутри квадратных скобочек вот так: `- [x] ...`.
  Галочки можно доставлять позже по мере окончания работы над PR'ом.
-->

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [x] Я запускал сервер со своими изменениями локально и все протестировал. Если были Merge Conflicts исправил все и после проверил снова свои изменения.
