### PR TITLE
fix-runtime: Исправление рантайма регистрации ассетов с одинаковым названием #1491

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -212,7 +212,10 @@
 		if (icon != 'icons/misc/language.dmi')
 			var/icon_state = initial(L.icon_state)
 			Insert("language-[icon_state]", icon, icon_state=icon_state)
-		..()
+	// [CELADON_EDIT] - Переместил вызов родительского прока из цикла
+	// 		..() [CELADON-EDIT] - ORIGINAL
+	..()
+	// [/CELADON_EDIT]
 
 /datum/asset/simple/lobby
 	assets = list(


### PR DESCRIPTION

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание / Что этот PR делает

Исправляет рантайм регистрации ассетов-спрайтов


<!-- Вкратце опишите изменения, которые вносите. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->
Fixes #1491
## Причина создания ПР / Почему это хорошо для игры

Стандартная правка рантаймов при запуске сервера, проблема заключалась в том что внутри цикла вызывался несколько раз родительский метод ../spritesheet/register(), увидел эту проблему и решил починить, лишний раз не будет вызываться родительский прок регистрации ассетов, судя по логам, он вызывался около 14 раз.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->
<!-- Здесь можно оставить ссылку на сообщение в #предложения, чтобы подтвердить, что предложение обсуждалось внутри Discord-сообщества. -->
<!-- Если это вне предложений было сделано, то укажите, почему это изменение положительно влияет на игру. -->
<!-- В случае исправления бага, укажите ссылку на канал в #bugs-code, #bugs-maps, #bugs-sprite или issue в репозитории. В ином случае, опишите баг и шаги для его воспроизведения. -->
<!-- Пример ссылки в Discord-сообщество: https://canary.discord.com/channels/1100198143456465067/1231354486522515456/1231354486522515456 -->

## Демонстрация изменений / Тестирование

Поднимал локальный сервер и чекал рантаймы, заскринил их кол-во

<!-- В случае наличия изменений, влияющих на игровую часть, опишите их здесь. Здесь необходимо описать шаги, которые предпринимались для тестирования изменения. Этот пункт обязателен, без него Pull request будет рассматриваться дольше. В случае их отсутствия, этот пункт можно удалить -->
До:
![image](https://github.com/user-attachments/assets/183f1018-0448-4271-a2fc-c7c4d0b6f69e)
После:
![image](https://github.com/user-attachments/assets/416e7b8a-0034-48b1-b5ef-1ca0fe7232c4)

## Список изменений

:cl:
tweak:  Передвинул строчку кода с вызовом родительского прока из цикла
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.

<!-- Если вы готовы, то ставьте крестик на уже готовой форме, чтобы согласиться и подтвердить готовность свою. -->
