### PR TITLE
Modening: shitpest edition

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_alone.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_alone.dmm
@@ -366,13 +366,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "VY" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/mod/control/pre_equipped/standard,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Wp" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
@@ -2332,8 +2332,9 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
-/obj/machinery/suit_storage_unit/rd,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/mod/control/pre_equipped/research,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "Id" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -481,11 +481,10 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "dM" = (
-/obj/item/clothing/suit/space/hardsuit/mining/heavy,
 /obj/effect/turf_decal/industrial/outline/orange,
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/mask/gas/explorer,
-/obj/item/tank/internals/oxygen,
+/obj/item/mod/control/pre_equipped/mining,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "dN" = (
@@ -6836,10 +6835,10 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "QH" = (
-/obj/item/clothing/suit/space/hardsuit/swat/captain,
-/obj/item/tank/jetpack/oxygen/captain,
-/obj/item/clothing/mask/gas/atmos/captain,
 /obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/gas/atmos/captain,
+/obj/item/mod/control/pre_equipped/magnate,
+/obj/item/tank/jetpack/oxygen/captain,
 /turf/open/floor/carpet/royalblue,
 /area/ship/general/command_crew)
 "QK" = (
@@ -7029,6 +7028,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "RX" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_darect.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_darect.dmm
@@ -221,6 +221,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "em" = (
@@ -345,13 +346,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/directional/east,
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/suit/space/hardsuit/security{
-	slowdown = 0.2
-	},
 /obj/effect/turf_decal/trimline/opaque/vired/filled/arrow_ccw{
 	dir = 4
 	},
+/obj/item/clothing/mask/gas/vigilitas,
+/obj/item/mod/control/pre_equipped/security,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "gb" = (
@@ -403,10 +402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/trash/pistachios{
-	pixel_x = -10;
-	pixel_y = -5
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "gS" = (
@@ -708,6 +704,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/pistachios{
+	pixel_x = -10;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "mz" = (
@@ -1338,7 +1338,6 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
 	req_access_txt = "10";
@@ -1457,15 +1456,11 @@
 	dir = 5
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/tank/internals/oxygen,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/suit/space/hardsuit/security/hos{
-	slowdown = 0;
-	desc = "A special bulky suit that protects against hazardous, low pressure environments. Has an additional layer of armor. This one seems to be modified with advanced servos and lightweight materials."
-	},
+/obj/item/mod/control/pre_equipped/safeguard,
 /turf/open/floor/wood,
 /area/ship/bridge)
 "zF" = (
@@ -1598,13 +1593,11 @@
 	pixel_x = 32
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/suit/space/hardsuit/security{
-	slowdown = 0.2
-	},
 /obj/effect/turf_decal/trimline/opaque/vired/filled/arrow_ccw{
 	dir = 4
 	},
+/obj/item/clothing/mask/gas/vigilitas,
+/obj/item/mod/control/pre_equipped/security,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "BG" = (
@@ -1659,12 +1652,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security/armory)
-"CA" = (
-/obj/structure/sign/poster/contraband/ntos{
-	pixel_y = 32
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/hallway/central)
 "Ds" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -2182,6 +2169,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/blue/diagonal,
+/obj/structure/sign/poster/contraband/ntos{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/medical)
 "Ld" = (
@@ -2352,6 +2342,9 @@
 /obj/effect/turf_decal/trimline/opaque/vired/filled/arrow_ccw{
 	dir = 8
 	},
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ok" = (
@@ -3143,7 +3136,7 @@ Uy
 BE
 fX
 Fz
-CA
+Gf
 mW
 FD
 tt

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_gecko.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_gecko.dmm
@@ -174,11 +174,10 @@
 "bK" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/engine,
-/obj/item/tank/jetpack/carbondioxide,
 /obj/effect/turf_decal/spline/fancy/opaque/nakamuraayellow{
 	dir = 9
 	},
+/obj/item/mod/control/pre_equipped/atmospheric,
 /turf/open/floor/plasteel/patterned,
 /area/ship/storage{
 	name = "Storage And Science Bay"
@@ -2095,10 +2094,9 @@
 /area/ship/cargo/starboard)
 "zE" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/engine/elite,
-/obj/item/clothing/mask/gas/atmos,
-/obj/item/tank/jetpack/void,
 /obj/effect/turf_decal/spline/fancy/opaque/ntblue,
+/obj/item/clothing/mask/gas/atmos,
+/obj/item/mod/control/pre_equipped/advanced,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm/captain)
 "zM" = (
@@ -4147,11 +4145,10 @@
 	dir = 5
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/engine,
-/obj/item/tank/jetpack/carbondioxide,
 /obj/effect/turf_decal/spline/fancy/opaque/nakamuraayellow{
 	dir = 8
 	},
+/obj/item/mod/control/pre_equipped/atmospheric,
 /turf/open/floor/plasteel/patterned,
 /area/ship/storage{
 	name = "Storage And Science Bay"

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
@@ -1292,12 +1292,12 @@
 	dir = 2;
 	color = "#332521"
 	},
-/obj/item/tank/jetpack,
-/obj/item/clothing/mask/gas/atmos/captain,
-/obj/item/clothing/suit/space/hardsuit/swat/captain,
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
 	},
+/obj/item/clothing/mask/gas/atmos/captain,
+/obj/item/mod/control/pre_equipped/magnate,
+/obj/item/tank/jetpack/oxygen/captain,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm/captain)
 "dR" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -573,12 +573,12 @@
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/tank/internals/emergency_oxygen,
 /obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 1
 	},
-/obj/item/clothing/suit/space/hardsuit/ert/lp/jani,
 /obj/item/clothing/mask/gas,
+/obj/item/mod/control/pre_equipped/responsory/janitor,
+/obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "eY" = (
@@ -1423,12 +1423,10 @@
 /obj/effect/turf_decal/corner/opaque/blue/half{
 	dir = 1
 	},
-/obj/item/tank/jetpack/oxygen,
-/obj/item/clothing/suit/space/hardsuit/ert/lp/med{
-	slowdown = 0.3
-	},
-/obj/item/clothing/mask/breath/medical,
 /obj/machinery/light/dim/directional/north,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/mod/control/pre_equipped/responsory/medic,
+/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "lB" = (
@@ -3408,9 +3406,9 @@
 /obj/effect/turf_decal/corner/opaque/ntblue/half{
 	dir = 1
 	},
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/suit/space/hardsuit/ert/lp,
 /obj/item/clothing/mask/gas/sechailer/swat,
+/obj/item/mod/control/pre_equipped/responsory/commander,
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "Eh" = (
@@ -3827,9 +3825,9 @@
 /obj/effect/turf_decal/corner/opaque/vired/half{
 	dir = 1
 	},
-/obj/item/tank/jetpack/oxygen/security,
-/obj/item/clothing/suit/space/hardsuit/ert/lp/sec,
 /obj/item/clothing/mask/gas/vigilitas,
+/obj/item/mod/control/pre_equipped/responsory/security,
+/obj/item/tank/jetpack/oxygen/security,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "IC" = (
@@ -4887,9 +4885,9 @@
 /obj/effect/turf_decal/corner/opaque/orange/half{
 	dir = 1
 	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/suit/space/hardsuit/ert/lp/engi,
 /obj/item/clothing/mask/gas/atmos,
+/obj/item/mod/control/pre_equipped/responsory/engineer,
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
 "TR" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_savior.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_savior.dmm
@@ -3770,7 +3770,10 @@
 "VH" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/suit_storage_unit/cmo,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/mod/control/pre_equipped/rescue,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "VL" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -630,7 +630,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/rechargefloor,
-/obj/item/mecha_parts/chassis/ripley,
+/obj/item/mecha_parts/chassis/ripley{
+	layer = 3.09
+	},
 /obj/item/mecha_parts/part/ripley_left_arm{
 	pixel_x = -10;
 	pixel_y = 2
@@ -933,7 +935,8 @@
 /area/ship/engineering)
 "fe" = (
 /obj/machinery/porta_turret/ship/nt/light{
-	dir = 10
+	dir = 10;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
@@ -1035,8 +1038,8 @@
 /area/ship/medical)
 "ge" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/hardsuit/rd,
 /obj/item/clothing/mask/gas/atmos,
+/obj/item/mod/control/pre_equipped/research,
 /obj/item/tank/jetpack/oxygen,
 /turf/open/floor/carpet/purple,
 /area/ship/general/command_crew/rd)
@@ -1084,13 +1087,16 @@
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
 /obj/item/mecha_parts/mecha_equipment/salvage_saw{
 	pixel_x = 0;
-	pixel_y = -2
+	pixel_y = -2;
+	layer = 3.09
 	},
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/mecha_kineticgun{
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/item/mecha_parts/mecha_equipment/conversion_kit/ripley/nanotrasen,
+/obj/item/mecha_parts/mecha_equipment/conversion_kit/ripley/nanotrasen{
+	layer = 3.1
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "gn" = (
@@ -1290,7 +1296,7 @@
 "ij" = (
 /obj/machinery/porta_turret/ship/nt/light{
 	dir = 5;
-	id = "meta_turrets"
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/external/dark)
@@ -1427,7 +1433,8 @@
 /area/ship/hallway/port)
 "jY" = (
 /obj/machinery/porta_turret/ship/nt/light{
-	dir = 9
+	dir = 9;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
@@ -1495,7 +1502,8 @@
 /area/ship/cargo/port)
 "lv" = (
 /obj/machinery/porta_turret/ship/nt{
-	dir = 5
+	dir = 5;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/general/command_crew)
@@ -1690,14 +1698,11 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "og" = (
-/obj/machinery/computer/upload/ai{
-	dir = 1;
-	density = 0
-	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/tech,
 /area/ship/science/ai_chamber)
 "oh" = (
@@ -1940,6 +1945,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/camera{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "rs" = (
@@ -2269,7 +2277,8 @@
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/turretid/ship{
 	pixel_x = -30;
-	pixel_y = 2
+	pixel_y = 2;
+	id = "squab_turrets"
 	},
 /obj/machinery/camera{
 	dir = 4
@@ -2374,7 +2383,8 @@
 /area/ship/cargo)
 "xB" = (
 /obj/machinery/porta_turret/ship/nt{
-	dir = 9
+	dir = 9;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/cryo)
@@ -2474,7 +2484,8 @@
 /area/ship/bridge)
 "yC" = (
 /obj/machinery/porta_turret/ship/nt{
-	dir = 10
+	dir = 10;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/security)
@@ -3860,7 +3871,8 @@
 /area/ship/crew)
 "RQ" = (
 /obj/machinery/porta_turret/ship/nt{
-	dir = 6
+	dir = 6;
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/general/command_crew/rd)
@@ -3992,7 +4004,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/camera,
 /obj/structure/closet/secure_closet/wall/directional/north{
 	icon_state = "sec_wall";
 	req_access_txt = "2";
@@ -4499,7 +4510,7 @@
 "YO" = (
 /obj/machinery/porta_turret/ship/nt/light{
 	dir = 6;
-	id = "meta_turrets"
+	id = "squab_turrets"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/external/dark)
@@ -5262,7 +5273,7 @@ rs
 rs
 rs
 lv
-eU
+Ba
 GM
 Kh
 Ba
@@ -5277,7 +5288,7 @@ hk
 Nm
 yp
 AP
-cC
+Nm
 RQ
 rs
 "}

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_hyena.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_hyena.dmm
@@ -1699,7 +1699,7 @@
 	pixel_x = -20
 	},
 /obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/suit/space/hardsuit/syndi/ngr,
+/obj/item/mod/control/pre_equipped/nuclear,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "Ck" = (
@@ -2247,10 +2247,8 @@
 	name = "foreman's suit storage unit";
 	req_access = list(56)
 	},
-/obj/item/clothing/shoes/magboots/syndie,
 /obj/item/clothing/mask/gas/syndicate,
-/obj/item/clothing/suit/space/syndicate,
-/obj/item/clothing/head/helmet/space/syndicate,
+/obj/item/mod/control/pre_equipped/loader,
 /turf/open/floor/carpet/red,
 /area/ship/cargo/office)
 "KX" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_kau_delta.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_kau_delta.dmm
@@ -130,7 +130,7 @@
 /obj/item/tank/jetpack/oxygen/security{
 	name = "Suspicious looking jetpack (oxygen)"
 	},
-/obj/item/clothing/suit/space/hardsuit/syndi/ngr,
+/obj/item/mod/control/pre_equipped/traitor,
 /turf/open/floor/carpet/red_gold,
 /area/ship/bridge)
 "dg" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_krait.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_krait.dmm
@@ -565,6 +565,14 @@
 "eA" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/industrial/traffic/full,
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = -4;
+	pixel_y = 5
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "eJ" = (
@@ -3963,9 +3971,8 @@
 "Ih" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/industrial/traffic/full,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/suit/space/hardsuit/syndi,
 /obj/machinery/light/directional/north,
+/obj/item/mod/control/pre_equipped/traitor,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "Ij" = (
@@ -5496,8 +5503,7 @@
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/effect/turf_decal/industrial/traffic/full,
 /obj/machinery/firealarm/directional/north,
-/obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/mod/control/pre_equipped/traitor,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "Xs" = (


### PR DESCRIPTION
## Описание / Что этот PR делает

ПР частично добавляют модсьюты на мету, скваб, геко, сейвиор, целестис, дарект, рейнджер, крейт, кау дельту, гиену, алон и немо!

## Причина создания ПР / Почему это хорошо для игры

Добавляем моды для которых квинал, ерринг и читука парились на некоторые шипы, даем игрокам их потрогать.
## Демонстрация изменений / Тестирование

На некоторые фракционных и не очень шипах лежат модсьюты. Вау.

## Список изменений

:cl:
add: Теперь модсьюты лежат на некоторых кораблях НТ, синдиката и независимых.
/:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
