### PR TITLE
squab fix lol

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -206,6 +206,7 @@
 "aW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer4,
+/obj/effect/turf_decal/ntspaceworks_small,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "aZ" = (
@@ -244,13 +245,15 @@
 	pixel_y = 8;
 	pixel_x = -6
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "bi" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
 	dir = 1
 	},
-/obj/machinery/drill,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "bk" = (
@@ -445,9 +448,8 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/port)
 "cr" = (
@@ -514,10 +516,6 @@
 "cD" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
-	},
-/obj/structure/sign/poster/nanotrasen/nakamura_advtools{
-	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/shower{
@@ -734,21 +732,7 @@
 "dU" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/line,
-/obj/structure/closet/crate{
-	name = "materials crate"
-	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/twenty,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/multitool,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "dV" = (
@@ -851,9 +835,6 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/patterned,
@@ -941,7 +922,24 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
 "fm" = (
-/turf/closed/wall/mineral/titanium,
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 10;
+	layer = 4.1
+	},
+/obj/structure/closet/crate/secure/exo,
+/obj/item/pinpointer/mineral,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/survivalcapsule,
+/obj/item/survivalcapsule,
+/obj/item/borg/upgrade/modkit/cooldown,
+/obj/item/borg/upgrade/modkit/cooldown,
+/obj/item/borg/upgrade/modkit/range,
+/obj/item/borg/upgrade/modkit/range,
+/turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "fs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -1113,9 +1111,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "delta2conv"
-	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "gu" = (
@@ -1163,7 +1158,6 @@
 /turf/open/floor/wood,
 /area/ship/general/command_crew)
 "gQ" = (
-/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/engineering)
@@ -1291,6 +1285,9 @@
 	pixel_y = 11
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "ij" = (
@@ -1400,15 +1397,12 @@
 /area/ship/crew/cryo)
 "jC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/ntspaceworks_small/right,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "jQ" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
@@ -1594,7 +1588,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "mz" = (
-/obj/effect/turf_decal/ntspaceworks_small,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer4{
 	dir = 10
 	},
@@ -1605,6 +1598,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "mF" = (
@@ -1659,9 +1655,8 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/end{
 	dir = 4
 	},
-/obj/machinery/mineral/unloading_machine{
-	input_dir = 2;
-	output_dir = 1
+/obj/machinery/mineral/ore_redemption{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
@@ -1755,6 +1750,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "pi" = (
@@ -1797,6 +1795,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "pH" = (
@@ -1845,7 +1846,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/ntspaceworks_small/left,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "ql" = (
@@ -1995,7 +1996,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -2003,6 +2003,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "so" = (
@@ -2253,7 +2256,14 @@
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "vT" = (
-/turf/closed/wall/mineral/titanium,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/science)
 "wh" = (
 /obj/structure/table/reinforced,
@@ -2508,13 +2518,11 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "zd" = (
@@ -2816,16 +2824,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/structure/closet/crate/secure/exo,
-/obj/item/borg/upgrade/modkit/range,
-/obj/item/borg/upgrade/modkit/range,
-/obj/item/borg/upgrade/modkit/cooldown,
-/obj/item/borg/upgrade/modkit/cooldown,
-/obj/item/survivalcapsule,
-/obj/item/survivalcapsule,
-/obj/item/gps/mining,
-/obj/item/gps/mining,
-/obj/item/pinpointer/mineral,
+/obj/machinery/drill,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "BK" = (
@@ -2963,6 +2962,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "DZ" = (
@@ -3037,6 +3039,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset/wall/directional/north,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Fx" = (
@@ -3128,7 +3133,6 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/port)
 "Ha" = (
-/obj/effect/turf_decal/ntspaceworks_small/left,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
@@ -3189,7 +3193,7 @@
 "HP" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/line,
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "Ib" = (
@@ -3216,6 +3220,7 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "ID" = (
@@ -3271,6 +3276,7 @@
 	pixel_x = -1;
 	pixel_y = -4
 	},
+/obj/item/book/fish_catalog,
 /turf/open/floor/wood,
 /area/ship/general/command_crew)
 "Jc" = (
@@ -3322,6 +3328,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/sign/poster/nanotrasen/nakamura_advtools{
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
@@ -3440,6 +3450,12 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering)
+"Lu" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/line,
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
 "LD" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
@@ -3602,9 +3618,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -3617,6 +3630,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "Oe" = (
@@ -3674,10 +3688,6 @@
 /obj/effect/turf_decal/spline/fancy/opaque/nsorange,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/mineral/processing_unit_console{
-	pixel_x = 0;
-	pixel_y = 30
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
@@ -4076,6 +4086,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/item/fish_feed{
+	pixel_x = -1;
+	pixel_y = 17
+	},
 /turf/open/floor/wood,
 /area/ship/general/command_crew)
 "TL" = (
@@ -4090,6 +4104,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
 "Ug" = (
@@ -4125,14 +4140,28 @@
 /turf/open/floor/carpet/orange,
 /area/ship/general/command_crew)
 "Ur" = (
+/obj/structure/closet/crate{
+	name = "materials crate"
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/multitool,
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
+	dir = 6
+	},
 /obj/structure/railing{
 	dir = 6;
 	layer = 4.1
 	},
-/obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
-	dir = 6
-	},
-/obj/machinery/mineral/processing_unit,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "UP" = (
@@ -4164,6 +4193,16 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
+"Vz" = (
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/cargo/port)
 "VF" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -4236,10 +4275,6 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/corner,
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
 	dir = 1
-	},
-/obj/machinery/conveyor/inverted{
-	dir = 5;
-	id = "delta2conv"
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
@@ -4379,7 +4414,7 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/filled/line{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "Ya" = (
@@ -4410,8 +4445,11 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/port)
 "Yj" = (
-/obj/effect/turf_decal/ntspaceworks_small/right,
 /obj/machinery/camera,
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Yq" = (
@@ -4521,6 +4559,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
@@ -5026,7 +5067,7 @@ Va
 iW
 JB
 ta
-mt
+Lu
 aN
 fC
 GL
@@ -5185,7 +5226,7 @@ nE
 ht
 rI
 Ba
-AM
+Vz
 nc
 YA
 hF


### PR DESCRIPTION
## ПР НЕ МЕРЖИТЬ, ДО МЕРЖА С АЛЬФОЙ, ЕГО БЫ В ТМ

### ПР добавляет на скваб автолат и гравген, меняет печку на стандартную, меняет речарджер в коридоре на второй киборг речарджер, протягивает кабель до одного из АПЦ и чуточку перемещает лут внутри корабля.

## Причина создания ПР / Почему это хорошо для игры

Это фикс ишшуя который никто даже на гит не залил...
https://discord.com/channels/1100198143456465067/1339321323620663296/1339321323620663296

<details>
<summary>Скриншоты/Видео с изменениями</summary>
Карта теперь выглядит так:

![image](https://github.com/user-attachments/assets/86de3ae3-c57f-436c-bbc9-e223d7ed3190)

</details>

## Список изменений

:cl:
tweak: На Squab-class поставили автолат и гравген, стандартную печку, речарджер в коридоре сменили на второй киборг речарджер, протянули кабель до одного из АПЦ и чуточку переместили лут внутри корабля.
/:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.

