### PR TITLE
Pirate announce fix

### DIFF
--- a/code/modules/overmap/objects/outpost/outpost.dm
+++ b/code/modules/overmap/objects/outpost/outpost.dm
@@ -239,9 +239,9 @@
 	var/obj/docking_port/stationary/h_dock
 	var/datum/map_template/outpost/h_template = get_hangar_template(dock_requester.shuttle_port)
 
-	// [CELADON-ADD] - CELADON_COMPONENT - Pirates Update - NEEDS_TO_FIX_ALARM!
+	// [CELADON-ADD] - CELADON_COMPONENT - Pirates Update
 	if(dock_requester.source_template.category == "Pirates") //Проверка шипа на пиратскую фракцию
-		return new /datum/docking_ticket(_docking_error = "Неавторизованным лицам отказано в стыковке с аванпостом.") //Запрет пиратам на стыковку с аванпостом
+		return new /datum/docking_ticket(_docking_error = "Docking request denied: Unauthorized ship") //Запрет пиратам на стыковку с аванпостом
 	// [/CELADON-ADD]
 
 	if(src in dock_requester.blacklisted)

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -160,16 +160,23 @@
 #endif
 	SSovermap.controlled_ships += src
 	current_overmap.controlled_ships += src
-	// [CELADON-ADD] - CELADON_COMPONENT - Добавляем оповещении о пиратах - NEEDS_TO_FIX_ALARM!
-	// if(get_faction() == "Pirates") //Проверка шипа на принадлежность к пиратской фракции
-	// 	radio = new(src.token)
-	// 	radio.name = "Outpost Security System" //Имя, что показывается в вайдбанде
-	// 	radio.talk_into(radio, "На датчиках дальнего действия обнаружена неавторизированная деятельность! Всем кораблям быть в боевой готовности!", FREQ_WIDEBAND) //Сообщение и путь в вайдбанд
-	// 	qdel(radio)
+
+	// [CELADON-ADD] - CELADON_COMPONENT - Добавляем оповещении о пиратах
+	if(istype(get_faction(), /datum/faction/pirate))
+		var/datum/overmap/outpost/outpost = SSovermap.outposts[1]
+		if(outpost)
+			if(!outpost.radio)
+				outpost.radio = new(outpost.token)
+			outpost.radio.name = "Outpost Security System"
+			var/T = rand(180,360) SECONDS //3-5mins
+			addtimer(CALLBACK(outpost.radio, TYPE_PROC_REF(/obj/item, talk_into), outpost.radio, "На датчиках дальнего действия обнаружен неавторизированный корабль. Всем кораблям рекомендуется быть в боевой готовности.", FREQ_WIDEBAND), T)
+
+/datum/overmap/outpost // Это тут потому-что если верхнее перепишется, то нижнее тоже. Срать вечно 🤙
+	var/obj/item/radio/intercom/wideband/radio
 	// [/CELADON-ADD]
 
-// /datum/overmap/ship/controlled/proc/get_faction() - NEEDS_TO_FIX_ALARM!
-// 	return source_template.faction_name
+/datum/overmap/ship/controlled/proc/get_faction()
+	return source_template.faction
 
 /datum/overmap/ship/controlled/Destroy()
 	//SHOULD be called first


### PR DESCRIPTION
Чиним поломку анонса спавна пиратов и делаём её с делеем в 3-5 минут, потому-что логика обнаружения и чтобы пираты подышали.
А также теперь оповещение идёт с аванпоста, а не с корабля.