### PR TITLE
Outpost collision protection

### DIFF
--- a/code/controllers/subsystem/overmap_move.dm
+++ b/code/controllers/subsystem/overmap_move.dm
@@ -67,7 +67,7 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 						var/obj/machinery/computer/helm/a = A.helms[arpdequeue_pointer]
 						a.say("Proximity alarm! Possible collision situation.")
 						playsound(a, 'sound/machines/engine_alert1.ogg', 50, FALSE)
-			if((if(get_pixel_distance(A.token, outpost.token)>32 && get_pixel_distance(B.token, outpost.token)>32)) && get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0)) // Thurther than that is full colision
+			if((get_pixel_distance(A.token, outpost.token)>32 && get_pixel_distance(B.token, outpost.token)>32) && get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0)) // Thurther than that is full colision
 				var/arpdequeue_pointer = 0
 				if(world.time - A.last_collision_alert >= 20)
 					A.last_collision_alert = world.time

--- a/code/controllers/subsystem/overmap_move.dm
+++ b/code/controllers/subsystem/overmap_move.dm
@@ -56,9 +56,10 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 	else
 		tcpa = max(tcpa_by_x, tcpa_by_y)
 
+	var/datum/overmap/outpost/outpost = SSovermap.outposts[1]
 	if(!info)
 		if(cpa != -1 && tcpa != -1)
-			if(tcpa/SSovermap_stuff.wait <= 5 && cpa <= 8)
+			if((get_pixel_distance(A.token, outpost.token)>16 && get_pixel_distance(B.token, outpost.token)>16) && tcpa/SSovermap_stuff.wait <= 5 && cpa <= 8) // Tile of outpost of full colision protection. Half of tile around outpost of prox warning procs.
 				var/arpdequeue_pointer = 0
 				if(world.time - A.last_proximity_alert >= 20)
 					A.last_proximity_alert = world.time
@@ -66,7 +67,7 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 						var/obj/machinery/computer/helm/a = A.helms[arpdequeue_pointer]
 						a.say("Proximity alarm! Possible collision situation.")
 						playsound(a, 'sound/machines/engine_alert1.ogg', 50, FALSE)
-			if(get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0))
+			if((if(get_pixel_distance(A.token, outpost.token)>32 && get_pixel_distance(B.token, outpost.token)>32)) && get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0)) // Thurther than that is full colision
 				var/arpdequeue_pointer = 0
 				if(world.time - A.last_collision_alert >= 20)
 					A.last_collision_alert = world.time

--- a/code/controllers/subsystem/overmap_move.dm
+++ b/code/controllers/subsystem/overmap_move.dm
@@ -59,7 +59,9 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 	var/datum/overmap/outpost/outpost = SSovermap.outposts[1]
 	if(!info)
 		if(cpa != -1 && tcpa != -1)
+			// [CELADON-EDIT] - Outpost collision protection - if(tcpa/SSovermap_stuff.wait <= 5 && cpa <= 8)
 			if((get_pixel_distance(A.token, outpost.token)>16 && get_pixel_distance(B.token, outpost.token)>16) && tcpa/SSovermap_stuff.wait <= 5 && cpa <= 8) // Tile of outpost of full colision protection. Half of tile around outpost of prox warning procs.
+			// [/CELADON-EDIT]
 				var/arpdequeue_pointer = 0
 				if(world.time - A.last_proximity_alert >= 20)
 					A.last_proximity_alert = world.time
@@ -67,7 +69,9 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 						var/obj/machinery/computer/helm/a = A.helms[arpdequeue_pointer]
 						a.say("Proximity alarm! Possible collision situation.")
 						playsound(a, 'sound/machines/engine_alert1.ogg', 50, FALSE)
+			// [CELADON-EDIT] - Outpost collision protection - if(get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0))
 			if((get_pixel_distance(A.token, outpost.token)>32 && get_pixel_distance(B.token, outpost.token)>32) && get_pixel_distance(A.token, B.token) <= 4 && cpa != -1 && (A.get_speed() != 0 || B.get_speed() != 0)) // Thurther than that is full colision
+			// [/CELADON-EDIT]
 				var/arpdequeue_pointer = 0
 				if(world.time - A.last_collision_alert >= 20)
 					A.last_collision_alert = world.time


### PR DESCRIPTION
Полная защита от коллизии кораблей в тайле аванпоста. В пределах половины следующего тайла будут предупреждения о коллизии, но самого столкновения не будет. После этого включены разрушающие столкновения.