### PR TITLE
TWEAK: Remember our Language

### DIFF
--- a/mod_celadon/items/code/languages.dm
+++ b/mod_celadon/items/code/languages.dm
@@ -87,3 +87,57 @@
 	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
 								/datum/language/lanius_rattle = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/lanius_rattle = list(LANGUAGE_ATOM))
+
+/datum/language_holder/human
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/solarian_international = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/solarian_international = list(LANGUAGE_ATOM))
+
+/datum/language_holder/jelly
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/slime = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/slime = list(LANGUAGE_ATOM))
+
+/datum/language_holder/lizard
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+
+/datum/language_holder/ipc
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/machine = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/machine = list(LANGUAGE_ATOM))
+
+/datum/language_holder/moth
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/moffic = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/moffic = list(LANGUAGE_ATOM))
+
+/datum/language_holder/ethereal
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/kalixcian_common = list(LANGUAGE_ATOM))
+
+/datum/language_holder/kepori
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/teceti_unified = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/teceti_unified = list(LANGUAGE_ATOM))
+
+/datum/language_holder/vox
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/vox_pidgin = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/vox_pidgin = list(LANGUAGE_ATOM))
+
+/datum/language_holder/spider
+	understood_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+								/datum/language/rachnidian = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/galactic_common = list(LANGUAGE_ATOM),
+							/datum/language/rachnidian = list(LANGUAGE_ATOM))


### PR DESCRIPTION
## Закрепляет знания языков за их носителями
Переопределяет знания языков в отдельный независимый мод.

### Наработки
По хорошему бы свои уникальные квирки языков независимые от рас добавить, раз уж так пошло.

## Причина создания ПР / Почему это хорошо для игры
Переделка языков на опережение, апстрим начал вырезать знания языков.
Странно что треть рас лишается языка, другая нет из-за квирков на них.

## Список изменений

:cl:
tweak: Закрепления языков за их носителями
:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
<!-- Если вы готовы, то ставьте крестик на уже готовой форме, чтобы согласиться и подтвердить готовность свою. -->
