### PR TITLE
TWEAK: Ammunition naming and fix Glock-17

### DIFF
--- a/mod_celadon/balance/code/sharplite_balance.dm
+++ b/mod_celadon/balance/code/sharplite_balance.dm
@@ -95,11 +95,11 @@
 //NT ballistics relore - MORE Vigilitas Interstellar!
 /obj/item/gun/ballistic/automatic/pistol/commander
 	name = "VI Commander"
-	desc = "A service pistol produced as Vigilitas Interstellar's standard sidearm. Has a reputation for being easy to use, due to its light recoil and high magazine capacity. Chambered in 9mm."
+	desc = "A service pistol produced as Vigilitas Interstellar's standard sidearm. Has a reputation for being easy to use, due to its light recoil and high magazine capacity. Chambered in 9x18mm."
 	manufacturer = MANUFACTURER_VIGILITAS
 
 /obj/item/gun/ballistic/automatic/pistol/commander/inteq
-	desc = "A modified version of the VI Commander, issued as standard to Inteq Risk Management Group personnel. Features the same excellent handling and high magazine capacity as the original. Chambered in 9mm."
+	desc = "A modified version of the VI Commander, issued as standard to Inteq Risk Management Group personnel. Features the same excellent handling and high magazine capacity as the original. Chambered in 9x18mm."
 
 /obj/item/gun/ballistic/automatic/smg/wt550
 	name = "\improper VI WT-550 Automatic Rifle"
@@ -107,12 +107,12 @@
 	manufacturer = MANUFACTURER_VIGILITAS
 
 /obj/item/gun/ballistic/automatic/smg/vector
-	desc = "A police carbine based on an old design originating from earth, Solar Federation. Modified by Vigilitas Interstellar and used as a common security SMG. Chambered in 9mm."
+	desc = "A police carbine based on an old design originating from earth, Solar Federation. Modified by Vigilitas Interstellar and used as a common security SMG. Chambered in 9x18mm."
 	manufacturer = MANUFACTURER_VIGILITAS
 
 /obj/item/gun/ballistic/automatic/smg/skm_carbine/saber
 	name = "\improper VI Saber SMG"
-	desc = "A full-auto 9mm submachine gun, designated 'VI SABR'. Has a threaded barrel for suppressors and a folding stock."
+	desc = "A full-auto 9x18mm submachine gun, designated 'VI SABR'. Has a threaded barrel for suppressors and a folding stock."
 	manufacturer = MANUFACTURER_VIGILITAS
 
 //Honorable mentions

--- a/mod_celadon/outpost_console/code/supply_pack/independent/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/ammo.dm
@@ -131,7 +131,7 @@ MARK: 10x22
 
 // /datum/supply_pack/faction/independent/ammo/ammoc10mmrubber_ammo_box
 // 	name = "10x22mm Rubber Ammo Box Crate"
-// 	desc = "Contains a 36-round 10mm box loaded with less-than-lethal rubber rounds."
+// 	desc = "Contains a 36-round 10x22mm box loaded with less-than-lethal rubber rounds."
 // 	contains = list(/obj/item/storage/box/ammo/c10mm_rubber)
 // 	cost = 210
 

--- a/mod_celadon/outpost_console/code/supply_pack/independent/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/gun.dm
@@ -58,7 +58,7 @@ MARK:		Pistols
 
 /datum/supply_pack/faction/independent/gun/ringneck
 	name = "Ringneck Pistol Crate"
-	desc = "Contains a civillian variant of the Ringneck pistol, produced by Scarborough Arms and chambered in 10mm."
+	desc = "Contains a civillian variant of the Ringneck pistol, produced by Scarborough Arms and chambered in 10x22mm."
 	cost = 1000
 	contains = list(/obj/item/storage/guncase/pistol/ringneck)
 
@@ -83,7 +83,7 @@ MARK:		Pistols
 
 /datum/supply_pack/faction/independent/gun/glock
 	name = "Glock Pistol Crate"
-	desc = "Contains a 9mm Glock pistol and two additional magazines for it."
+	desc = "Contains a 9x18mm Glock pistol and two additional magazines for it."
 	cost = 1300
 	contains = list(/obj/item/storage/guncase/glock)
 	crate_name = "auto rifle crate"
@@ -348,13 +348,13 @@ MARK: Pistols
 
 // /datum/supply_pack/faction/independent/gun/cm23
 // 	name = "CM-23 Pistol Crate"
-// 	desc = "Contains a 10mm CM-23 Pistol, standard issue of the Colonial Minutemen."
+// 	desc = "Contains a 10x22mm CM-23 Pistol, standard issue of the Colonial Minutemen."
 // 	cost = 1000
 // 	contains = list(/obj/item/storage/guncase/pistol/cm23)
 
 // /datum/supply_pack/faction/independent/gun/cm70
 // 	name = "CM-70 Machinepistol Crate"
-// 	desc = "Contains a 9mm machinepistol produced proudly within Lanchester City. Colonial Minuteman issue only."
+// 	desc = "Contains a 9x18mm machinepistol produced proudly within Lanchester City. Colonial Minuteman issue only."
 // 	cost = 2500
 // 	contains = list(/obj/item/storage/guncase/pistol/cm70)
 

--- a/mod_celadon/outpost_console/code/supply_pack/independent/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/magazines.dm
@@ -9,20 +9,20 @@
 
 /datum/supply_pack/faction/independent/magazine/c38_mag
 	name = ".38 Speedloader Crate"
-	desc = "Contains a .38 speedloader for revolvers, containing six rounds."
+	desc = "Contains a .38 speedloader for revolvers, containing 6 rounds."
 	contains = list(/obj/item/ammo_box/c38/empty)
 	cost = 100
 	faction_discount = 20
 
 /datum/supply_pack/faction/independent/magazine/a44roum_speedloader
 	name = ".44 Roumain Speedloader Crate"
-	desc = "Contains a .44 Roumain speedloader for the HP Montagne, with a capacity of six rounds."
+	desc = "Contains a .44 Roumain speedloader for the HP Montagne, with a capacity of 6 rounds."
 	contains = list(/obj/item/ammo_box/a44roum_speedloader/empty)
 	cost = 250
 
 /datum/supply_pack/faction/independent/magazine/a357_mag_independent
 	name = ".357 Speedloader Crate"
-	desc = "Contains a .357 speedloader for revolvers, containing six rounds."
+	desc = "Contains a .357 speedloader for revolvers, containing 6 rounds."
 	contains = list(/obj/item/ammo_box/a357/empty)
 	cost = 275
 
@@ -32,37 +32,37 @@
 
 /datum/supply_pack/faction/independent/magazine/m45_mag
 	name = ".45 ACP Candor Magazine Crate"
-	desc = "Contains a .45 ACP magazine for the Candor pistol, with a capacity of eight rounds."
+	desc = "Contains a .45 ACP magazine for the Candor pistol, with a capacity of 8 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m45/empty)
 	cost = 100
 
 /datum/supply_pack/faction/independent/magazine/m17_mag
 	name = "Micro Target Magazine Crate"
-	desc = "Contains a .22lr magazine for the Micro Target pistol, with a capacity of ten rounds."
+	desc = "Contains a .22lr magazine for the Micro Target pistol, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m17/empty)
 	cost = 100
 
 /datum/supply_pack/faction/independent/magazine/m20_auto_elite
 	name = "Auto Elite Magazine Crate"
-	desc = "Contains a .44 Roumain magazine for the Auto Elite pistol, with a capacity of nine rounds."
+	desc = "Contains a .44 Roumain magazine for the Auto Elite pistol, with a capacity of 9 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m20_auto_elite/empty)
 	cost = 250
 
 /datum/supply_pack/faction/independent/magazine/m10mm_mag
-	name = "10mm Ringneck Magazine Crate"
-	desc = "Contains a 10mm magazine for the Ringneck pistol, with a capacity of eight rounds."
+	name = "10x22mm Ringneck Magazine Crate"
+	desc = "Contains a 10x22mm magazine for the Ringneck pistol, with a capacity of 8 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m10mm_ringneck/empty)
 	cost = 350
 
 /datum/supply_pack/faction/independent/magazine/glock_magazine
 	name = "Glock Pistol Magazine Crate"
-	desc = "Contains 9mm magazine for the Glock pistol family, containing seventeen rounds."
+	desc = "Contains 9x18mm magazine for the Glock pistol family, containing 17 rounds."
 	contains = list(/obj/item/ammo_box/magazine/glock_standart/empty)
 	cost = 500
 
 /datum/supply_pack/faction/independent/magazine/usp_magazine
 	name = "USP Pistol Magazine Crate"
-	desc = "Contains .45 caliber magazine for the USP pistol, containing twelve rounds."
+	desc = "Contains .45 caliber magazine for the USP pistol, containing 12 rounds."
 	contains = list(/obj/item/ammo_box/magazine/usp45_standart/empty)
 	cost = 650
 
@@ -78,14 +78,14 @@
 
 /datum/supply_pack/faction/independent/magazine/woodsman_mag
 	name = "Woodsman Magazine Crate"
-	desc = "Contains an 8x50mmR magazine for the Woodsman Rifle, with a capacity of five rounds."
+	desc = "Contains an 8x50mmR magazine for the Woodsman Rifle, with a capacity of 5 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m23/empty)
 	cost = 200
 
 /datum/supply_pack/faction/independent/magazine/firestorm_mag
 
 	name = "Firestorm Stick Magazine Crate"
-	desc = "Contains a 24-round magazine for the Hunter's Pride Firestorm SMG."
+	desc = "Contains a .44 magazine for the Hunter's Pride Firestorm SMG, with a capacity of 24 rounds."
 	contains = list(/obj/item/ammo_box/magazine/c44_firestorm_mag/empty)
 	cost = 300
 
@@ -104,37 +104,37 @@
 
 /datum/supply_pack/faction/independent/magazine/skm_46_30
 	name = "SKM-24v Magazine Crate"
-	desc = "Contains a 4.6x30mm 30-round magazine for the SKM-24v. These rounds do okay damage with average performance against armor."
+	desc = "Contains a 4.6x30mm for the SKM-24v, with a capacity of 30 rounds. These rounds do okay damage with average performance against armor."
 	cost = 450
 	contains = list(/obj/item/ammo_box/magazine/skm_46_30/empty)
 
 /datum/supply_pack/faction/independent/magazine/woodsman_mag_extended
 	name = "Woodsman Magazine Crate"
-	desc = "Contains an 8x50mmR magazine for the Woodsman Rifle, with a capacity of ten rounds."
+	desc = "Contains an 8x50mmR magazine for the Woodsman Rifle, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m23/extended/empty)
 	cost = 500
 
 /datum/supply_pack/faction/independent/magazine/skm_ammo
 	name = "SKM Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of twenty rounds."
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of 20 rounds."
 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/empty)
 	cost = 500
 
 /datum/supply_pack/faction/independent/magazine/boomslang_mag
 	name = "6.5x57 Boomslang-90 Magazine Crate"
-	desc = "Contains a 6.5x57 CLIP magazine for the Boomslang rifle platform, with a capacity of five rounds."
+	desc = "Contains a 6.5x57 CLIP magazine for the Boomslang rifle platform, with a capacity of 5 rounds."
 	contains = list(/obj/item/ammo_box/magazine/boomslang/short/empty)
 	cost = 750
 
 /datum/supply_pack/faction/independent/magazine/firestorm_40_mag
 	name = "Firestorm Pan Magazine Crate"
-	desc = "Contains a 40-round pan magazine for the Hunter's Pride Firestorm SMG."
+	desc = "Contains a .44 pan magazine for the Hunter's Pride Firestorm SMG, with a capacity of 40 rounds."
 	contains = list(/obj/item/ammo_box/magazine/c44_firestorm_mag/pan/empty)
 	cost = 1000
 
 /datum/supply_pack/faction/independent/magazine/skm762_40_extended
 	name = "SKM Extended Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, containing fourty rounds."
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, containing 40 rounds."
 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/extended/empty)
 	cost = 2800
 
@@ -144,13 +144,13 @@
 
 /datum/supply_pack/faction/independent/magazine/a300_clip
 	name = ".300 Scout Rifle Clip Crate"
-	desc = "Contains a .300 clip for the Scout Sniper Rifle, with a capacity of five rounds."
+	desc = "Contains a .300 clip for the Scout Sniper Rifle, with a capacity of 5 rounds."
 	cost = 550
 	contains = list(/obj/item/ammo_box/a300/empty)
 
 /datum/supply_pack/faction/independent/magazine/a850r_clip
 	name = "8x50mmR Illestren Clip Crate"
-	desc = "Contains a 8x50mmR clip for the HP-Illestren, with a capacity of five rounds."
+	desc = "Contains a 8x50mmR clip for the HP-Illestren, with a capacity of 5 rounds."
 	cost = 550
 	contains = list(/obj/item/ammo_box/magazine/illestren_a850r/empty)
 
@@ -174,7 +174,7 @@
 
 // /datum/supply_pack/faction/independent/magazine/skm762_40_drum - [Balance?]
 // 	name = "SKM Drum Magazine Crate"
-// 	desc = "Contains a 7.62x40mm magazine for the SKM rifles, containing seventy-five rounds."
+// 	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of 75 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/drum/empty)
 // 	cost = 5000
 
@@ -191,41 +191,41 @@
 
 // /datum/supply_pack/faction/independent/magazine/g36_sh
 // 	name = "G36 Short Magazine Double Pack Crate"
-// 	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, containing twenty rounds each."
+// 	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 20 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/g36/sh/empty,
 // 					/obj/item/ammo_box/magazine/g36/sh/empty)
 // 	cost = 1400
 
 // /datum/supply_pack/faction/independent/magazine/g36
 // 	name = "G36 Standard Magazine Double Pack Crate"
-// 	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, containing thirty rounds each."
+// 	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 30 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/g36/empty,
 // 					/obj/item/ammo_box/magazine/g36/empty)
 // 	cost = 1950
 
 // /datum/supply_pack/faction/independent/magazine/g36_drum
 // 	name = "G36 Drum Magazine Crate"
-// 	desc = "Contains 5.56x45mm drum magazine for the G36 family rifles, containing seventy-five rounds."
+// 	desc = "Contains 5.56x45mm drum magazine for the G36 family rifles, with a capacity of 75 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/g36/drum/empty)
 // 	cost = 5000
 
 // /datum/supply_pack/faction/independent/magazine/morita_ammo_small
 // 	name = "Morita MK1 Short Magazine Double Pack Crate"
-// 	desc = "Contains two .310 caliber magazines for the Morita family rifles, containing ten rounds each."
+// 	desc = "Contains two .310 caliber magazines for the Morita family rifles, with a capacity of 10 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/morita1/small/empty,
 // 					/obj/item/ammo_box/magazine/morita1/small/empty)
 // 	cost = 2000
 
 // /datum/supply_pack/faction/independent/magazine/morita_ammo
 // 	name = "Morita MK1 Standard Magazine Double Pack Crate"
-// 	desc = "Contains two .310 caliber magazines for the Morita family rifles, containing twenty-five rounds each."
+// 	desc = "Contains two .310 caliber magazines for the Morita family rifles, with a capacity of 25 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/morita1/empty,
 // 					/obj/item/ammo_box/magazine/morita1/empty)
 // 	cost = 4000
 
 // /datum/supply_pack/faction/independent/magazine/morita_ammo_drum
 // 	name = "Morita MK1 Drum Magazine Crate"
-// 	desc = "Contains .310 caliber drum magazine for the Morita family rifles, containing fifty rounds."
+// 	desc = "Contains .310 caliber drum magazine for the Morita family rifles, with a capacity of 50 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/morita1/drum/empty)
 // 	cost = 5000
 
@@ -233,20 +233,20 @@
 
 // /datum/supply_pack/faction/independent/magazine/a410_saiga
 // 	name = "Saiga-410 Short Magazine Double Pack Crate"
-// 	desc = "Contains two .410 caliber short magazines for the Saiga-410 shotgun, containing six rounds each."
+// 	desc = "Contains two .410 caliber short magazines for the Saiga-410 shotgun, containing 6 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/saiga/empty,
 // 					/obj/item/ammo_box/magazine/saiga/empty)
 // 	cost = 1800
 
 // /datum/supply_pack/faction/independent/magazine/a410_saiga_medium
 //     name = "Saiga-410 Standard Magazine Crate"
-//     desc = "Contains .410 caliber magazine for the Saiga-410 shotgun, containing nine rounds."
+//     desc = "Contains .410 caliber magazine for the Saiga-410 shotgun, containing 9 rounds."
 //     contains = list(/obj/item/ammo_box/magazine/saiga/medium/empty)
 //     cost = 2800
 
 // /datum/supply_pack/faction/independent/magazine/a410_saiga_drum
 //     name = "Saiga-410 Drum Magazine Crate"
-//     desc = "Contains .410 caliber drum magazine for the Saiga-410 shotgun, containing fourteen rounds."
+//     desc = "Contains .410 caliber drum magazine for the Saiga-410 shotgun, containing 14 rounds."
 //     contains = list (/obj/item/ammo_box/magazine/saiga/drum/empty)
 //     cost = 5000
 
@@ -256,43 +256,43 @@
 
 // /datum/supply_pack/faction/independent/magazine/cm23_mag
 // 	name = "CM-23 Magazine Crate"
-// 	desc = "Contains a 10mm magazine for the CM-23 handgun with a capacity of 10 rounds."
+// 	desc = "Contains a 10x22mm magazine for the CM-23 handgun, with a capacity of 10 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/cm23/empty)
 // 	cost = 150
 
 // /datum/supply_pack/faction/independent/magazine/cm70_mag
 // 	name = "CM-70 Magazine Crate"
-// 	desc = "Contains a 9mm magazine for the CM-70 machinepistol."
+// 	desc = "Contains a 9x18mm magazine for the CM-70 machinepistol, with a capacity of 18 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/m9mm_cm70/empty)
 // 	cost = 350
 
 // /datum/supply_pack/faction/independent/magazine/cm357_mag
 // 	name = "CM-357 Magazine Crate"
-// 	desc = "Contains a .357 magazine for the CM-357 automag pistol with a capacity of 7 rounds."
+// 	desc = "Contains a .357 magazine for the CM-357 automag pistol, with a capacity of 7 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/cm357/empty)
 // 	cost = 250
 
 // /datum/supply_pack/faction/independent/magazine/cm5_mag
 // 	name = "CM-5 Magazine Crate"
-// 	desc = "Contains a 9mm magazine for the CM-5 SMG with a capacity of 30 rounds."
+// 	desc = "Contains a 9x18mm magazine for the CM-5 SMG, with a capacity of 30 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/cm5_9mm/empty)
 // 	cost = 300
 
 // /datum/supply_pack/faction/independent/magazine/cm82_mag
 // 	name = "CM-82 Magazine Crate"
-// 	desc = "Contains a 5.56mm magazine for the CM-82 rifle, with a capacity of thirty rounds."
+// 	desc = "Contains a 5.56mm magazine for the CM-82 rifle, with a capacity of 30 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/p16/empty)
 // 	cost = 500
 
 // /datum/supply_pack/faction/independent/magazine/f4_mag
 // 	name = "F4 Magazine Crate"
-// 	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, with a capacity of ten rounds."
+// 	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, with a capacity of 10 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/f4_308/empty)
 // 	cost = 500
 
 // /datum/supply_pack/faction/independent/magazine/f90
 // 	name = "CM-F90 Magazine Crate"
-// 	desc = "Contains a 5-round 6.5mm magazine for use with the CM-F90 sniper rifle."
+// 	desc = "Contains a 6.5mm magazine for use with the CM-F90 sniper rifle, with a capacity of 5 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/f90/empty)
 // 	cost = 750
 
@@ -304,7 +304,7 @@
 
 // /datum/supply_pack/faction/independent/magazine/cm40
 // 	name = "CM-40 Magazine Crate"
-// 	desc = "Contains an 80-round 7.62x40mm CLIP box for the CM-40 Squad Automatic Weapon. Consider designating an ammo bearer."
+// 	desc = "Contains a 7.62x40mm CLIP box for the CM-40 Squad Automatic Weapon. Consider designating an ammo bearer, with a capacity of 80 rounds."
 // 	contains = list(/obj/item/ammo_box/magazine/cm40_762_40_box/empty)
 // 	cost = 1000
 

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
@@ -5,8 +5,8 @@
 [*] - отсутствуют.
 [-] - отключены.
 
-> 9mm
-> 10mm
+> 9x18mm
+> 10x22mm
 > .44 Roumain
 > .357
 > 12 Gauge
@@ -14,58 +14,58 @@
 > .308
 > 5.56x45mm
 
-MARK: 9mm
+MARK: 9x18mm
 */
 
 /datum/supply_pack/faction/inteq/ammo/c9mm_ammo_box
-	name = "9mm Ammo Box Crate"
-	desc = "9mm ammo box for guns like the commander. Contains 45 shells"
+	name = "9x18mm Ammo Box Crate"
+	desc = "9x18mm ammo box for guns like the commander. Contains 45 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm)
 	cost = 200
 
 /datum/supply_pack/faction/inteq/ammo/c9mmap_ammo_box
-	name = "9mm AP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with armor piercing ammo."
+	name = "9x18mm AP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c9mm_ap)
 	cost = 250
 
 /datum/supply_pack/faction/inteq/ammo/c9mmhp_ammo_box
-	name = "9mm HP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with hollow point ammo, great against unarmored targets."
+	name = "9x18mm HP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c9mm_hp)
 	cost = 250
 
 /datum/supply_pack/faction/inteq/ammo/c9mmrubber_ammo_box
-	name = "9mm Rubber Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with less-than-lethal rubber rounds."
+	name = "9x18mm Rubber Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c9mm_rubber)
 	cost = 200
 
 /*
-MARK: 10mm
+MARK: 10x22mm
 */
 
 /datum/supply_pack/faction/inteq/ammo/c10mm_ammo_box
-	name = "10mm Ammo Box Crate"
-	desc = "Contains a 36-round 10mm box for SMGs like the SKM-44v Mongrel."
+	name = "10x22mm Ammo Box Crate"
+	desc = "Contains a 36-round 10x22mm box for SMGs like the SKM-44v Mongrel."
 	contains = list(/obj/item/storage/box/ammo/c10mm)
 	cost = 210
 
 /datum/supply_pack/faction/inteq/ammo/c10mmap_ammo_box
-	name = "10mm AP Ammo Box Crate"
-	desc = "Contains a 36-round 10mm box loaded with armor piercing ammo."
+	name = "10x22mm AP Ammo Box Crate"
+	desc = "Contains a 36-round 10x22mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c10mm_ap)
 	cost = 260
 
 /datum/supply_pack/faction/inteq/ammo/c10mmhp_ammo_box
-	name = "10mm HP Ammo Box Crate"
-	desc = "Contains a 36-round 10mm box loaded with hollow point ammo, great against unarmored targets."
+	name = "10x22mm HP Ammo Box Crate"
+	desc = "Contains a 36-round 10x22mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c10mm_hp)
 	cost = 260
 
 /datum/supply_pack/faction/inteq/ammo/c10mmrubber_ammo_box
-	name = "10mm Rubber Ammo Box Crate"
-	desc = "Contains a 36-round 10mm box loaded with less-than-lethal rubber rounds."
+	name = "10x22mm Rubber Ammo Box Crate"
+	desc = "Contains a 36-round 10x22mm box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c10mm_rubber)
 	cost = 210
 

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/gun.dm
@@ -23,14 +23,14 @@
 
 /datum/supply_pack/faction/inteq/gun/mongrel
 	name = "SKM-44v Mongrel SMG Crate"
-	desc = "Contains a shortened variant of the SKM rechambered to 10mm and painted in the brown-and-gold of Inteq."
+	desc = "Contains a shortened variant of the SKM rechambered to 10x22mm and painted in the brown-and-gold of Inteq."
 	cost = 3000
 	contains = list(/obj/item/storage/guncase/mongrel)
 	crate_name = "SMG crate"
 
 /datum/supply_pack/faction/inteq/gun/kingsnake
 	name = "Kingsnake Machinepistol Crate"
-	desc = "Contains an automatic machinepistol chambered in 9mm, painted in the brown-and-gold of Inteq."
+	desc = "Contains an automatic machinepistol chambered in 9x18mm, painted in the brown-and-gold of Inteq."
 	cost = 2500
 	contains = list(/obj/item/storage/guncase/kingsnake)
 	crate_name = "Machinepistol crate"

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/magazines.dm
@@ -3,43 +3,43 @@
 
 /datum/supply_pack/faction/inteq/magazine/mongrel_mag
 	name = "Mongrel Magazine Crate"
-	desc = "Contains a 10mm magazine for the SKM-44v 'Mongrel' SMG, with a capacity of twenty-four rounds."
+	desc = "Contains a 10x22mm magazine for the SKM-44v 'Mongrel' SMG, with a capacity of 24 rounds."
 	contains = list(/obj/item/ammo_box/magazine/smgm10mm/empty)
 	cost = 300
 
 /datum/supply_pack/faction/inteq/magazine/rottweiler_mag
 	name = "Rottweiler Box Magazine Crate"
-	desc = "Contains a .308 box magazine for the KM-05 'Rottweiler' LMG, with a capacity of fifty rounds."
+	desc = "Contains a .308 box magazine for the KM-05 'Rottweiler' LMG, with a capacity of 50 rounds."
 	contains = list(/obj/item/ammo_box/magazine/rottweiler_308_box/empty)
 	cost = 750
 
 /datum/supply_pack/faction/inteq/magazine/skm_ammo_extended
 	name = "SKM Extended Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of fourty rounds."
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of 40 rounds."
 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/extended/empty)
 	cost = 1250
 
 /datum/supply_pack/faction/inteq/magazine/co9mm_mag
 	name = "Commisioner pistol magazine"
-	desc = "A 12-round double-stack 9mm magazine for Commander pistols. These rounds do okay damage, but struggle against armor."
+	desc = "A 12-round double-stack 9x18mm magazine for Commander pistols. These rounds do okay damage, but struggle against armor."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 
 /datum/supply_pack/faction/inteq/magazine/m9mm_rattlesnake
 	name = "Kingsnake Magazine Crate"
-	desc = "Contains a 9mm magazine for the Kingsnake machine pistol, with a capacity of 18 rounds."
+	desc = "Contains a 9x18mm magazine for the Kingsnake machine pistol, with a capacity of 18 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m9mm_rattlesnake/empty)
 	cost = 300
 
 /datum/supply_pack/faction/inteq/magazine/m20_auto_elite
 	name = "Pinscher Magazine Crate"
-	desc = "Contains a .44 Roumain magazine for the Auto Elite pistol, with a capacity of nine rounds."
+	desc = "Contains a .44 Roumain magazine for the Auto Elite pistol, with a capacity of 9 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m20_auto_elite/empty)
 	cost = 250
 
 /datum/supply_pack/faction/inteq/magazine/a357_speedloader
 	name = ".357 Speedloader Crate"
-	desc = "Contains a .357 speedloader for revolvers, with a capacity of six rounds."
+	desc = "Contains a .357 speedloader for revolvers, with a capacity of 6 rounds."
 	contains = list(/obj/item/ammo_box/a357/empty)
 	cost = 250
 
@@ -61,13 +61,13 @@
 
 /datum/supply_pack/faction/inteq/magazine/skm_ammo
 	name = "SKM Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of twenty rounds."
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of 20 rounds."
 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/empty)
 	cost = 500
 
 /datum/supply_pack/faction/inteq/magazine/skm762_40_drum
 	name = "SKM Drum Magazine Crate"
-	desc = "Contains a 7.62x40mm magazine for the SKM rifles, containing seventy-five rounds."
+	desc = "Contains a 7.62x40mm magazine for the SKM rifles, with a capacity of 75 rounds."
 	contains = list(/obj/item/ammo_box/magazine/skm_762_40/drum/empty)
 	cost = 5000
 
@@ -75,7 +75,7 @@
 
 /datum/supply_pack/faction/inteq/magazine/f4_mag
 	name = "SsG-04 Magazine Crate"
-	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, with a capacity of ten rounds."
+	desc = "Contains a .308 magazine for SsG-04 and CM-F4 platform rifles, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/f4_308/empty)
 	cost = 500
 
@@ -83,20 +83,20 @@
 
 /datum/supply_pack/faction/inteq/magazine/g36_sh
 	name = "G36 Short Magazine Double Pack Crate"
-	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, containing twenty rounds each."
+	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 20 rounds."
 	contains = list(/obj/item/ammo_box/magazine/g36/sh/empty,
 					/obj/item/ammo_box/magazine/g36/sh/empty)
 	cost = 1400
 
 /datum/supply_pack/faction/inteq/magazine/g36
 	name = "G36 Standard Magazine Double Pack Crate"
-	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, containing thirty rounds each."
+	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 30 rounds."
 	contains = list(/obj/item/ammo_box/magazine/g36/empty,
 					/obj/item/ammo_box/magazine/g36/empty)
 	cost = 1950
 
 /datum/supply_pack/faction/inteq/magazine/g36_drum
 	name = "G36 Drum Magazine Crate"
-	desc = "Contains 5.56x45mm drum magazine for the G36 family rifles, containing seventy-five rounds."
+	desc = "Contains 5.56x45mm drum magazine for the G36 family rifles, with a capacity of 75 rounds."
 	contains = list(/obj/item/ammo_box/magazine/g36/drum/empty)
 	cost = 5000

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/ammo.dm
@@ -5,34 +5,34 @@
 [*] - отсутствуют.
 [-] - отключены.
 
-> 9mm
+> 9x18mm
 > 4.63x30mm
 > ferro pellets
 
-MARK: 9mm
+MARK: 9x18mm
 */
 
 /datum/supply_pack/faction/nanotrasen/ammo/c9mm_ammo_box
-	name = "9mm ammo box"
-	desc = "9mm ammo box for guns like the commander or the saber SMG. Contains 50 shells"
+	name = "9x18mm ammo box"
+	desc = "9x18mm ammo box for guns like the commander or the saber SMG. Contains 50 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm)
 	cost = 250
 
 /datum/supply_pack/faction/nanotrasen/ammo/c9mm_ammo_box_ap
-	name = "9mm AP ammo box"
-	desc = "9mm AP ammo box for guns like the commander or the saber SMG. Contains 50 shells"
+	name = "9x18mm AP ammo box"
+	desc = "9x18mm AP ammo box for guns like the commander or the saber SMG. Contains 50 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm_ap)
 	cost = 450
 
 /datum/supply_pack/faction/nanotrasen/ammo/c9mm_ammo_box_hp
-	name = "9mm HP ammo box"
-	desc = "9mm HP ammo box for guns like the commander or the saber SMG. Contains 50 shells"
+	name = "9x18mm HP ammo box"
+	desc = "9x18mm HP ammo box for guns like the commander or the saber SMG. Contains 50 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm_hp)
 	cost = 350
 
 /datum/supply_pack/faction/nanotrasen/ammo/c9mm_rubber
-	name = "9mm Rubber ammo box"
-	desc = "9mm Rubber ammo box for guns like the commander or the saber SMG. Contains 50 shells"
+	name = "9x18mm Rubber ammo box"
+	desc = "9x18mm Rubber ammo box for guns like the commander or the saber SMG. Contains 50 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm_rubber)
 	cost = 250
 

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/gun.dm
@@ -100,20 +100,20 @@ MARK: VI
 
 /datum/supply_pack/faction/nanotrasen/gun/commanders
 	name = "VI 'Commander' handgun"
-	desc = "Contains a double stacked Commander pistol, produced by Nanotrasen along with Vigilitas Interstellar and is chambered in 9mm."
+	desc = "Contains a double stacked Commander pistol, produced by Nanotrasen along with Vigilitas Interstellar and is chambered in 9x18mm."
 	cost = 750
 	contains = list(/obj/item/storage/guncase/pistol/commander)
 
 /datum/supply_pack/faction/nanotrasen/gun/saber
 	name = "VI Saber SMG"
-	desc = "An experimental ballistic weapon produced by Vigilitas Interstellar. Uses 9mm rounds"
+	desc = "An experimental ballistic weapon produced by Vigilitas Interstellar. Uses 9x18mm rounds"
 	cost = 2500
 	contains = list(/obj/item/storage/guncase/saber)
 	crate_name = "SMG crate"
 
 /datum/supply_pack/faction/nanotrasen/gun/vector
 	name = "VI Vector SMG"
-	desc = "Contains a Vector PDW produced by Sharplite Defense and chambered in 9mm."
+	desc = "Contains a Vector PDW produced by Sharplite Defense and chambered in 9x18mm."
 	cost = 3000
 	contains = list(/obj/item/storage/guncase/vector)
 	crate_name = "SMG crate"

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
@@ -6,20 +6,20 @@ MARK: VI
 */
 
 /datum/supply_pack/faction/nanotrasen/magazine/co9mm_mag
-	name = "9mm Commander Magazine Crate"
-	desc = "Contains a 9mm magazine for the standard-issue Commander pistol, with a capacity of twelve rounds."
+	name = "9x18mm  Commander Magazine Crate"
+	desc = "Contains a 9x18mm  magazine for the standard-issue Commander pistol, with a capacity of twelve rounds."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 
 /datum/supply_pack/faction/nanotrasen/magazine/smgm9mm_mag
-	name = "9mm SMG Magazine Crate"
-	desc = "Contains a 9mm magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
+	name = "9x18mm  SMG Magazine Crate"
+	desc = "Contains a 9x18mm  magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
 	contains = list(/obj/item/ammo_box/magazine/smgm9mm/empty)
 	cost = 250
 
 /datum/supply_pack/faction/nanotrasen/magazine/wt550_mag
 	name = "WT-550 Auto Rifle Magazine Crate"
-	desc = "Contains a 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads."
+	desc = "Contains a 9x18mm magazine for the WT-550 Auto Rifle, with a capacity of 30 rounds Each magazine is designed to facilitate rapid tactical reloads."
 	cost = 300
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/empty)
 

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/ammo.dm
@@ -5,7 +5,7 @@
 [*] - отсутствуют.
 [-] - отключены.
 
-> 9mm
+> 9x18mm
 > 5.56 Caseless
 > 5.56x42mm
 > 7.62x40mm
@@ -14,30 +14,30 @@
 > Ferro Lances
 > 8x58mm Caseless
 
-MARK: 9mm
+MARK: 9x18mm
 */
 
 /datum/supply_pack/faction/solfed/ammo/c9mm_ammo_box
-	name = "9mm Ammo Box Crate"
-	desc = "9mm ammo box for guns like the Vector. Contains 45 shells"
+	name = "9x18mm Ammo Box Crate"
+	desc = "9x18mm ammo box for guns like the Vector. Contains 45 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm)
 	cost = 200
 
 /datum/supply_pack/faction/solfed/ammo/c9mmap_ammo_box
-	name = "9mm AP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with armor piercing ammo."
+	name = "9x18mm AP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c9mm_ap)
 	cost = 250
 
 /datum/supply_pack/faction/solfed/ammo/c9mmhp_ammo_box
-	name = "9mm HP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with hollow point ammo, great against unarmored targets."
+	name = "9x18mm HP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c9mm_hp)
 	cost = 250
 
 /datum/supply_pack/faction/solfed/ammo/c9mmrubber_ammo_box
-	name = "9mm Rubber Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with less-than-lethal rubber rounds."
+	name = "9x18mm Rubber Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c9mm_rubber)
 	cost = 200
 

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/gun.dm
@@ -36,7 +36,7 @@
 
 /datum/supply_pack/faction/solfed/gun/vector
 	name = "Vector Carbine"
-	desc = "Contains a classic automatic carbine from earth, solar system. Chambered in 9mm."
+	desc = "Contains a classic automatic carbine from earth, solar system. Chambered in 9x18mm."
 	contains = list(/obj/item/storage/guncase/vector)
 	cost = 3500
 

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
@@ -3,31 +3,31 @@
 
 /datum/supply_pack/faction/solfed/magazine/mag_556mm
 	name = "5.56 Pistole C Magazine Crate"
-	desc = "Contains a 5.56mm magazine for the Pistole C, with a capacity of twelve rounds."
+	desc = "Contains a 5.56mm magazine for the Pistole C, with a capacity of 12 rounds."
 	contains = list(/obj/item/ammo_box/magazine/pistol556mm/empty)
 	cost = 150
 
 /datum/supply_pack/faction/solfed/magazine/fms_mag
 	name = "Model H Magazine Crate"
-	desc = "Contains a ferromagnetic slug magazine for the Model H pistol, with a capacity of ten rounds."
+	desc = "Contains a ferromagnetic slug magazine for the Model H pistol, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/modelh/empty)
 	cost = 350
 
 /datum/supply_pack/faction/solfed/magazine/gar_ammo
 	name = "GAR Ferromagnetic Lance Magazine Crate"
-	desc = "Contains a ferromagnetic lance magazine for the GAR rifle, with a capacity of thirty two rounds."
+	desc = "Contains a ferromagnetic lance magazine for the GAR rifle, with a capacity of 32 rounds."
 	contains = list(/obj/item/ammo_box/magazine/gar/empty)
 	cost = 500
 
 /datum/supply_pack/faction/solfed/magazine/claris_ammo
 	name = "Claris Ferromagnetic Pellet Speedloader Crate"
-	desc = "Contains a ferromagnetic pellet speedloader for the Claris rifle, with a capacity of twenty two rounds."
+	desc = "Contains a ferromagnetic pellet speedloader for the Claris rifle, with a capacity of 32 rounds."
 	contains = list(/obj/item/ammo_box/amagpellet_claris/empty)
 	cost = 400
 
 /datum/supply_pack/faction/solfed/magazine/smgm9mm_mag
-	name = "9mm SMG Magazine Crate"
-	desc = "Contains a 9mm magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
+	name = "9x18mm SMG Magazine Crate"
+	desc = "Contains a 9x18mm magazine for the Vector and Saber SMGs, with a capacity of 30 rounds."
 	contains = list(/obj/item/ammo_box/magazine/smgm9mm/empty)
 	cost = 250
 

--- a/mod_celadon/outpost_console/code/supply_pack/syndicate/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/syndicate/ammo.dm
@@ -7,8 +7,8 @@
 
 > .22lr
 > .357
-> 9mm
-> 10mm
+> 9x18mm
+> 10x22mm
 > .45
 > 5.7x39mm
 > 12 Gauge
@@ -61,52 +61,52 @@ MARK: .357
 	cost = 320
 
 /*
-MARK: 9mm
+MARK: 9x18mm
 */
 
 /datum/supply_pack/faction/syndicate/ammo/c9mm_ammo_box
-	name = "9mm Ammo Box Crate"
-	desc = "9mm ammo box for guns like the commander. Contains 45 shells"
+	name = "9x18mm Ammo Box Crate"
+	desc = "9x18mm ammo box for guns like the commander. Contains 45 shells"
 	contains = list(/obj/item/storage/box/ammo/c9mm)
 	cost = 200
 
 /datum/supply_pack/faction/syndicate/ammo/c9mmap_ammo_box
-	name = "9mm AP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with armor piercing ammo."
+	name = "9x18mm AP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with armor piercing ammo."
 	contains = list(/obj/item/storage/box/ammo/c9mm_ap)
 	cost = 250
 
 /datum/supply_pack/faction/syndicate/ammo/c9mmhp_ammo_box
-	name = "9mm HP Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with hollow point ammo, great against unarmored targets."
+	name = "9x18mm HP Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/c9mm_hp)
 	cost = 250
 
 /datum/supply_pack/faction/syndicate/ammo/c9mm_rubber
-	name = "9mm Rubber Ammo Box Crate"
-	desc = "Contains a 45-round 9mm box loaded with less-than-lethal rubber rounds."
+	name = "9x18mm Rubber Ammo Box Crate"
+	desc = "Contains a 45-round 9x18mm box loaded with less-than-lethal rubber rounds."
 	contains = list(/obj/item/storage/box/ammo/c9mm_rubber)
 	cost = 200
 
 /*
-MARK: 10mm
+MARK: 10x22mm
 */
 
 /datum/supply_pack/faction/syndicate/ammo/c10mm_ammo_box
-	name = "10mm Ammo Box Crate"
-	desc = "Contains a 10mm ammo box for guns like the Ringneck"
+	name = "10x22mm Ammo Box Crate"
+	desc = "Contains a 10x22mm ammo box for guns like the Ringneck"
 	contains = list(/obj/item/storage/box/ammo/c10mm)
 	cost = 350
 
 /datum/supply_pack/faction/syndicate/ammo/c10mm_ammo_box_ap
-	name = "10mm AP Ammo Box Crate"
-	desc = "Contains a 10mm AP ammo box for guns like the Ringneck"
+	name = "10x22mm AP Ammo Box Crate"
+	desc = "Contains a 10x22mm AP ammo box for guns like the Ringneck"
 	contains = list(/obj/item/storage/box/ammo/c10mm_ap)
 	cost = 350
 
 /datum/supply_pack/faction/syndicate/ammo/c10mm_ammo_box_hp
-	name = "10mm HP Ammo Box Crate"
-	desc = "Contains a 10mm HP ammo box for guns like the Ringneck"
+	name = "10x22mm HP Ammo Box Crate"
+	desc = "Contains a 10x22mm HP ammo box for guns like the Ringneck"
 	contains = list(/obj/item/storage/box/ammo/c10mm_hp)
 	cost = 350
 

--- a/mod_celadon/outpost_console/code/supply_pack/syndicate/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/syndicate/gun.dm
@@ -3,19 +3,19 @@
 
 /datum/supply_pack/faction/syndicate/gun/ringneck
 	name = "Ringneck Pistol Crate"
-	desc = "Contains a civilian variant of the Ringneck pistol, produced by Scarborough Arms and chambered in 10mm."
+	desc = "Contains a civilian variant of the Ringneck pistol, produced by Scarborough Arms and chambered in 10x22mm."
 	cost = 1000
 	contains = list(/obj/item/storage/guncase/pistol/ringneck)
 
 /datum/supply_pack/faction/syndicate/gun/pc76
 	name = "PC-76 'Ringneck' Pistol Crate"
-	desc = "Contains a noticably smaller military variant of the Ringneck pistol, chambered in 10mm."
+	desc = "Contains a noticably smaller military variant of the Ringneck pistol, chambered in 10x22mm."
 	cost = 1250
 	contains = list(/obj/item/storage/guncase/pistol/pc76)
 
 /datum/supply_pack/faction/syndicate/gun/asp
 	name = "BC-81 'Asp' Crate"
-	desc = "Contains a compact armor-piercing sidearm, chambered in 5.7mm"
+	desc = "Contains a compact armor-piercing sidearm, chambered in 5.7x39mm"
 	cost = 1250
 	contains = list(/obj/item/storage/guncase/pistol/asp)
 
@@ -54,14 +54,14 @@
 
 /datum/supply_pack/faction/syndicate/gun/rattlesnake
 	name = "Rattlesnake Machinepistol Crate"
-	desc = "Contains an automatic machinepistol produced by Scarborough Arms, chambered in 9mm."
+	desc = "Contains an automatic machinepistol produced by Scarborough Arms, chambered in 9x18mm."
 	cost = 2500
 	contains = list(/obj/item/storage/guncase/rattlesnake)
 	crate_name = "Machinepistol crate"
 
 /datum/supply_pack/faction/syndicate/gun/sidewinder
 	name = "Sidewinder SMG Crate"
-	desc = "Contains a Sidewinder PDW produced by Scarborough Arms and chambered in 5.7mm for armor-piercing capabilities."
+	desc = "Contains a Sidewinder PDW produced by Scarborough Arms and chambered in 5.7x39mm for armor-piercing capabilities."
 	cost = 3000
 	contains = list(/obj/item/storage/guncase/sidewinder)
 	crate_name = "SMG crate"

--- a/mod_celadon/outpost_console/code/supply_pack/syndicate/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/syndicate/magazines.dm
@@ -5,13 +5,13 @@
 
 /datum/supply_pack/faction/syndicate/magazine/himehabu_mag
 	name = "Himehabu Magazine Crate"
-	desc = "Contains a .22lr magazine for the Himehabu pistol, with a capacity of ten rounds."
+	desc = "Contains a .22lr magazine for the Himehabu pistol, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m22lr_himehabu/empty)
 	cost = 100
 
 /datum/supply_pack/faction/syndicate/magazine/hognose_mag
 	name = "Hognose Magazine Crate"
-	desc = "Contains a .22lr magazine for the Hognose underbarrel pistol, with a capacity of eight rounds."
+	desc = "Contains a .22lr magazine for the Hognose underbarrel pistol, with a capacity of 8 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m22lr_himehabu/hognose/empty)
 	cost = 100
 
@@ -23,26 +23,26 @@
 
 /datum/supply_pack/faction/syndicate/magazine/m10mm_mag
 	name = "Ringneck Magazine Crate"
-	desc = "Contains a 10mm magazine for the Ringneck pistol, with a capacity of eight rounds."
+	desc = "Contains a 10x22mm magazine for the Ringneck pistol, with a capacity of 8 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m10mm_ringneck/empty)
 	cost = 150
 
 /datum/supply_pack/faction/syndicate/magazine/m9mm_rattlesnake
 	name = "Rattlesnake Magazine Crate"
-	desc = "Contains a 9mm magazine for the Rattlesnake machine pistol, with a capacity of 18 rounds."
+	desc = "Contains a 9x18mm magazine for the Rattlesnake machine pistol, with a capacity of 18 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m9mm_rattlesnake/empty)
 	cost = 300
 
 /datum/supply_pack/faction/syndicate/magazine/a357_mag
 	name = ".357 Speedloader Crate"
-	desc = "Contains a .357 speedloader for revolvers, with a capacity of six rounds."
+	desc = "Contains a .357 speedloader for revolvers, with a capacity of 6 rounds."
 	contains = list(/obj/item/ammo_box/a357/empty)
 	cost = 250
 	faction_discount = 20
 
 /datum/supply_pack/faction/syndicate/magazine/sidewinder_mag
 	name = "Sidewinder Magazine Crate"
-	desc = "Contains a 30 round magazine for the Sidewinder SMG."
+	desc = "Contains a 5.7x39mm magazine for the Sidewinder SMG, with a capacity of 30 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m57_39_sidewinder/empty)
 	cost = 300
 
@@ -66,19 +66,19 @@
 
 /datum/supply_pack/faction/syndicate/magazine/saw_mag
 	name = "SAW-80 Magazine Crate"
-	desc = "Contains a 5.56x42mm CLIP magazine for the SAW-80 Squad Automatic Weapon, with a capacity of sixty rounds. Count your shots, they run out fast."
+	desc = "Contains a 5.56x42mm CLIP magazine for the SAW-80 Squad Automatic Weapon, with a capacity of 60 rounds. Count your shots, they run out fast."
 	contains = list(/obj/item/ammo_box/magazine/m556_42_hydra/extended/empty)
 	cost = 750
 
 /datum/supply_pack/faction/syndicate/magazine/boomslang_mag
 	name = "Boomslang-90 Magazine Crate"
-	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, with a capacity of five rounds."
+	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, with a capacity of 5 rounds."
 	contains = list(/obj/item/ammo_box/magazine/boomslang/short/empty)
 	cost = 750
 
 /datum/supply_pack/faction/syndicate/magazine/boomslang_mag_extended
 	name = "MSR-90 'Boomslang' Magazine Crate"
-	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, with a capacity of ten rounds."
+	desc = "Contains a 6.5 CLIP magazine for the Boomslang rifle platform, with a capacity of 10 rounds."
 	contains = list(/obj/item/ammo_box/magazine/boomslang/empty)
 	cost = 1500
 

--- a/mod_celadon/turrets/code/turrets.dm
+++ b/mod_celadon/turrets/code/turrets.dm
@@ -174,8 +174,8 @@
 	max_integrity = 150 //сепарские турели очевидно не особо крепкие
 
 /obj/machinery/porta_turret/ship/elysium/light
-	name = "Scrapped 10mm Light Turret"
-	desc = "A light Separatist's Ahisai'i turret. Shoots 10mm projectiles at a close range."
+	name = "Scrapped 10x22mm Light Turret"
+	desc = "A light Separatist's Ahisai'i turret. Shoots 10x22mm projectiles at a close range."
 	stun_projectile = /obj/projectile/bullet/c10mm/rubber
 	stun_projectile_sound = 'sound/weapons/gun/smg/vector_fire.ogg'
 	lethal_projectile = /obj/projectile/bullet/c10mm

--- a/mod_celadon/weapons/code/gun.dm
+++ b/mod_celadon/weapons/code/gun.dm
@@ -46,7 +46,7 @@
 
 /datum/supply_pack/gun/glock
 	name = "Оружейный ящик Glock"
-	desc = "Содержит пистолет Glock калибра 9mm и одну дополнительную обойму к нему."
+	desc = "Содержит пистолет Glock калибра 9x18mm и одну дополнительную обойму к нему."
 	cost = 1300
 	contains = list(/obj/item/storage/guncase/glock)
 	crate_name = "auto rifle crate"

--- a/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -116,12 +116,12 @@
 		start_empty = TRUE
 
 /obj/item/ammo_box/magazine/glock_standart
-	name = "\improper Glock 9mm magazine"
-	desc = "glock 9mm magazine"
+	name = "\improper Glock 9x18mm magazine"
+	desc = "glock 9x18mm magazine"
 	icon = 'mod_celadon/_storge_icons/icons/ammo/ammo.dmi'
 	item_state = "glock"
 	icon_state = "glock"
-	caliber = "9mm"
+	caliber = "9x18mm"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	max_ammo = 17
 

--- a/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -29,7 +29,7 @@ NO_MAG_GUN_HELPER(automatic/pistol/usp45)
 
 /obj/item/gun/ballistic/automatic/pistol/glock
 	name = "\improper Glock 17"
-	desc = "A really old SolFed 9mm pistol. Still used by some solarian police forces. It is also popular as a civilian firearm."
+	desc = "A really old SolFed 9x18mm pistol. Still used by some solarian police forces. It is also popular as a civilian firearm."
 	icon = 'mod_celadon/_storge_icons/icons/guns/glock.dmi'
 	icon_state = "glock"
 	manufacturer = MANUFACTURER_SOLARARMORIES


### PR DESCRIPTION
## Ребрендинг пистолетных калибров в карго 
Переименование описания пистолетных калибров под единый стиль, прочие правки описания по мелочи.
Фикс калибра Глока-17 из-за которого он не мог заряжать пули в обойму.

## Причина создания ПР / Почему это хорошо для игры
[discord/bug-code: Глок и калибр 9мм сломался](https://discord.com/channels/1100198143456465067/1368923378332991508)

## Список изменений

:cl:
tweak: Общее описание в модах о калибрах (9x18mm, 10x22mm)
tweak: Карго-консоль - описание о количестве патрон в обоймах теперь прописано в цифрах.
fix: Glock 17 - починка калибра (9mm -> 9x18mm)
:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.