### PR TITLE
DISABLE: Mod helmet_seclite, generation runtime errors 

### DIFF
--- a/mod_celadon/mod_celadon.dme
+++ b/mod_celadon/mod_celadon.dme
@@ -65,7 +65,7 @@
 #include "inteq_vendor/inteq_vendor.dme"
 #include "rnd/_rnd.dme"
 #include "rus_labeler/_rus_labeler.dme"
-#include "helmet_seclite/_helmet_seclite.dme"
+//#include "helmet_seclite/_helmet_seclite.dme"
 #include "vending_cash/_vending_cash.dme"
 
 // --- MOBS --- //


### PR DESCRIPTION
## Отключаем мод на фикс секлайтов с последующим удалением
Выключает мод что вызывал рантаймы. По сути он уже не нужен, и его бы удалить. 
Для теста можно глянуть как будет без него, пока просто отключение дальше посмотрим.

## Причина создания ПР / Почему это хорошо для игры
Этот баг пофиксили спустя месяц после этого мода.
Shiptest Official: [Helmet lights and goggles consistency #4266](https://github.com/shiptest-ss13/Shiptest/pull/4266)

## Список изменений

:cl:
disable: Выключает мод фонариков на шлем, больше никаких рантаймов
:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
