### PR TITLE
TWEAK: Solfed helmet seclite and overlay googles, buff etar module

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -72,7 +72,7 @@
 
 /obj/item/ammo_casing/energy/laser/sharplite/smg
 	projectile_type = /obj/projectile/beam/weak/sharplite
-	e_cost = 396 //25 shots with a normal power cell, 50 with an upgraded
+	e_cost = 799 //12 shots with a normal power cell, 25 with an upgraded
 	select_name = "kill"
 	delay = 0.13 SECONDS
 

--- a/mod_celadon/balance/code/sharplite_balance.dm
+++ b/mod_celadon/balance/code/sharplite_balance.dm
@@ -59,6 +59,10 @@
 	projectile_type = /obj/projectile/beam/laser/light/smg
 	e_cost = 400 //cheaper to fire but worse projectiles as stated above
 
+/obj/item/ammo_casing/energy/laser/sharplite/smg
+	projectile_type = /obj/projectile/beam/weak/sharplite
+	e_cost = 396 //25 shots with a normal power cell, 50 with an upgraded
+
 ////////////
 //NT-SL HADES egun
 ////////////

--- a/mod_celadon/outfit/code/solfed/solfed_other_stuff.dm
+++ b/mod_celadon/outfit/code/solfed/solfed_other_stuff.dm
@@ -220,6 +220,8 @@
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/solfed/clothing/mob/head.dmi'
 	icon_state = "solfed_m11"
 	item_state = "solfed_m11"
+	can_flashlight = TRUE
+	content_overlays = TRUE
 
 /obj/item/clothing/head/helmet/solfed/m11/elysium
 	name = "Elysium Brigade M11 helmet"


### PR DESCRIPTION
## Различные изменения по мелочи
К каскам СФ теперь можно крепить фонарики, и на них визуально отображаются очки.
Перенос бафа етара #1765 в модуль.

## Причина создания ПР / Почему это хорошо для игры
Удобство для СФ, и перенес изменение **КОР-КОДА** #1765 в модуль.

## Список изменений

:cl:
tweak: Шлемах СФ: отображение на них очков и возможность прицепить фонарик
fix: прошлые изменения етара перенесены в модуль
:cl:

## Подтверждение о готовности PR
- [x] Я, полностью подтверждаю что мой PR протестирован и закончен полностью в соответствии с ТЗ из предложения. Мне не нужна помощь для его завершения. Я принимаю полностью на себя ответственность за возникновение багов и недоработок и обязуюсь их исправить в случае появления.
