### PR TITLE
FIX: RUNTIME: Cargo landing_turf - Landing Zone

### DIFF
--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -113,7 +113,7 @@
 			if(!pack || !charge_account?.has_money(pack.cost) || !istype(current_area))
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 				if(!charge_account?.has_money(pack.cost) && message_cooldown <= world.time)
-					say("Error: No funds! Transaction canceled.")
+					say("ERROR: Infufficient funds! Transaction canceled.")
 					message_cooldown = world.time + 5 SECONDS
 				return
 
@@ -137,7 +137,7 @@
 				if(!length(empty_turfs))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 					if(message_cooldown <= world.time)
-						say("Error: Landing zone full! No space for drop!")
+						say("ERROR: Landing zone full! No space for drop!")
 						message_cooldown = world.time + 5 SECONDS
 					return
 				landing_turf = pick(empty_turfs)

--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -6,7 +6,6 @@
 	var/obj/docking_port/mobile/D = SSshuttle.get_containing_shuttle(src)
 	var/datum/overmap/ship/controlled/ship
 	var/outpost_docked = FALSE
-	var/cooldown = 0
 	if(D)
 		ship = D.current_ship
 		outpost_docked = istype(ship.docked_to, /datum/overmap/outpost)
@@ -112,6 +111,10 @@
 			var/area/current_area = get_area(src)
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[text2path(params["id"])]
 			if(!pack || !charge_account?.has_money(pack.cost) || !istype(current_area))
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
+				if(!charge_account?.has_money(pack.cost) && message_cooldown <= world.time)
+					say("Error: No funds! Transaction canceled.")
+					message_cooldown = world.time + 5 SECONDS
 				return
 
 			var/turf/landing_turf
@@ -133,9 +136,10 @@
 					CHECK_TICK
 				if(!length(empty_turfs))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
-					if(cooldown <= world.time)
+					if(message_cooldown <= world.time)
 						say("Error: Landing zone full! No space for drop!")
-					return cooldown = world.time + 5 SECONDS
+						message_cooldown = world.time + 5 SECONDS
+					return
 				landing_turf = pick(empty_turfs)
 
 			// note that, because of CHECK_TICK above, we aren't sure if we can

--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -6,6 +6,7 @@
 	var/obj/docking_port/mobile/D = SSshuttle.get_containing_shuttle(src)
 	var/datum/overmap/ship/controlled/ship
 	var/outpost_docked = FALSE
+	var/cooldown = 0
 	if(D)
 		ship = D.current_ship
 		outpost_docked = istype(ship.docked_to, /datum/overmap/outpost)
@@ -132,8 +133,9 @@
 					CHECK_TICK
 				if(!length(empty_turfs))
 					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
-					src.visible_message(span_notice("[src] could not find any suitable landing spot in landing zone."))
-					return
+					if(cooldown <= world.time)
+						say("Error: Landing zone full! No space for drop!")
+					return cooldown = world.time + 5 SECONDS
 				landing_turf = pick(empty_turfs)
 
 			// note that, because of CHECK_TICK above, we aren't sure if we can

--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -130,6 +130,10 @@
 						continue
 					empty_turfs += T
 					CHECK_TICK
+				if(!length(empty_turfs))
+					playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
+					src.visible_message(span_notice("[src] could not find any suitable landing spot in landing zone."))
+					return
 				landing_turf = pick(empty_turfs)
 
 			// note that, because of CHECK_TICK above, we aren't sure if we can


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет проверку на пустоту в зоне посадки в карго под грузы, и добавляет оповещения если все зоны забиты.

## Причина создания ПР / Почему это хорошо для игры
Добавляет звук и оповещение о том когда зона посадки в карго забита, и убирает рантайм с этим связанный

## Список изменений

:cl:
add: Оповещение и звук когда зона посадки в карго забита либо недостаточно средств
fix: Runtime при забитой зоне посадки в карго
:cl: