### PR TITLE
FIX: Infinite carry-throwing exploit

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1159,8 +1159,8 @@
 	return ishuman(target) && target.body_position == LYING_DOWN
 
 /mob/living/carbon/human/proc/fireman_carry(mob/living/carbon/target)
-// [/CELADON-EDIT] - Fix Throw Exploit (Когда починят тогда можно убирать)
-/*
+// [CELADON-EDIT] - Fix Throw Exploit (Когда починят тогда можно убирать)
+/* CELADON-EDIT - ORIGINAL
 	var/carrydelay = 50 //if you have latex you are faster at grabbing
 	var/skills_space = "" //cobby told me to do this
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1159,6 +1159,8 @@
 	return ishuman(target) && target.body_position == LYING_DOWN
 
 /mob/living/carbon/human/proc/fireman_carry(mob/living/carbon/target)
+// [/CELADON-EDIT] - Fix Throw Exploit (Когда починят тогда можно убирать)
+/*
 	var/carrydelay = 50 //if you have latex you are faster at grabbing
 	var/skills_space = "" //cobby told me to do this
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
@@ -1180,6 +1182,29 @@
 		visible_message(span_warning("[src] fails to fireman carry [target]!"))
 	else
 		to_chat(src, span_warning("You can't fireman carry [target] while they're standing!"))
+*/
+	var/carrydelay = 50 //if you have latex you are faster at grabbing
+	var/skills_space = "" //cobby told me to do this
+	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
+		carrydelay = 30
+		skills_space = "expertly"
+	else if(HAS_TRAIT(src, TRAIT_QUICK_CARRY))
+		carrydelay = 40
+		skills_space = "quickly"
+	if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE))
+		visible_message(span_notice("[src] starts [skills_space] lifting [target] onto their back.."),
+		//Joe Medic starts quickly/expertly lifting Grey Tider onto their back..
+		span_notice("[carrydelay < 35 ? "Using your gloves' nanochips, you" : "You"] [skills_space] start to lift [target] onto your back[carrydelay == 40 ? ", while assisted by the nanochips in your gloves.." : "..."]"))
+		//(Using your gloves' nanochips, you/You) (/quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
+		if(do_after(src, carrydelay, target))
+			//Second check to make sure they're still valid to be carried
+			if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE) && !target.buckled)
+				buckle_mob(target, TRUE, TRUE, 90, 1, 0)
+				return
+		visible_message(span_warning("[src] fails to fireman carry [target]!"))
+	else
+		to_chat(src, span_warning("You can't fireman carry [target] while they're standing!"))
+// [/CELADON-EDIT]
 
 /mob/living/carbon/human/proc/scoop(mob/living/carbon/target)
 	var/carrydelay = 20 //if you have latex you are faster at grabbing

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1183,7 +1183,11 @@
 	else
 		to_chat(src, span_warning("You can't fireman carry [target] while they're standing!"))
 */
-	var/carrydelay = 50 //if you have latex you are faster at grabbing
+	if(!can_be_firemanned(target) || incapacitated(IGNORE_GRAB))
+		to_chat(src, span_warning("You can't fireman carry [target] while [target.p_they()] [target.p_are()] standing!"))
+		return
+
+	var/carrydelay = 5 SECONDS //if you have latex you are faster at grabbing
 	var/skills_space = "" //cobby told me to do this
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
 		carrydelay = 30
@@ -1191,19 +1195,28 @@
 	else if(HAS_TRAIT(src, TRAIT_QUICK_CARRY))
 		carrydelay = 40
 		skills_space = "quickly"
-	if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE))
-		visible_message(span_notice("[src] starts [skills_space] lifting [target] onto their back.."),
-		//Joe Medic starts quickly/expertly lifting Grey Tider onto their back..
-		span_notice("[carrydelay < 35 ? "Using your gloves' nanochips, you" : "You"] [skills_space] start to lift [target] onto your back[carrydelay == 40 ? ", while assisted by the nanochips in your gloves.." : "..."]"))
-		//(Using your gloves' nanochips, you/You) (/quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
-		if(do_after(src, carrydelay, target))
-			//Second check to make sure they're still valid to be carried
-			if(can_be_firemanned(target) && !incapacitated(FALSE, TRUE) && !target.buckled)
-				buckle_mob(target, TRUE, TRUE, 90, 1, 0)
-				return
-		visible_message(span_warning("[src] fails to fireman carry [target]!"))
-	else
+
+	visible_message(span_notice("[src] starts [skills_space] lifting [target] onto their back.."),
+	//Joe Medic starts quickly/expertly lifting Grey Tider onto their back..
+	span_notice("[carrydelay < 35 ? "Using your gloves' nanochips, you" : "You"] [skills_space] start to lift [target] onto your back[carrydelay == 40 ? ", while assisted by the nanochips in your gloves.." : "..."]"))
+	//(Using your gloves' nanochips, you/You) (/quickly/expertly) start to lift Grey Tider onto your back(, while assisted by the nanochips in your gloves../...)
+	if(!do_after(src, carrydelay, target))
 		to_chat(src, span_warning("You can't fireman carry [target] while they're standing!"))
+		return
+
+	//Second check to make sure they're still valid to be carried
+	if(!can_be_firemanned(target) || incapacitated(IGNORE_GRAB) || target.buckled)
+		to_chat(src, span_warning("You can't fireman carry [target] while they're standing!"))
+		return
+
+	if(target.loc != loc)
+		var/old_density = density
+		density = FALSE // Hacky and doesn't use set_density()
+		step_towards(target, loc)
+		density = old_density // Avoid changing density directly in normal circumstances, without the setter.
+
+	if(target.loc == loc)
+		return buckle_mob(target, TRUE, TRUE, 90, 1, 0)
 // [/CELADON-EDIT]
 
 /mob/living/carbon/human/proc/scoop(mob/living/carbon/target)


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет эксплойт, из-за которого игроки могли бесконечно бросать персонажей, злоупотребляя механиками игры.
А ну ещё мне надоело ждать когда оригинальный шиптест зальет к себе этот фикс.

## Демонстрация изменений
<details>
<summary>Видео о баге</summary>

https://github.com/user-attachments/assets/801c896f-19fd-4411-9de8-63bdec319359

</details>

## Причина создания ПР / Почему это хорошо для игры
Это не должно так работать.
[discord/bug-code: Становление Сансом](https://discord.com/channels/1100198143456465067/1370822512966893723)

## Список изменений

:cl:
fix: Эксплойт на бесконечное метание
:cl: