### PR TITLE
FIX: planet and ruin runtimes

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
@@ -1035,15 +1035,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/overmap_encounter/planetoid/lava/explored)
-"acs" = (
-/obj/item/stack/rods{
-	icon_state = "rods-1";
-	dir = 1;
-	pixel_x = 7;
-	pixel_y = -8
-	},
-/turf/open/lava/smooth,
-/area/overmap_encounter/planetoid/lava/explored)
 "act" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -1161,6 +1152,10 @@
 	icon_state = "rods-1";
 	pixel_x = 8;
 	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/smes{
+	pixel_x = 8;
+	pixel_y = 7
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -4191,18 +4186,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/overmap_encounter/planetoid/cave/explored)
-"ahc" = (
-/obj/item/circuitboard/machine/smes{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/stack/sheet/metal{
-	amount = 5;
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/lava/smooth,
-/area/overmap_encounter/planetoid/lava/explored)
 "ahd" = (
 /obj/effect/mob_spawn/human/corpse/assistant/husked{
 	short_desc = "Тело все обгорело и повреждено. Сложно сказать кому оно принадлежало, но кажется это один из членов команды судна!"
@@ -15139,49 +15122,27 @@
 	},
 /area/ruin/unpowered/corprejectrooms)
 "awU" = (
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth,
 /area/ruin/unpowered/corprejectrooms)
 "awW" = (
-/obj/item/stock_parts/cell/high/empty{
-	pixel_x = 3
+/obj/effect/mob_spawn/human/corpse{
+	mob_species = /datum/species/lizard/ashwalker
 	},
-/turf/open/lava/smooth,
-/area/overmap_encounter/planetoid/lava/explored)
+/turf/closed/indestructible/rock,
+/area/overmap_encounter/planetoid/cave/explored)
 "axc" = (
 /obj/structure/lattice,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/overmap_encounter/planetoid/lava/explored)
-"axi" = (
-/obj/item/stack/cable_coil{
-	amount = 1;
-	name = "cable piece";
-	icon_state = "coil1";
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -2;
-	color = "#ff0000"
-	},
-/obj/item/stack/rods{
-	icon_state = "rods-1";
-	dir = 1;
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/turf/open/lava/smooth,
-/area/overmap_encounter/planetoid/lava/explored)
 "axn" = (
-/obj/item/stack/sheet/metal{
-	pixel_x = -4;
-	pixel_y = 3
+/obj/structure/lattice,
+/obj/item/stock_parts/cell/high/empty{
+	pixel_x = 3
 	},
-/obj/item/stack/sheet/mineral/titanium{
-	amount = 2;
-	pixel_y = -1
-	},
-/turf/open/lava/smooth,
-/area/overmap_encounter/planetoid/lava/explored)
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/corprejectrooms)
 "cxt" = (
 /obj/item/stack/sheet/metal{
 	pixel_x = 3;
@@ -15817,7 +15778,7 @@ abD
 abE
 abF
 abG
-axn
+aah
 abI
 abh
 aah
@@ -16132,7 +16093,7 @@ acz
 acA
 aaC
 acB
-ahc
+aah
 aah
 aaS
 aah
@@ -16286,8 +16247,8 @@ adj
 adk
 aaS
 adl
-aaD
-awW
+axn
+aah
 aah
 adn
 ado
@@ -18380,7 +18341,7 @@ afu
 aaD
 ajN
 ajO
-acs
+aah
 ajQ
 ajR
 aaS
@@ -22555,7 +22516,7 @@ aao
 "}
 (94,1,1) = {"
 aaF
-aqK
+awW
 aaF
 aah
 aah
@@ -23726,7 +23687,7 @@ aah
 aah
 aah
 aah
-axi
+aah
 aah
 anH
 awm

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_fun_maze.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_fun_maze.dmm
@@ -1480,12 +1480,6 @@
 /obj/structure/sign/poster/contraband/xenofauna_parasite,
 /turf/closed/indestructible/reinforced,
 /area/ruin/lavaland)
-"zV" = (
-/obj/structure/table/reinforced,
-/obj/item/implantcase,
-/obj/item/implanter,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/lavaland)
 "Ab" = (
 /obj/effect/landmark/portal_exit{
 	alpha = 0;
@@ -8375,7 +8369,7 @@ hS
 uR
 Ss
 fI
-zV
+Rz
 Zg
 uP
 jC

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_bubbleOutpost.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_bubbleOutpost.dmm
@@ -350,9 +350,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},

--- a/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_distillery.dmm
+++ b/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_distillery.dmm
@@ -3569,10 +3569,8 @@
 	},
 /area/overmap_encounter/planetoid/rockplanet/explored)
 "Os" = (
-/obj/effect/spawner/random/vending/snack{
-	tilted = 1
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/white,
+/obj/machinery/vending/snack/green,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ruin/rockplanet/distillery/crew)
 "Ow" = (

--- a/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_lasttemplar.dmm
+++ b/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_lasttemplar.dmm
@@ -1298,8 +1298,7 @@
 	health = 500;
 	melee_damage_lower = 50;
 	melee_damage_upper = 50;
-	maxHealth = 500;
-	movespeed_modification = 1.2
+	maxHealth = 500
 	},
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
@@ -2092,12 +2091,11 @@
 	gps_name = "???l";
 	melee_damage_lower = 30;
 	melee_damage_upper = 35;
-	move_to_delay = 1;
 	aggro_vision_range = 8;
 	crusher_loot = list(/obj/item/upgradescroll);
 	loot = list(/obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor);
 	speed = 2;
-	movespeed_modification = 1.2
+	move_to_delay = 1
 	},
 /obj/effect/temp_visual/cult/turf,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_starfurycrash.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_starfurycrash.dmm
@@ -34,9 +34,7 @@
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "dX" = (
-/obj/item/gun/ballistic/automatic/pistol/ringneck{
-	spawnwithmagazine = 0
-	},
+/obj/item/gun/ballistic/automatic/pistol/ringneck/no_mag,
 /turf/open/floor/plating/asteroid/whitesands,
 /area/overmap_encounter/planetoid/cave/explored)
 "eg" = (

--- a/code/game/objects/effects/anomalies/anomalies_static.dm
+++ b/code/game/objects/effects/anomalies/anomalies_static.dm
@@ -44,6 +44,11 @@ GLOBAL_LIST_INIT(tvstatic_sayings, list(
 		var/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/vicspawner = new (src)
 		var/mob/living/carbon/victim = (vicspawner.spawned_mob_ref)?.resolve()
 		src.stored_mob = victim
+		//[CELADON-REMOVE]
+		/* CELADON-REMOVE - ORIGINAL
+		victim.forceMove(src)
+		*/
+		// [/CELADON-REMOVE]
 	. = ..()
 
 

--- a/code/game/objects/effects/anomalies/anomalies_static.dm
+++ b/code/game/objects/effects/anomalies/anomalies_static.dm
@@ -44,7 +44,6 @@ GLOBAL_LIST_INIT(tvstatic_sayings, list(
 		var/obj/effect/mob_spawn/human/corpse/damaged/legioninfested/vicspawner = new (src)
 		var/mob/living/carbon/victim = (vicspawner.spawned_mob_ref)?.resolve()
 		src.stored_mob = victim
-		victim.forceMove(src)
 	. = ..()
 
 

--- a/code/modules/mob_spawner/spawner_componet.dm
+++ b/code/modules/mob_spawner/spawner_componet.dm
@@ -106,7 +106,11 @@
 		var/mob/living/simple_animal/L = new chosen_mob_type(spot)
 		L.flags_1 |= (P.flags_1 & ADMIN_SPAWNED_1)
 		spawned_mobs += L
-		//L.nest = src
+		//[CELADON-REMOVE]
+		/* CELADON-REMOVE - ORIGINAL
+		L.nest = src
+		*/
+		// [/CELADON-REMOVE]
 		L.faction = src.faction
 		P.visible_message(span_danger("[L] [pick(spawn_text)] [P]."))
 		// [CELADON-ADD] - DELETION_TIMER_TO_SPAWNED_MOBS

--- a/code/modules/mob_spawner/spawner_componet.dm
+++ b/code/modules/mob_spawner/spawner_componet.dm
@@ -106,7 +106,7 @@
 		var/mob/living/simple_animal/L = new chosen_mob_type(spot)
 		L.flags_1 |= (P.flags_1 & ADMIN_SPAWNED_1)
 		spawned_mobs += L
-		L.nest = src
+		//L.nest = src
 		L.faction = src.faction
 		P.visible_message(span_danger("[L] [pick(spawn_text)] [P]."))
 		// [CELADON-ADD] - DELETION_TIMER_TO_SPAWNED_MOBS


### PR DESCRIPTION
## Описание / Что этот PR делает
Чинит различные рантаймы, которые возникали на некоторых руинках.
Чинит аномалию tvstatic, которая тоже вызывала рантаймы на некоторых руинах и планетах
Чинит рантаймы ледянки, которые возникали из-за попытки спавна несуществуещего моба
## Причина создания ПР / Почему это хорошо для игры
Таска от хедмаппера
## Демонстрация изменений / Тестирование

## Список изменений

:cl:
del: Удаляет на руинках и в коде причины рантаймов.
:cl:
