### PR TITLE
ADD: Chest rig in cargo

### DIFF
--- a/mod_celadon/outpost_console/code/supply_pack/independent/tools.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/tools.dm
@@ -55,6 +55,13 @@
 	contains = list(/obj/item/storage/belt/military/assault)
 	crate_name = "assault belt crate"
 
+/datum/supply_pack/faction/independent/tools/milbelt
+	name = "Military Chest Rig"
+	desc = "Contains an chest rig, with not one, not two, but seven pockets."
+	cost = 1000
+	contains = list(/obj/item/storage/belt/military)
+	crate_name = "chest rig crate"
+
 /datum/supply_pack/faction/independent/tools/cellcharger
 	name = "Cell Charger Crate"
 	desc = "Contains a cell charger, able to charge all sorts of power cells."


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляем в карго разгрузку на 7 слотов за базовую цену в 1000 кредитов.
closed #1800

## Демонстрация изменений / Тестирование

<details>
<summary>Скриншоты</summary>

![image](https://github.com/user-attachments/assets/53414efa-3025-455b-9440-ff91d101a5c6)

</details>

## Причина создания ПР / Почему это хорошо для игры
Больше разнообразия товаров в карго.
Разгрузка за `1000 cr` с 7 слотами.
Есть похожий товар за `500 cr` но с 6 слотами.

## Список изменений

:cl:
add: Добавлена в общее карго: разгрузка (`chest rig`) на 7 слотов.
:cl: