### PR TITLE
FIX: Runtime loot: null - ramzi mob

### DIFF
--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -147,7 +147,7 @@ Weebstick (Красная катана) теперь нельзя сломать
 ### Авторы:
 
 
-RalseiDreemuurr, Mirag1993 , Корольный крыс, MrCat15352, MysticalFaceLesS, Burbonchik, MrRomainzZ, Molniz, Redwizz, Sjerty, Garomt, Ganza9991
+RalseiDreemuurr, Mirag1993 , Корольный крыс, MrCat15352, MysticalFaceLesS, Burbonchik, MrRomainzZ, Molniz, Redwizz, Sjerty, Garomt, Ganza9991, KOCMOHABT
 
 <!--
   Здесь находится твой никнейм

--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -19,6 +19,7 @@
 #include "code/newscaster.dm"
 #include "code/plants_data_disk.dm"
 #include "code/railings.dm"
+#include "code/ramzi_mob.dm"
 #include "code/rdconsole.dm"
 #include "code/replicapod.dm"
 #include "code/research_mission.dm"

--- a/mod_celadon/fixes/code/ramzi_mob.dm
+++ b/mod_celadon/fixes/code/ramzi_mob.dm
@@ -1,0 +1,2 @@
+/mob/living/simple_animal/hostile/human/ramzi
+	loot = list()


### PR DESCRIPTION
## Фикс багов
Убирает рантайм при смерти любого рамзи моба.

## Причина создания ПР / Почему это хорошо для игры
Рантайм при смерти любого рамзи, тк возвращал пустоту вместо пустого списка.

## Список изменений

:cl:
fix: Рантайм при смерти любого рамзи
:cl: