### PR TITLE
TWEAK: Снижаем кол-во миссий в консоле за раз.

### DIFF
--- a/code/modules/missions/dynamic/kill.dm
+++ b/code/modules/missions/dynamic/kill.dm
@@ -21,7 +21,7 @@
 
 /datum/mission/ruin/signaled/kill/frontiersmen
 	value = 2000
-	mission_limit = 3
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 3
 	mission_reward = list(
 		/obj/item/gun/ballistic/automatic/pistol/mauler,
 		/obj/item/gun/ballistic/automatic/pistol/spitter
@@ -31,7 +31,7 @@
 
 /datum/mission/ruin/signaled/kill/ramzi
 	value = 2500
-	mission_limit = 3
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 3
 	mission_reward = list(
 		/obj/item/gun/ballistic/automatic/smg/cobra,
 		/obj/item/gun/ballistic/automatic/smg/sidewinder,
@@ -47,7 +47,7 @@
 	setpiece_item = /obj/item/folder/documents/syndicate
 
 /datum/mission/ruin/signaled/kill/megafauna
-	mission_limit = 2
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 2
 
 /datum/mission/ruin/signaled/kill/megafauna/generate_mission_details()
 	registered_type = pick(
@@ -58,7 +58,7 @@
 
 /datum/mission/ruin/signaled/kill/elite
 	value = 6000
-	mission_limit = 2
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 2
 
 /datum/mission/ruin/signaled/kill/elite/generate_mission_details()
 	registered_type = pick(

--- a/code/modules/missions/dynamic/missions.dm
+++ b/code/modules/missions/dynamic/missions.dm
@@ -1,7 +1,7 @@
 /datum/mission/ruin/data_retrieval
 	name = "Data Recovery"
 	desc = "We would like %MISSION_REQUIRED retrieved from a site of interest."
-	mission_limit = 2
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 1
 	setpiece_item = list(
 		/obj/item/research_notes/loot,
 		/obj/item/documents
@@ -20,6 +20,6 @@
 /datum/mission/ruin/blackbox
 	name = "Blackbox Recovery"
 	desc = "Communication has recently been lost with this world. Investigate the site, engage hostiles at your discretion, and recover the %MISSION_REQUIRED so we can plan a course of action."
-	mission_limit = 2
+	mission_limit = 1 //[CELADON-EDIT] OLD- mission_limit = 1
 	setpiece_item = /obj/machinery/blackbox_recorder
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Снижает кол-во миссий с 8-10 до 1-5.
## Причина создания ПР / Почему это хорошо для игры
Новые миссии заполонили пулл руин, в основном спавнились руины, связанные с миссиями. Из-за этого одну и ту же руину можно было увидеть трижды за раунд. Этот ПР устраняет эту проблему.
## Демонстрация изменений / Тестирование

## Список изменений

:cl:
tweak: Снизил везде  mission_limit до 1-го
:cl:
