### PR TITLE
FIX: MECH - Runtime & Jump/Enter to nullspace

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -61,13 +61,22 @@
 	RegisterSignal(user, COMSIG_MOB_LOGOUT, PROC_REF(clean_user_client))
 	RegisterSignal(user, COMSIG_MOB_LOGIN, PROC_REF(on_user_login))
 	if(!(timed_action_flags & IGNORE_USER_LOC_CHANGE))
-		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+// [CELADON-EDIT] - FIX_MECH
+//		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved)) // CELADON-EDIT - ORIGINAL
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
+// [/CELADON-EDIT]
 		var/obj/mecha/mech = user.loc
 		if(ismecha(user.loc) && user == mech.occupant)
-			RegisterSignal(mech, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+// [CELADON-EDIT] - FIX_MECH
+//			RegisterSignal(mech, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved)) // CELADON-EDIT - ORIGINAL
+			RegisterSignal(mech, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
+// [/CELADON-EDIT]
 	if(!(timed_action_flags & IGNORE_TARGET_LOC_CHANGE))
 		if(user != target)
-			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+// [CELADON-EDIT] - FIX_MECH
+//			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved)) // CELADON-EDIT - ORIGINAL
+			RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved), override = TRUE)
+// [/CELADON-EDIT]
 	if(!(timed_action_flags & IGNORE_HELD_ITEM))
 		var/obj/item/held = user.get_active_held_item()
 		if(held)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -997,6 +997,9 @@
 		else if(user.has_buckled_mobs())
 			to_chat(user, span_warning("You can't enter the exosuit with other creatures attached to you!"))
 		else
+// [CELADON-ADD] - FIX_MECH
+			ADD_TRAIT(M, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
+// [/CELADON-ADD]
 			moved_inside(user)
 	else
 		to_chat(user, span_warning("You stop entering the exosuit!"))
@@ -1150,6 +1153,9 @@
 	silicon_pilot = FALSE
 	SEND_SIGNAL(src,COMSIG_MECH_EXITED,L)
 	if(mob_container.forceMove(newloc))//ejecting mob container
+// [CELADON-ADD] - FIX_MECH
+		REMOVE_TRAIT(L, TRAIT_HANDS_BLOCKED, VEHICLE_TRAIT)
+// [/CELADON-ADD]
 		log_message("[mob_container] moved out.", LOG_MECHA)
 		L << browse(null, "window=exosuit")
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,13 @@
 	return
 
 /obj/mecha/proc/handle_unique_action(mob/user)
+// [CELADON-ADD] - FIX_MECH
+/* CELADON-EDIT - ORIGINAL
 	mech_unique_action.Activate()
+*/
+	if(!mech_unique_action == null)
+		mech_unique_action.Activate()
+// [/CELADON-EDIT]
 	return
 
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -551,7 +551,7 @@
 	return
 
 /obj/mecha/proc/handle_unique_action(mob/user)
-// [CELADON-ADD] - FIX_MECH
+// [CELADON-EDIT] - FIX_MECH
 /* CELADON-EDIT - ORIGINAL
 	mech_unique_action.Activate()
 */
@@ -1347,4 +1347,10 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 /// Sets the direction of the mecha and all of its occcupents, required for FOV. Alternatively one could make a recursive contents registration and register topmost direction changes in the fov component
 /obj/mecha/proc/set_dir_mecha(new_dir)
 	setDir(new_dir)
+// [CELADON-EDIT] - FIX_MECH
+/* CELADON-EDIT - ORIGINAL
 	occupant.setDir(new_dir)
+*/
+	if(!occupant == null)
+		occupant.setDir(new_dir)
+// [/CELADON-EDIT]

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1007,6 +1007,10 @@
 // wake up should go off here
 /obj/mecha/proc/moved_inside(mob/living/carbon/human/H)
 	. = FALSE
+// [CELADON-ADD] - FIX_MECH
+	if(ishuman(H) && !Adjacent(H))
+		return FALSE
+// [/CELADON-ADD]
 	if(H && H.client && (H in range(1)))
 		occupant = H
 		H.forceMove(src)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -552,9 +552,7 @@
 
 /obj/mecha/proc/handle_unique_action(mob/user)
 // [CELADON-EDIT] - FIX_MECH
-/* CELADON-EDIT - ORIGINAL
-	mech_unique_action.Activate()
-*/
+//	mech_unique_action.Activate() // CELADON-EDIT - ORIGINAL
 	if(!mech_unique_action == null)
 		mech_unique_action.Activate()
 // [/CELADON-EDIT]
@@ -1348,9 +1346,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 /obj/mecha/proc/set_dir_mecha(new_dir)
 	setDir(new_dir)
 // [CELADON-EDIT] - FIX_MECH
-/* CELADON-EDIT - ORIGINAL
-	occupant.setDir(new_dir)
-*/
+//	occupant.setDir(new_dir) // CELADON-EDIT - ORIGINAL
 	if(!occupant == null)
 		occupant.setDir(new_dir)
 // [/CELADON-EDIT]

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -25,7 +25,12 @@
 
 
 /datum/action/innate/mecha
+// [CELADON-EDIT] - FIX_MECH
+/* CELADON-EDIT - ORIGINAL
 	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
+*/
+	check_flags = AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
+// [/CELADON-EDIT]
 	icon_icon = 'icons/mob/actions/actions_mecha.dmi'
 	var/obj/mecha/chassis
 

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -26,9 +26,7 @@
 
 /datum/action/innate/mecha
 // [CELADON-EDIT] - FIX_MECH
-/* CELADON-EDIT - ORIGINAL
-	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
-*/
+//	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS // CELADON-EDIT - ORIGINAL
 	check_flags = AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS
 // [/CELADON-EDIT]
 	icon_icon = 'icons/mob/actions/actions_mecha.dmi'


### PR DESCRIPTION
## Фикс багов
Блокирует руки пилота в мехе. (При наличии перчаток перехвата, пилот мог выпрыгнуть из меха в пустоту)
Прерывает залезание в мех когда его улучшили. (Нельзя залезть в то что уже не существует)
Фикс рантаймов.

## Причина создания ПР / Почему это хорошо для игры
fixed #673
[discord/bug-code: Отправка в валльг.. Дебаг-рум](https://discord.com/channels/1100198143456465067/1378769732554981458)

## Список изменений

:cl:
fix: Прыжок в нуллспейс внутри меха с перчатками перехвата
fix: Вход в меха вовремя его улучшения более не отправляет в нуллспейс
fix: Райнтайм, уникальное действия у меха (по умолчанию кнопка: `Space`)
fix: Райнтайм, овверрайд `RegisterSignal` при выходе из меха
fix: Райнтайм, всегда возвращающий `null` при выходе из меха
:cl: