### PR TITLE
FIX: Diagnostic HUD for silicons

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1004,6 +1004,10 @@
 // wake up should go off here
 /obj/mecha/proc/moved_inside(mob/living/carbon/human/H)
 	. = FALSE
+// [CELADON-ADD] - FIX_MECH
+	if(ishuman(H) && !Adjacent(H))
+		return FALSE
+// [/CELADON-ADD]
 	if(H && H.client && (H in range(1)))
 		occupant = H
 		H.forceMove(src)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1004,10 +1004,6 @@
 // wake up should go off here
 /obj/mecha/proc/moved_inside(mob/living/carbon/human/H)
 	. = FALSE
-// [CELADON-ADD] - FIX_MECH
-	if(ishuman(H) && !Adjacent(H))
-		return FALSE
-// [/CELADON-ADD]
 	if(H && H.client && (H in range(1)))
 		occupant = H
 		H.forceMove(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -855,6 +855,9 @@
 		else
 			set_stat(CONSCIOUS)
 	diag_hud_set_status()
+// [CELADON-ADD] - FIX_DIAGNISTIC_HUD
+	diag_hud_set_health()
+// [/CELADON-ADD]
 	diag_hud_set_aishell()
 	update_health_hud()
 


### PR DESCRIPTION
## Фикс багов
Исправляет ошибку у Силиконов, связанную с неверным отображением целостности в Диагностическом HUD.

## Причина создания ПР
[discord/bug-code: Сломанный робо HUD](https://discord.com/channels/1100198143456465067/1381772400323989635)

## Список изменений

:cl:
fix: Диагностический HUD, корректно отображается и обновляет информацию на Силиконах/Боргах.
:cl: