### PR TITLE
ADD: Outpost - Ghost-roles add start capital-money 

### DIFF
--- a/mod_celadon/ghost_roles/code/outpost/outfits.dm
+++ b/mod_celadon/ghost_roles/code/outpost/outfits.dm
@@ -25,7 +25,8 @@
 	id = /obj/item/card/id/elysium_cook
 	back = /obj/item/storage/backpack
 	backpack_contents = list(/obj/item/sharpener = 1,
-							/obj/item/plant_analyzer)
+							/obj/item/plant_analyzer,
+							/obj/item/spacecash/bundle/c100 = 3)
 
 /datum/outfit/outpost/cook/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -66,7 +67,8 @@
 							/obj/item/storage/box/ammo/a12g_rubbershot,
 							/obj/item/barcodescanner,
 							/obj/item/barcode = 5,
-							/obj/item/reagent_containers/food/drinks/shaker)
+							/obj/item/reagent_containers/food/drinks/shaker,
+							/obj/item/spacecash/bundle/c100 = 3)
 	shoes = /obj/item/clothing/shoes/laceup
 	box = /obj/item/storage/box/survival
 	id = /obj/item/card/id/elysium_Bartender
@@ -107,13 +109,12 @@
 	uniform = /obj/item/clothing/under/costume/maid/white
 	gloves = /obj/item/clothing/gloves/maid/white
 	back = /obj/item/storage/backpack
-	belt = /obj/item/pda/janitor
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced = 1)
+	belt = /obj/item/pda/bar
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced = 1,
+							/obj/item/spacecash/bundle/c100 = 3)
 	shoes = /obj/item/clothing/shoes/laceup
 	box = /obj/item/storage/box/survival
 	id = /obj/item/card/id/elysium_maid
-	suit_store = /obj/item/gun/ballistic/shotgun/doublebarrel
-	l_pocket = /obj/item/pda/bar
 	r_pocket = /obj/item/lighter
 
 // /datum/outfit/outpost/maid/pre_equip(mob/living/carbon/human/H, visualsOnly)
@@ -153,6 +154,7 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/instrument/bikehorn = 1,
+		/obj/item/spacecash/bundle/c100 = 3
 		)
 
 	implants = list(/obj/item/implant/sad_trombone)


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет стартовый капитал в 300 кредитов, всем гост-ролям на аванпосте.
Убирает из аутфита горничной двухстволку (Она все ровно не появлялась с ней) и лишний второй ПДА.

## Причина создания ПР / Почему это хорошо для игры
Работники аванпоста работали за идею и пустую миску риса, вендинговые-автоматы требуют деньги за тот же рис.

## Список изменений

:cl:
add: Гост-роли: Работники аванпоста получили стартовый капитал в 300 кредитов
del: Гост-роли: Лишний ПДА и фантомный обрез (его и не было) у горничной
:cl:
