### PR TITLE
FIX: Acceleration rifle - LARGE EMPTY CELL

### DIFF
--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -32,6 +32,9 @@
 	default_ammo_type = /obj/item/stock_parts/cell/gun/large
 	allowed_ammo_types = list(
 		/obj/item/stock_parts/cell/gun/large,
+// [CELADON-ADD] - FIX LARGE EMPTY CELL
+		/obj/item/stock_parts/cell/gun/large/empty,
+// [/CELADON-ADD]
 	)
 	canMouseDown = TRUE
 	var/aiming = FALSE


### PR DESCRIPTION
## Фикс багов
Добавляет подтип пустой обоймы в список того что может использовать Акселераторная винтовка.
`(Да для игры два разных типа батареек, хоть и одинаковые по виду и коду)`

## Причина создания ПР / Почему это хорошо для игры
[discord/bug-code: particle acceleration rifle (Empty Cell)](https://discord.com/channels/1100198143456465067/1367980184333975593)

## Список изменений
:cl:
fix: Крупные пустые батарейки теперь подходят на `Acceleration rifle`
:cl:
