### PR TITLE
FIX: Overlay - Ammo stack correctly see mod sprite

### DIFF
--- a/code/modules/projectiles/ammunition/_ammo_casing.dm
+++ b/code/modules/projectiles/ammunition/_ammo_casing.dm
@@ -147,6 +147,9 @@
 /obj/item/ammo_casing/proc/stack_with(obj/item/ammo_casing/other_casing)
 	var/obj/item/ammo_box/magazine/ammo_stack/ammo_stack = new stack_type(drop_location())
 	ammo_stack.name = "handful of [name]s" //"handful of .9mm bullet casings"
+// [CELADON-ADD] - ADD_MOD_BULLET_STACK - Загружает путь если из мода, иначе дефолтный
+	ammo_stack.base_icon = other_casing.icon
+// [/CELADON-ADD]
 	ammo_stack.base_icon_state = other_casing.icon_state
 	ammo_stack.caliber = caliber
 	ammo_stack.max_ammo = stack_size

--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/_ammo_stack.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/_ammo_stack.dm
@@ -8,6 +8,9 @@
 	desc = "A pile of live rounds."
 	icon = 'icons/obj/ammunition/ammo_bullets.dmi'
 	icon_state = "pistol-brass"
+// [CELADON-ADD] - ADD_MOD_BULLET_STACK - Загружает путь если из мода, иначе дефолтный
+	var/base_icon = null
+// [/CELADON-ADD]
 	base_icon_state = "pistol-brass"
 	item_flags = NO_PIXEL_RANDOM_DROP
 	multiple_sprites = AMMO_BOX_ONE_SPRITE
@@ -26,6 +29,10 @@
 	icon_state = ""
 	for(var/casing in stored_ammo)
 		var/image/bullet = image(initial(icon), src, "[base_icon_state]")
+// [CELADON-ADD] - ADD_MOD_BULLET_STACK - Загружает путь если из мода, иначе дефолтный
+		if(base_icon != null)
+			bullet = image(base_icon, src, "[base_icon_state]")
+// [/CELADON-ADD]
 		bullet.pixel_x = rand(-8, 8)
 		bullet.pixel_y = rand(-8, 8)
 		bullet.transform = bullet.transform.Turn(round(45 * rand(0, 32) / 2)) //this is the equation Eris uses on their bullet stacks


### PR DESCRIPTION
## Фикс багов
Фиксит невидимые пачки патрон из Модового вооружения, если были использованные не стандартные патроны из наших модов оно было невидимым.
Обходит жесткую прописанную привязку к пути в пачках патрон, на ссылку на путь в самом патроне.

## Демонстрация изменений / Абстрактный пример на модовом патроне
https://github.com/user-attachments/assets/78d50eae-a76e-44ed-9327-57218deaea3d

## Причина создания ПР / Почему это хорошо для игры
Это лучше чем невидимые спрайты пачек гильз

## Список изменений

:cl:
add: Гибкий путь к файлу спрайтов для пачек патрон
fix: Отображение невидимых пачек гильз модового оружия
:cl:
