### PR TITLE
DISABLE: Fax - Fix fax naming

### DIFF
--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -111,9 +111,10 @@ Weebstick (Красная катана) теперь нельзя сломать
 - `mod_celadon/fixes/code/research_mission.dm` - вроде перезаписывает
 
 <!-- fax_name -->
+<!-- 
 - `code\controllers\subsystem\overmap.dm`: `proc/spawn_ship_at_start`,
 - `code\modules\paperwork\fax.dm`: `proc/connect_to_shuttle`
-
+ -->
 <!--
   Если ты добавлял новый модульный оверрайд, его нужно указать здесь.
   Здесь указываются оверрайды в твоём моде и папке `_master_files`

--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -7,7 +7,7 @@
 #include "code/ammo.dm"
 #include "code/coil.dm"
 #include "code/cutter.dm"
-#include "code/fax_name.dm"
+//#include "code/fax_name.dm"
 #include "code/field_gen.dm"
 #include "code/icons.dm"
 #include "code/jetpack_upgrade.dm"


### PR DESCRIPTION
## Фикс багов
Отключает наш фикс у факсов тк, на апстриме это уже пофиксили.

## Причина создания ПР / Почему это хорошо для игры
Всего лишь отключает код что конфликтует с оригинальным, тк оригинальный использует методы лучше.

## Список изменений

:cl:
del: Отключение нашего фикса на факсы, что ломает другой фикс на факсы
:cl:
