### PR TITLE
RE-BALANCE: Падение цен на одежду и вендорматы

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -19346,16 +19346,6 @@
 /obj/machinery/recycler,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/fraction/nanotrasen)
-"lwm" = (
-/obj/effect/turf_decal/corner_techfloor_gray/diagonal{
-	layer = 2.030
-	},
-/obj/machinery/vending/mining_equipment{
-	default_price = 1000;
-	extra_price = 2000
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/cargo)
 "lwu" = (
 /obj/effect/turf_decal/borderfloor{
 	dir = 4
@@ -71896,7 +71886,7 @@ tgL
 rfa
 nfo
 svY
-lwm
+cLD
 cLD
 aeD
 rfa

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -1245,14 +1245,10 @@
 "aMq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/wardrobe/viro_wardrobe{
-	pixel_x = 15;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 15
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe{
-	pixel_x = -7;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -7
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -8557,9 +8553,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/vending/wardrobe/curator_wardrobe{
-	pixel_x = -5;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -5
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -16770,9 +16764,7 @@
 /area/outpost/fraction/inteq)
 "jNm" = (
 /obj/machinery/vending/clothing{
-	all_items_free = 1;
-	default_price = 120;
-	extra_price = 240
+	all_items_free = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -16885,14 +16877,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
 /obj/machinery/vending/wardrobe/law_wardrobe{
-	pixel_x = -16;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -16
 	},
 /obj/machinery/vending/wardrobe/det_wardrobe{
-	pixel_x = 5;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -19362,7 +19350,10 @@
 /obj/effect/turf_decal/corner_techfloor_gray/diagonal{
 	layer = 2.030
 	},
-/obj/structure/table/wood,
+/obj/machinery/vending/mining_equipment{
+	default_price = 1000;
+	extra_price = 2000
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "lwu" = (
@@ -24982,10 +24973,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/machinery/vending/wardrobe/cargo_wardrobe{
-	default_price = 700;
-	extra_price = 900
-	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
@@ -25219,10 +25207,7 @@
 "oKH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
-/obj/machinery/vending/wardrobe/atmos_wardrobe{
-	default_price = 700;
-	extra_price = 900
-	},
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -26496,9 +26481,7 @@
 /area/outpost/fraction/syndi/donkco_shop)
 "pAg" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe{
-	pixel_x = 5;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -28142,9 +28125,7 @@
 	network = list("outpostelysium")
 	},
 /obj/machinery/vending/wardrobe/hydro_wardrobe{
-	pixel_x = -1;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -1
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -31600,9 +31581,7 @@
 /area/outpost/crew/lounge/cab_1)
 "sCc" = (
 /obj/machinery/vending/wardrobe/science_wardrobe{
-	pixel_x = 3;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 3
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/plasteel/tech,
@@ -34996,14 +34975,10 @@
 "uDL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/vending/wardrobe/medi_wardrobe{
-	pixel_x = 13;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 13
 	},
 /obj/machinery/vending/wardrobe/robo_wardrobe{
-	pixel_x = -9;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -9
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -35253,10 +35228,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/machinery/vending/wardrobe/chap_wardrobe{
-	default_price = 700;
-	extra_price = 900
-	},
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
 "uLC" = (
@@ -39054,10 +39026,7 @@
 	pixel_x = -10;
 	network = list("outpostelysium")
 	},
-/obj/machinery/vending/wardrobe/engi_wardrobe{
-	default_price = 700;
-	extra_price = 900
-	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
 "wTE" = (
@@ -41265,14 +41234,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_x = 10;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = 10
 	},
 /obj/machinery/vending/wardrobe/bar_wardrobe{
-	pixel_x = -11;
-	default_price = 700;
-	extra_price = 900
+	pixel_x = -11
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/dop_zone_2)
@@ -71930,8 +71895,8 @@ qtK
 tgL
 rfa
 nfo
-lwm
 svY
+lwm
 cLD
 aeD
 rfa

--- a/code/__DEFINES/~mod_celadon/economy.dm
+++ b/code/__DEFINES/~mod_celadon/economy.dm
@@ -5,7 +5,6 @@
 // Для общего карго диапазон цены выбирается между -10% до +10% к цене
 // Для фракционного карго скидка выбрана от 0% до -25% к цене
 // Для экспорта ценник может варироваться от -40% до +10% к цене
-// Для Вендор автоматов диапазон цен от -25% до -15%
 
 // Также после тестов возможно прописывать любые формулы и значения
 // Также цены указаны не на отдельные категории. В будущем будет по
@@ -31,18 +30,6 @@
 #define PRICES_GENERAL_MIN				0.9
 #define PRICES_GENERAL_MAX				1.1
 
-// ЦЕНА НА ТОВАРЫ ВЕНДОМАТОВ
-#define PRICES_VENDING_MIN				0.75
-#define PRICES_VENDING_PREMIUM_MIN		0.85
-
-
-#define PRICES_VENDING_REFILL			0.9
-#define PRICES_VENDING_TAGGER			0.9
-
 // Пока общие на все категории
 #define PRICES_EXPORT_GENERAL_MIN		0.6
 #define PRICES_EXPORT_GENERAL_MAX		1.1
-
-// Bounty
-#define BOUNTY_ASSISTANT_MIN			0.9
-#define BOUNTY_ASSISTANT_MAX			1.1

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -132,8 +132,10 @@
 		/obj/item/storage/box/maid = 2,
 		/obj/item/instrument/piano_synth/headphones/spacepods = 1)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 10
-	extra_price = 60
+	// [CELADON-REMOVE] - CELADON_ECONOMY - Вынесено в модуль. Иначе оверайд будет
+	// default_price = 10
+	// extra_price = 60
+	// [/CELADON-REMOVE]
 	light_mask = "wardrobe-light-mask"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,10 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = 200
-	extra_price = 500
+	// [CELADON-REMOVE] - CELADON_ECONOMY - Вынесено в модуль. Иначе оверайд будет
+	// default_price = 200
+	// extra_price = 500
+	// [/CELADON-REMOVE]
 	input_display_header = "Returned Clothing"
 	light_mask = "wardrobe-light-mask"
 

--- a/mod_celadon/economy/code/vending.dm
+++ b/mod_celadon/economy/code/vending.dm
@@ -1,15 +1,13 @@
 /obj/machinery/vending
-	///Default price of items if not overridden
-	default_price = 100 * PRICES_VENDING_MIN
-	///Default price of premium items if not overridden
-	extra_price = 200 * PRICES_VENDING_PREMIUM_MIN
+	default_price = 75
+	extra_price = 125
 
 /obj/machinery/vending/wardrobe
-	default_price = 200 * PRICES_VENDING_MIN
-	extra_price = 400 * PRICES_VENDING_PREMIUM_MIN
+	default_price = 150
+	extra_price = 300
 
 /obj/item/vending_refill/custom
-	custom_premium_price = 100 * PRICES_VENDING_REFILL
+	custom_premium_price = 90
 
 /obj/item/price_tagger
-	custom_premium_price = 50 * PRICES_VENDING_TAGGER
+	custom_premium_price = 45

--- a/mod_celadon/economy/code/vending.dm
+++ b/mod_celadon/economy/code/vending.dm
@@ -5,11 +5,11 @@
 	extra_price = 200 * PRICES_VENDING_PREMIUM_MIN
 
 /obj/machinery/vending/wardrobe
-	default_price = 100 * PRICES_VENDING_MIN
-	extra_price = 200 * PRICES_VENDING_PREMIUM_MIN
+	default_price = 200 * PRICES_VENDING_MIN
+	extra_price = 400 * PRICES_VENDING_PREMIUM_MIN
 
 /obj/item/vending_refill/custom
-	custom_premium_price = 200 * PRICES_VENDING_REFILL
+	custom_premium_price = 100 * PRICES_VENDING_REFILL
 
 /obj/item/price_tagger
 	custom_premium_price = 50 * PRICES_VENDING_TAGGER

--- a/mod_celadon/outpost_console/code/supply_pack/independent/vendor_refill.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/vendor_refill.dm
@@ -5,7 +5,7 @@
 /datum/supply_pack/faction/independent/vendor_refill/bartending
 	name = "Booze-o-mat and Coffee Supply Crate"
 	desc = "Bring on the booze and coffee vending machine refills."
-	cost = 2000
+	cost = 700
 	contains = list(/obj/item/vending_refill/boozeomat,
 					/obj/item/vending_refill/coffee)
 	crate_name = "bartending supply crate"
@@ -13,35 +13,35 @@
 /datum/supply_pack/faction/independent/vendor_refill/cola
 	name = "Softdrinks Supply Crate"
 	desc = "Got whacked by a toolbox, but you still have those pesky teeth? Get rid of those pearly whites with this soda machine refill, today!"
-	cost = 1500
+	cost = 700
 	contains = list(/obj/item/vending_refill/cola)
 	crate_name = "soft drinks supply crate"
 
 /datum/supply_pack/faction/independent/vendor_refill/snack
 	name = "Snack Supply Crate"
 	desc = "One vending machine refill of cavity-bringin' goodness! The number one dentist recommended order!"
-	cost = 1500
+	cost = 700
 	contains = list(/obj/item/vending_refill/snack)
 	crate_name = "snacks supply crate"
 
 /datum/supply_pack/faction/independent/vendor_refill/autodrobe
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today with this autodrobe refill."
-	cost = 1000
+	cost = 700
 	contains = list(/obj/item/vending_refill/autodrobe)
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/faction/independent/vendor_refill/cigarette
 	name = "Cigarette Supply Crate"
 	desc = "Don't believe the reports - smoke today! Contains a cigarette vending machine refill."
-	cost = 1500
+	cost = 700
 	contains = list(/obj/item/vending_refill/cigarette)
 	crate_name = "cigarette supply crate"
 
 /datum/supply_pack/faction/independent/vendor_refill/games
 	name = "Games Supply Crate"
 	desc = "Get your game on with this game vending machine refill."
-	cost = 1000
+	cost = 700
 	contains = list(/obj/item/vending_refill/games)
 	crate_name = "games supply crate"
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Этот ПР меняет ценовую политику в отношении одежды продающиеся в различных торговых автоматах. А также, производители самих торговых автоматов, снимают эмбарго и понижают цены на пополнители запасов.

## Причина создания ПР / Почему это хорошо для игры
Зарплата капитанов маленькая, сами капитаны не платят достойной зп своим людям, а одежда неимоверно высоко стоит в автоматах. Делаем доступность одежды по низким ценам, повышая мотивацию к РП.

## Демонстрация изменений / Тестирование
![image](https://github.com/user-attachments/assets/56b35904-3579-4d0a-8608-f17826d82d5c)
![image](https://github.com/user-attachments/assets/7a8e1cf7-2f9d-4403-8f84-61c649c3b466)
![image](https://github.com/user-attachments/assets/831a818e-88bd-4afc-9609-d5dc3e02948d)

## Список изменений

:cl:
del: Удалены с карты аванпоста захардкореные цены на вендорматы

tweak: Изменены цены на одежду
| Тип вендора | Обычная цена | Экстра цена |
|--------|--------|--------|
| Обычный | 75 | 125 |
| Вардроб | 150 | 300 |

tweak: Изменены цены на рефил. Разброс цены может варироваться от -10% до +10%
| Тип рефила | Старая цена | Новая цена |
|--------|--------|--------|
| Обычный | 2000 | 700 |
| Вардроб | 2k-8k | - |

:cl:
