### PR TITLE
ADD: Патроны для G36 в карго СФ, но не саму G36

### DIFF
--- a/mod_celadon/outpost_console/code/supply_pack/solfed/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/ammo.dm
@@ -42,6 +42,28 @@ MARK: 9x18mm
 	cost = 200
 
 /*
+MARK: 5.56x45mm
+*/
+
+/datum/supply_pack/faction/solfed/ammo/box556_box
+	name = "5.56mm Ammo Box Crate"
+	desc = "A box of standard 5.56x45mm ammo."
+	contains = list(/obj/item/storage/box/ammo/a556_box)
+	cost = 500
+
+/datum/supply_pack/faction/solfed/ammo/box556/a856_box
+	name = "5.56mm EP Ammo Box Crate"
+	desc = "A box of enhanced performance 5.56x45mm ammo."
+	contains = list(/obj/item/storage/box/ammo/a556_box/a856)
+	cost = 650
+
+/datum/supply_pack/faction/solfed/ammo/box556/m903_box
+	name = "5.56mm AP Ammo Box Crate"
+	desc = "A box of armour-piercing 5.56x45mm ammo."
+	contains = list(/obj/item/storage/box/ammo/a556_box/m903)
+	cost = 1300
+
+/*
 MARK: 5.56 Caseless
 */
 

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
@@ -54,3 +54,25 @@
 	desc = "Contains a Solar Federation weapon cell, compatible with gauss weaponry."
 	contains = list(/obj/item/stock_parts/cell/gun/solgov)
 	cost = 500
+
+/* 5.56x45mm */
+
+/datum/supply_pack/faction/solfed/magazine/g36_sh
+	name = "G36 Short Magazine Double Pack Crate"
+	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 20 rounds."
+	contains = list(/obj/item/ammo_box/magazine/g36/sh/empty,
+					/obj/item/ammo_box/magazine/g36/sh/empty)
+	cost = 1400
+
+/datum/supply_pack/faction/solfed/magazine/g36
+	name = "G36 Standard Magazine Double Pack Crate"
+	desc = "Contains two 5.56x45mm magazines for the G36 family rifles, with a capacity of 30 rounds."
+	contains = list(/obj/item/ammo_box/magazine/g36/empty,
+					/obj/item/ammo_box/magazine/g36/empty)
+	cost = 1950
+
+/datum/supply_pack/faction/solfed/magazine/g36_drum
+	name = "G36 Drum Magazine Crate"
+	desc = "Contains 5.56x45mm drum magazine for the G36 family rifles, with a capacity of 75 rounds."
+	contains = list(/obj/item/ammo_box/magazine/g36/drum/empty)
+	cost = 5000


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет в карго СФ, возможность покупать патроны для их фирменного Оружия `G36` калибром `5.56x45mm`

## Причина создания ПР / Почему это хорошо для игры
На фисте лежит G36 к которому боеприпасы могут пополнять только Интеки
discord/bugs-code: [Отсутствие у SolFed пополнять G36 - InteQ перекупыч](https://discord.com/channels/1100198143456465067/1394020348894122066)

## Список изменений

:cl:
add: Карго СФ - Патроны `5.56x45mm`
add: Карго СФ - Обоймы для `G36`
:cl:
