### PR TITLE
TWEAK: Радио SolGov -> SolFed

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -17,7 +17,7 @@
 #define RADIO_KEY_CENTCOM "e"
 #define RADIO_TOKEN_CENTCOM ":e"
 
-#define RADIO_CHANNEL_SOLGOV "SolGov"
+#define RADIO_CHANNEL_SOLGOV "SolFed" //#define RADIO_CHANNEL_SOLGOV "SolGov"	// [CELADON-EDIT] - CELADON_FIXES
 #define RADIO_KEY_SOLGOV "s"
 #define RADIO_TOKEN_SOLGOV ":s"
 

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -127,7 +127,8 @@ Weebstick (Красная катана) теперь нельзя сломать
 ### Дефайны
 
 <!-- fax_name -->
-- `code/__defines/~mod_celadon/ship.dm`
+<!-- - `code/__defines/~mod_celadon/ship.dm` -->
+- `code/__DEFINES/radio.dm` - Переименование частоты SolGov -> SolFed
 
 <!--
   Если требовалось добавить какие-либо дефайны, укажи файлы,


### PR DESCRIPTION
## Переименование частоты рации у СФ
Меняет название частоты на правильную.

## Причина создания ПР / Почему это хорошо для игры
В описании ПР, у нас вместо `SolGov` фракция `SolFed`

## Список изменений

```yml
🆑
tweak: Название частоты `SolGov` -> `SolFed`
/🆑
```