### PR TITLE
TWEAK: Buff Sunset, nerf lavaland ruin

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
@@ -5266,7 +5266,6 @@
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
 /obj/item/radio,
-/obj/item/melee/duelenergy/saber/yellow,
 /turf/open/floor/plating/moss,
 /area/overmap_encounter/planetoid/lava/explored)
 "ZS" = (

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm
@@ -2446,7 +2446,7 @@
 	speak_emote = list("rants","screams","sobs");
 	verb_exclaim = "rants";
 	verb_yell = "rants";
-	weapon_drop_chance = 100
+	weapon_drop_chance = 0
 	},
 /turf/open/floor/carpet/blue,
 /area/ruin/lavaland/factory/manager_office)
@@ -2626,7 +2626,7 @@
 /area/ruin/lavaland/factory/warehouse)
 "yq" = (
 /obj/structure/displaycase/noalert{
-	start_showpiece_type = /obj/item/gun/energy/e_gun/hades
+	start_showpiece_type = /obj/item/melee/duelenergy/saber/red
 	},
 /turf/open/floor/carpet/blue,
 /area/ruin/lavaland/factory/manager_office)
@@ -5266,6 +5266,7 @@
 /area/overmap_encounter/planetoid/cave/explored)
 "ZO" = (
 /obj/item/radio,
+/obj/item/melee/duelenergy/saber/yellow,
 /turf/open/floor/plating/moss,
 /area/overmap_encounter/planetoid/lava/explored)
 "ZS" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -527,6 +527,13 @@
 	},
 /turf/open/floor/marble/black,
 /area/ship/hallway/fore)
+"hW" = (
+/obj/item/gun/ballistic/automatic/smg/wt550{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/template_noop,
+/area/template_noop)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -1075,8 +1082,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/guncloset,
 /obj/effect/turf_decal/spline/plain/opaque/syndiered,
-/obj/item/gun/ballistic/automatic/assault/hydra,
-/obj/item/gun/ballistic/automatic/assault/hydra,
 /obj/machinery/light/directional/north,
 /obj/item/gun/ballistic/automatic/smg/vector{
 	name = "Special Operations Vector";
@@ -1086,6 +1091,18 @@
 	desc = "A police carbine based on an old design originating from earth, Solar Federation. Modified by Gorlex and used as a common security SMG. Chambered in 45."
 	},
 /obj/item/gun/ballistic/automatic/assault/saiga,
+/obj/item/gun/ballistic/automatic/smg/wt550{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/gun/ballistic/automatic/smg/wt550{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/gun/ballistic/automatic/smg/wt550{
+	pixel_x = 0;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/lightdark,
 /area/ship/security/armory)
 "si" = (
@@ -1825,16 +1842,6 @@
 	name = "Ammo Locker";
 	req_access_txt = "1"
 	},
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/ammo_box/magazine/m556_42_hydra,
-/obj/item/storage/box/ammo/a556_42,
-/obj/item/storage/box/ammo/a556_42,
-/obj/item/storage/box/ammo/a556_42,
-/obj/item/storage/box/ammo/a556_42,
 /obj/item/attachment/laser_sight,
 /obj/item/attachment/laser_sight,
 /obj/item/attachment/laser_sight,
@@ -1846,6 +1853,21 @@
 /obj/item/ammo_box/magazine/saiga,
 /obj/item/storage/box/ammo/a410_ammo_box,
 /obj/item/ammo_box/magazine/saiga,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "CZ" = (
@@ -3961,7 +3983,7 @@ xo
 xo
 xo
 xo
-xo
+hW
 eD
 zO
 PP

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -527,13 +527,6 @@
 	},
 /turf/open/floor/marble/black,
 /area/ship/hallway/fore)
-"hW" = (
-/obj/item/gun/ballistic/automatic/smg/wt550{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/template_noop,
-/area/template_noop)
 "hX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -1091,17 +1084,17 @@
 	desc = "A police carbine based on an old design originating from earth, Solar Federation. Modified by Gorlex and used as a common security SMG. Chambered in 45."
 	},
 /obj/item/gun/ballistic/automatic/assault/saiga,
-/obj/item/gun/ballistic/automatic/smg/wt550{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/gun/ballistic/automatic/smg/sidewinder{
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/item/gun/ballistic/automatic/smg/wt550{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/gun/ballistic/automatic/smg/sidewinder{
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/item/gun/ballistic/automatic/smg/wt550{
-	pixel_x = 0;
-	pixel_y = 0
+/obj/item/gun/ballistic/automatic/smg/sidewinder{
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/lightdark,
 /area/ship/security/armory)
@@ -1853,21 +1846,45 @@
 /obj/item/ammo_box/magazine/saiga,
 /obj/item/storage/box/ammo/a410_ammo_box,
 /obj/item/ammo_box/magazine/saiga,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/ammo_box/magazine/wt550m9,
-/obj/item/storage/box/ammo/c46x30mm,
-/obj/item/storage/box/ammo/c46x30mm,
-/obj/item/storage/box/ammo/c46x30mm,
-/obj/item/storage/box/ammo/c46x30mm,
-/obj/item/storage/box/ammo/c46x30mm,
-/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/m57_39_sidewinder{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/storage/box/ammo/c57x39,
+/obj/item/storage/box/ammo/c57x39,
+/obj/item/storage/box/ammo/c57x39,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security/armory)
 "CZ" = (
@@ -3258,6 +3275,14 @@
 	name = "Syndicate dogtag";
 	desc = "And the dog tag marked with the name and rank of a Syndicate member."
 	},
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
 /turf/open/floor/marble/black,
 /area/ship/crew/cryo)
 "XM" = (
@@ -3983,7 +4008,7 @@ xo
 xo
 xo
 xo
-hW
+xo
 eD
 zO
 PP


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет гидры на стечкины и сайндвиндеры(Sunset)
Меняет хадесы на даблу(_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm)
## Причина создания ПР / Почему это хорошо для игры
приказ сверху
## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
tweak: 
Sunset: меняем гидры на три сайндвиндера и 4 стечкина
_maps/RandomRuins/LavaRuins/lavaland_surface_wrecked_factory.dmm: режем дроплут хадеса у менеджера и заменяем хадес на даблу в дисплей кейсе.
/🆑
```
