### PR TITLE
BUG-FIX: Исправление неверных флагов сокрытия частей ксеносов

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -914,7 +914,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "tajara_facial_hairs"
 
 	if("tajara_ears_markings" in mutant_bodyparts)
-		if(!H.dna.features["tajara_ears_markings"] || H.dna.features["tajara_ears_markings"] == "None" || H.head && (H.head.flags_inv & HIDEFACE) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || !HD) // || HD.status == BODYTYPE_ROBOTIC
+		if(!H.dna.features["tajara_ears_markings"] || H.dna.features["tajara_ears_markings"] == "None" || H.head && (H.head.flags_inv & HIDEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEEARS)) || !HD) // || HD.status == BODYTYPE_ROBOTIC
 			bodyparts_to_add -= "tajara_ears_markings"
 
 	if("tajara_head_markings" in mutant_bodyparts)
@@ -934,7 +934,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "tajara_hairs"
 
 	if("tajara_ears" in mutant_bodyparts)
-		if(!H.dna.features["tajara_ears"] || H.dna.features["tajara_ears"] == "None" || (H.head && (H.head.flags_inv & HIDEHAIR)))
+		if(!H.dna.features["tajara_ears"] || H.dna.features["tajara_ears"] == "None" || (H.head && (H.head.flags_inv & HIDEEARS)))
 			bodyparts_to_add -= "tajara_ears"
 
 	if("tajara_tail" in mutant_bodyparts)
@@ -957,7 +957,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "riol_facial_hairs"
 
 	if("riol_ears_markings" in mutant_bodyparts)
-		if(!H.dna.features["riol_ears_markings"] || H.dna.features["riol_ears_markings"] == "None" || H.head && (H.head.flags_inv & HIDEFACE) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEFACE)) || !HD) // || HD.status == BODYTYPE_ROBOTIC
+		if(!H.dna.features["riol_ears_markings"] || H.dna.features["riol_ears_markings"] == "None" || H.head && (H.head.flags_inv & HIDEEARS) || (H.wear_mask && (H.wear_mask.flags_inv & HIDEEARS)) || !HD) // || HD.status == BODYTYPE_ROBOTIC
 			bodyparts_to_add -= "riol_ears_markings"
 
 	if("riol_head_markings" in mutant_bodyparts)
@@ -993,7 +993,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "riol_tail"
 
 	if("riol_ears" in mutant_bodyparts)
-		if(!H.dna.features["riol_ears"] || H.dna.features["riol_ears"] == "None" || (H.head && (H.head.flags_inv & HIDEHAIR)))
+		if(!H.dna.features["riol_ears"] || H.dna.features["riol_ears"] == "None" || (H.head && (H.head.flags_inv & HIDEEARS)))
 			bodyparts_to_add -= "riol_ears"
 	// [/CELADON-ADD]
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет древний баг, когда надевая капюшон могли не скрыться ушки или маркинги ушек у таяр, риолов и т.д.
Теперь все работает. Также исправляет баг с наложением и пропаданием этих самых ушек при надевании любого оружия на спину https://canary.discord.com/channels/1100198143456465067/1356745629203693721 

## Демонстрация изменений / Тестирование
<img width="172" height="201" alt="изображение" src="https://github.com/user-attachments/assets/50eca739-032d-49c8-9e63-4f3b2b27e635" />

## Список изменений

```yml
🆑
fix: Исправлены дефайны, флаги на сокрытие частей тела: Уши, маркинги ушей
/🆑
```
