### PR TITLE
BUG-FIX: Кепори вновь умеют держать мелкие предметы в клюве

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -136,7 +136,7 @@
 	if(slot != ITEM_SLOT_MASK)
 		return FALSE
 	//Blocks all items that are equippable to other slots. (block anything with a flag that ISN'T item_slot_mask)
-	if(I.slot_flags & ~ITEM_SLOT_KEPORI_BEAK)
+	if(I.slot_flags && !ITEM_SLOT_KEPORI_BEAK)	// [CELADON-EDIT] - CELADON_FIXES - Было if(I.slot_flags & ~ITEM_SLOT_KEPORI_BEAK)
 		return FALSE
 	if(H.wear_mask && !swap)
 		return FALSE

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -85,7 +85,7 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code\modules\hydroponics\gene_modder.dm` - Добавление удаления мусора а не данных с диска
 
-- EDIT: `code\modules\hydroponics\grown\replicapod.dm` - Исправление отобрежения ДНК на сканере 
+- EDIT: `code\modules\hydroponics\grown\replicapod.dm` - Исправление отобрежения ДНК на сканере
 
 - EDIT: `code\modules\hydroponics\grown\replicapod.dm` - Исправлено появление людей из капусты
 
@@ -99,7 +99,9 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code/modules/clothing/head/helmet.dm` - Отображение оверлеев
 
-- EDIT: `code/modules/surgery/surgery_step.dm` - Исправление ухода операции в бесконечный цикл 
+- EDIT: `code/modules/surgery/surgery_step.dm` - Исправление ухода операции в бесконечный цикл
+
+- EDIT: `code/modules/mob/living/carbon/human/species_types/kepori.dm` : Делаем так чтобы кепори могли брать мелкие предметы в клюв
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Делаем так чтобы кепори могли брать мелкие предметы в клюв

## Демонстрация изменений / Тестирование
Кепори могут теперь нормально брать мелкие предметы в клюв. Даже гранату...
<img width="744" height="689" alt="image" src="https://github.com/user-attachments/assets/da5d9f08-8751-4018-9368-ff71f75566db" />
<img width="658" height="566" alt="image" src="https://github.com/user-attachments/assets/513d7fbb-87d6-4810-adce-6e6135ea7ab8" />
<img width="622" height="668" alt="image" src="https://github.com/user-attachments/assets/dc28c9d5-5c9d-427d-831a-a5e96dd87a62" />

## Список изменений

```yml
🆑
fix: Починена возможность брать в клюв мелкие вещие размера SMALL, такие как отвертки, кабели, фонарики, гранаты и т.д.
/🆑
```
