### PR TITLE
FIX: Риолы - Digi-legs try path

### DIFF
--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -160,19 +160,11 @@
 		if(BODY_ZONE_L_LEG)
 			if(species.is_digitigrade(src))
 				L = robotic ? new species.species_robotic_digi_l_leg() : new species.species_digi_l_leg()
-			// [CELADON-ADD] - CELADON_RIOL
-			else if(species.is_digitigrade(src) && BODYTYPE_RIOL)
-				L = new species.riol_digi_l_leg()
-			// [/CELADON-ADD]
 			else
 				L = robotic ? new species.species_robotic_l_leg() : new species.species_l_leg()
 		if(BODY_ZONE_R_LEG)
 			if(species.is_digitigrade(src))
 				L = robotic ? new species.species_robotic_digi_r_leg() : new species.species_digi_r_leg()
-			// [CELADON-ADD] - CELADON_RIOL
-			else if(species.is_digitigrade(src) && BODYTYPE_RIOL)
-				L = new species.riol_digi_r_leg()
-			// [/CELADON-ADD]
 			else
 				L = robotic ? new species.species_robotic_r_leg() : new species.species_r_leg()
 		if(BODY_ZONE_CHEST)

--- a/mod_celadon/riol/code/species/species.dm
+++ b/mod_celadon/riol/code/species/species.dm
@@ -7,8 +7,6 @@
 /datum/species
 	/// Does the species use skintones or not?
 	var/use_skintoneriol = FALSE
-	var/obj/item/bodypart/riol_digi_l_leg = /obj/item/bodypart/leg/left/riol/digitigrade
-	var/obj/item/bodypart/riol_digi_r_leg = /obj/item/bodypart/leg/right/riol/digitigrade
 
 /datum/species/riol
 	name = "\improper Riol"
@@ -22,6 +20,7 @@
 	disliked_food = VEGETABLES | FRUIT | GRAIN | GROSS
 	liked_food = MEAT | RAW | DAIRY
 	digitigrade_customization = DIGITIGRADE_OPTIONAL
+
 
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'
@@ -92,8 +91,8 @@
 	species_r_arm = /obj/item/bodypart/r_arm/riol
 	species_l_leg = /obj/item/bodypart/leg/left/riol
 	species_r_leg = /obj/item/bodypart/leg/right/riol
-	riol_digi_l_leg = /obj/item/bodypart/leg/left/riol/digitigrade
-	riol_digi_r_leg = /obj/item/bodypart/leg/right/riol/digitigrade
+	species_digi_l_leg = /obj/item/bodypart/leg/left/riol/digitigrade
+	species_digi_r_leg = /obj/item/bodypart/leg/right/riol/digitigrade
 
 	species_robotic_chest = /obj/item/bodypart/chest/robot
 	species_robotic_head = /obj/item/bodypart/head/robot


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправлен недочет в коде, из-за чего всегда присваивались диги-ноги ящеров к риолам.

## Список изменений

```yml
🆑
fix: Риолы - используют свои Диги-ноги, а не Диги-ноги Сарати
/🆑
```