### PR TITLE
Cargo Update - Add contents in cargo supply packs

### DIFF
--- a/mod_celadon/outpost_console/_outpost_console.dme
+++ b/mod_celadon/outpost_console/_outpost_console.dme
@@ -38,6 +38,7 @@
 #include "code/supply_pack/inteq/magazines.dm"
 #include "code/supply_pack/inteq/mechs.dm"
 #include "code/supply_pack/inteq/medical.dm"
+#include "code/supply_pack/inteq/sec_supply.dm"
 #include "code/supply_pack/inteq/spacesuit.dm"
 
 #include "code/supply_pack/nanotrasen/ammo.dm"
@@ -46,6 +47,7 @@
 #include "code/supply_pack/nanotrasen/magazines.dm"
 #include "code/supply_pack/nanotrasen/mechs.dm"
 #include "code/supply_pack/nanotrasen/medical.dm"
+#include "code/supply_pack/nanotrasen/sec_supply.dm"
 #include "code/supply_pack/nanotrasen/spacesuit.dm"
 #include "code/supply_pack/nanotrasen/tools.dm"
 

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/sec_supply.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/sec_supply.dm
@@ -1,0 +1,11 @@
+/datum/supply_pack/faction/inteq/sec_supply
+	category = "Security Supplies"
+	crate_type = /obj/structure/closet/crate/secure/gear
+
+/datum/supply_pack/faction/inteq/sec_supply/saber
+	name = "Double-Bladed Energy Sword Crate"
+	desc = "Contains one double-bladed energy sword, for when simply killing someone isn't enough."
+	cost = 3600
+	contains = list(/obj/item/melee/duelenergy/saber)
+	crate_name = "dualsaber crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/sec_supply.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/sec_supply.dm
@@ -1,0 +1,11 @@
+/datum/supply_pack/faction/nanotrasen/sec_supply
+	category = "Security Supplies"
+	crate_type = /obj/structure/closet/crate/secure/gear
+
+/datum/supply_pack/faction/nanotrasen/sec_supply/saber
+	name = "Proto-Magnetic Crusher Crate"
+	desc = "Contains one multipurpose disembarkation and self-defense tool designed by EXOCOM using an incomplete Nanotrasen prototype."
+	cost = 1500
+	contains = list(/obj/item/kinetic_crusher)
+	crate_name = "dualsaber crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/sec_supply.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/sec_supply.dm
@@ -5,7 +5,7 @@
 /datum/supply_pack/faction/solfed/sec_supply/halberd
 	name = "Energy Halberd Crate"
 	desc = "Contains one Solarian Energy Halberd, for issue to your local Sonnensoldner battalion."
-	cost = 1500
+	cost = 3000
 	contains = list(/obj/item/melee/duelenergy/halberd)
 	crate_name = "energy halberd crate"
 

--- a/mod_celadon/outpost_console/code/supply_pack/syndicate/sec_supply.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/syndicate/sec_supply.dm
@@ -2,6 +2,14 @@
 	category = "Security Supplies"
 	crate_type = /obj/structure/closet/crate/secure/gear
 
+/datum/supply_pack/faction/syndicate/sec_supply/saber
+	name = "Double-Bladed Energy Sword Crate"
+	desc = "Contains one double-bladed energy sword, for when simply killing someone isn't enough."
+	cost = 3000
+	contains = list(/obj/item/melee/duelenergy/saber)
+	crate_name = "dualsaber crate"
+	crate_type = /obj/structure/closet/crate/secure/weapon
+
 /datum/supply_pack/faction/syndicate/sec_supply/flamethrower
 	name = "Flamethrower Crate"
 	desc = "Contains one flamethrower. Point the nozzle away from anything important."


### PR DESCRIPTION
## Описание / Что этот PR делает
_Повышение цен:_
**Energy Halberd Crate** в карго SolarFederation: **1500 => 3000**

_Добавлен новый товар:_
**"Double-Bladed Energy Sword Crate"** в карго Syndicate по цене: **3000cr.**
**"Double-Bladed Energy Sword Crate"** в карго InteQ по цене: **3600cr.**
**"Proto-Magnetic Crusher Crate"** в карго Nanotrasen по цене: **1500cr.**

## Демонстрация изменений / Тестирование
<img width="1425" height="925" alt="image" src="https://github.com/user-attachments/assets/8336c661-c4e1-4d05-a7c1-db23628a210f" />

## Список изменений

```yml
🆑
add: Добавлены новые предметы в карго Supply Packs.
tweak: Поднята цена в два раза на Energy Halbert в карго SF.
/🆑
```
