### PR TITLE
FIXES: Попытка починить дикую радиацию

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -22,9 +22,14 @@
 			continue
 		processing_list += thing.contents
 
+// [CELADON-EDIT] - CELADON_FIXES_RADIATION
+// /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
+// 	// fusion will never ever be balanced. god bless it
+// 	intensity = min(intensity, INFINITY)	// ORIGINAL
 /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
-	// fusion will never ever be balanced. god bless it
-	intensity = min(intensity, INFINITY)
+	// Ограничиваем максимальное значение радиации
+	intensity = SSradiation.cap_radiation(intensity)
+// [/CELADON-EDIT]
 
 	if(!SSradiation.can_fire)
 		return

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -5,7 +5,7 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 
 	var/list/warned_atoms = list()
 
-	// Максимальное значение радиации для предотвращения чрезмерного накопления
+	// Максимальное значение радиации для предотвращения чрезмерного накопления // [CELADON-ADD]
 	var/max_radiation_value = 500000	// [CELADON-ADD] - CELADON_FIXES_RADIATION
 
 /datum/controller/subsystem/processing/radiation/proc/warn(datum/component/radioactive/contamination)

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -6,7 +6,7 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 	var/list/warned_atoms = list()
 
 	// Максимальное значение радиации для предотвращения чрезмерного накопления
-	var/max_radiation_value = 10000	// [CELADON-ADD] - CELADON_FIXES_RADIATION
+	var/max_radiation_value = 500000	// [CELADON-ADD] - CELADON_FIXES_RADIATION
 
 /datum/controller/subsystem/processing/radiation/proc/warn(datum/component/radioactive/contamination)
 	if(!contamination || !contamination.parent || QDELETED(contamination))

--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -1,9 +1,12 @@
 PROCESSING_SUBSYSTEM_DEF(radiation)
 	name = "Radiation"
-	flags = SS_NO_INIT | SS_BACKGROUND
+	flags = SS_BACKGROUND	// [CELADON-EDIT] - CELADON_FIXES_RADIATION // flags = SS_NO_INIT | SS_BACKGROUND	// ORIGINAL
 	wait = 1 SECONDS
 
 	var/list/warned_atoms = list()
+
+	// Максимальное значение радиации для предотвращения чрезмерного накопления
+	var/max_radiation_value = 10000	// [CELADON-ADD] - CELADON_FIXES_RADIATION
 
 /datum/controller/subsystem/processing/radiation/proc/warn(datum/component/radioactive/contamination)
 	if(!contamination || !contamination.parent || QDELETED(contamination))
@@ -16,3 +19,20 @@ PROCESSING_SUBSYSTEM_DEF(radiation)
 	SSblackbox.record_feedback("tally", "contaminated", 1, master.type)
 	var/msg = "has become contaminated with enough radiation to contaminate other objects. || Source: [contamination.source] || Strength: [contamination.strength]"
 	master.investigate_log(msg, INVESTIGATE_RADIATION)
+
+// [CELADON-ADD] - CELADON_FIXES_RADIATION
+/datum/controller/subsystem/processing/radiation/Initialize()
+	. = ..()
+	// Проверяем и исправляем существующие высокие значения радиации
+	for(var/datum/component/radioactive/R in processing)
+		if(R.strength > max_radiation_value)
+			R.strength = max_radiation_value
+			if(R.parent)
+				var/atom/A = R.parent
+				A.investigate_log("Radiation value capped from [R.strength] to [max_radiation_value]", INVESTIGATE_RADIATION)
+
+/datum/controller/subsystem/processing/radiation/proc/cap_radiation(value)
+	if(value > max_radiation_value)
+		return max_radiation_value
+	return value
+// [/CELADON-ADD]

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -13,7 +13,8 @@
 
 /datum/component/radioactive/Initialize(_strength=0, _source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE)
 	// shouldn't ever happen, but it pays to be a little careful
-	strength = min(_strength, INFINITY)
+	// Ограничиваем максимальное значение радиации
+	strength = SSradiation.cap_radiation(_strength)	// [CELADON-EDIT] - CELADON_FIXES_RADIATION // strength = min(_strength, INFINITY)	// ORIGINAL
 	source = _source
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
@@ -46,7 +47,19 @@
 	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 	if(!hl3_release_date)
 		return
-	strength -= strength / hl3_release_date
+
+	// [CELADON-ADD] - CELADON_FIXES_RADIATION
+	// Ускоренное уменьшение для больших значений
+	if(strength > 1000)
+		// Для больших значений уменьшаем быстрее
+		var/decay_factor = max(1, log(10, strength) / 2)
+		strength -= (strength / hl3_release_date) * decay_factor
+	else
+		// Стандартное уменьшение
+		strength -= strength / hl3_release_date
+
+	// Проверка на минимальное значение
+	// [/CELADON-ADD]
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(src)
 		return PROCESS_KILL
@@ -63,9 +76,11 @@
 		return
 	if(C)
 		var/datum/component/radioactive/other = C
-		strength = max(strength, other.strength)
+	// [CELADON-EDIT] - CELADON_FIXES_RADIATION
+		strength = SSradiation.cap_radiation(max(strength, other.strength))	// strength = max(strength, other.strength) // ORIGINAL
 	else
-		strength = max(strength, _strength)
+		strength = SSradiation.cap_radiation(max(strength, _strength)) // strength = max(strength, _strength) // ORIGINAL
+	// [/CELADON-EDIT]
 
 /datum/component/radioactive/proc/rad_examine(datum/source, mob/user, atom/thing)
 	SIGNAL_HANDLER

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -13,7 +13,7 @@
 
 /datum/component/radioactive/Initialize(_strength=0, _source, _half_life=RAD_HALF_LIFE, _can_contaminate=TRUE)
 	// shouldn't ever happen, but it pays to be a little careful
-	// Ограничиваем максимальное значение радиации
+	// Ограничиваем максимальное значение радиации // [CELADON-ADD]
 	strength = SSradiation.cap_radiation(_strength)	// [CELADON-EDIT] - CELADON_FIXES_RADIATION // strength = min(_strength, INFINITY)	// ORIGINAL
 	source = _source
 	hl3_release_date = _half_life
@@ -48,7 +48,8 @@
 	if(!hl3_release_date)
 		return
 
-	// [CELADON-ADD] - CELADON_FIXES_RADIATION
+	// [CELADON-EDIT] - CELADON_FIXES_RADIATION
+	//strength -= strength / hl3_release_date	// ORIGINAL
 	// Ускоренное уменьшение для больших значений
 	if(strength > 1000)
 		// Для больших значений уменьшаем быстрее
@@ -59,7 +60,7 @@
 		strength -= strength / hl3_release_date
 
 	// Проверка на минимальное значение
-	// [/CELADON-ADD]
+	// [/CELADON-EDIT]
 	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(src)
 		return PROCESS_KILL

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -17,7 +17,6 @@ ID мода: CELADON_FIXES
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
 -->
-CELADON_FIXES_RADIATION
 
 ### Описание мода
 
@@ -106,11 +105,6 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code/datums/mapgen/planetary/waterGenerator.dm` : Убираем спавн лавы на водяной планете
 
-
-
-
-
-- `code/datums/components/radioactive.dm`, `code/controllers/subsystem/radiation.dm`, `code/__HELPERS/radiation.dm`
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -17,6 +17,7 @@ ID мода: CELADON_FIXES
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
 -->
+CELADON_FIXES_RADIATION
 
 ### Описание мода
 
@@ -105,6 +106,11 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code/datums/mapgen/planetary/waterGenerator.dm` : Убираем спавн лавы на водяной планете
 
+
+
+
+
+- `code/datums/components/radioactive.dm`, `code/controllers/subsystem/radiation.dm`, `code/__HELPERS/radiation.dm`
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет радиацию. А именно, ограничивает верхний предел радиации с INFINITY до 10000. Вводится механизм по снижению радиации при огромных её значениях, старый способ оставлен. Т.е. теперь есть быстр метод и медленный. Все данные действия должны снизить нагрузку на сервер при неконтролируемом росте радиации.

## Список изменений

```yml
🆑
tweak: Введены ограничения на кап радиации и методы её снижения на фоне
/🆑
```
