### PR TITLE
Ai controller fix & Kinetic Crusher against hostiles

### DIFF
--- a/code/controllers/subsystem/ai_controllers.dm
+++ b/code/controllers/subsystem/ai_controllers.dm
@@ -25,9 +25,16 @@ SUBSYSTEM_DEF(ai_controllers)
 /datum/controller/subsystem/ai_controllers/fire(resumed)
 	for(var/datum/ai_controller/ai_controller as anything in active_ai_controllers)
 		// [CELADON-EDIT] — IDLE_NPC_SLEEP
-		ai_controller.check_should_sleep()
-		// [/CELADON-EDIT]
+		if(isnull(ai_controller)) // Раньше удаление из списка было в ai_controller/proc/set_ai_status(), но чтобы мониторить отключенных перенёс из прока выключение на проверку удалённого датума
+			active_ai_controllers -= ai_controller.pawn
+			continue
 
+		ai_controller.check_should_sleep()
+
+		if(ai_controller.ai_status == AI_STATUS_OFF)
+			continue
+
+		// [/CELADON-EDIT]
 		if(!COOLDOWN_FINISHED(ai_controller, failed_planning_cooldown))
 			continue
 

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -217,11 +217,16 @@ multiple modular subtrees with behaviors
 	ai_status = new_ai_status
 	switch(ai_status)
 		if(AI_STATUS_ON)
-			SSai_controllers.active_ai_controllers += src
+			// [CELADON-ADD] — IDLE_NPC_SLEEP
+			if(!(src in SSai_controllers.active_ai_controllers))
+			// [CELADON-ADD]
+				SSai_controllers.active_ai_controllers += src
 			START_PROCESSING(SSai_behaviors, src)
 		if(AI_STATUS_OFF)
 			STOP_PROCESSING(SSai_behaviors, src)
-			SSai_controllers.active_ai_controllers -= src
+			// [CELADON-REMOVE] — IDLE_NPC_SLEEP — Перенёс прок на удаление из листа в сабсистему
+			// SSai_controllers.active_ai_controllers -= src
+			// [CELADON-REMOVE]
 			CancelActions()
 
 /datum/ai_controller/proc/PauseAi(time)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -220,18 +220,6 @@
 	desc = "Your biological functions have halted. You could live forever this way, but it's pretty boring."
 	icon_state = "stasis"
 
-/datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
-	if(isnum(set_duration))
-		duration = set_duration
-	. = ..()
-
-/datum/status_effect/pacify/on_apply()
-	ADD_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-	return ..()
-
-/datum/status_effect/pacify/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_PACIFISM, "status_effect")
-
 //OTHER DEBUFFS
 /datum/status_effect/pacify
 	id = "pacify"
@@ -266,7 +254,10 @@
 		hammer_synced = new_hammer_synced
 
 /datum/status_effect/crusher_mark/on_apply()
-	if(owner.mob_size >= MOB_SIZE_LARGE)
+	// [CELADON-EDIT] — CRUSHER_MARK_ON_MOBS
+	// if(owner.mob_size >= MOB_SIZE_LARGE)
+	if(owner.mob_size >= MOB_SIZE_HUMAN && !(ishuman(owner)))
+	// [CELADON-EDIT]
 		marked_underlay = mutable_appearance('icons/effects/effects.dmi', "shield2")
 		marked_underlay.pixel_x = -owner.pixel_x
 		marked_underlay.pixel_y = -owner.pixel_y

--- a/mod_celadon/mobs/code/ai_controller.dm
+++ b/mod_celadon/mobs/code/ai_controller.dm
@@ -3,7 +3,7 @@
 	var/players_on_virtual_z = 0
 	if(virt_z)
 		players_on_virtual_z = LAZYACCESS(SSmobs.players_by_virtual_z, "[virt_z]")
-		if(ai_status == AI_STATUS_ON && !length(players_on_virtual_z))
+		if(!length(players_on_virtual_z))
 			set_ai_status(AI_STATUS_OFF)
 		else if(ai_status == AI_STATUS_OFF)
 			set_ai_status(AI_STATUS_ON)


### PR DESCRIPTION
## Описание / Что этот PR делает
Чинит ИИ мобов, и Кинетические крашеры

## Причина создания ПР / Почему это хорошо для игры
- Хостайлы давно ушли за пределы большого размера, а крашер против них не работал в полную мощность.
- Мобы, работающие от контроллеров, а не от базового ИИ, теперь будут переключаться нормально.

## Демонстрация изменений / Тестирование
`бебебе с бабаба`

## Список изменений
```yml
🆑
fix: AI_Controller теперь активируется при наличии игроков на virt_z
fix: Метка крашера теперь работает на мобов среднего размера и выше (кроме карбонов)
fix: Почистил дублирующийся код
/🆑
```
