### PR TITLE
[TESTMERGE] FIX: Магнитные ботинки снвова работают

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -46,7 +46,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
-	return clothing_flags & NOSLIP
+	return magpulse // [CELADON-EDIT] - FIXES_CELADON_MAGBOOTS // return clothing_flags & NOSLIP // ORIGINAL
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
Инженеры спустя год, наконец-то поняли почему магбутцы не работали. Надо было переключить тумблер с NOSLIP на приманичивание...

## Причина создания ПР / Почему это хорошо для игры
Магбутцы не работали

## Список изменений

```yml
🆑
tweak: Изменен прок на актвивацию магбутцов
/🆑
```
