### PR TITLE
TWEAK: Color Tooltips for new UI

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -147,13 +147,22 @@
 				background-color: #354e35;
 			}
 
-			.operative .wrap {
-				border-color: #1e0101;
+			.tetramon .wrap {
+				border-color: #2b2b33;
 			}
-			.operative .content {
-				color: #ffffff;
+			.tetramon .content {
+				color: #ffa800;
 				border-color: #750000;
 				background-color: #350000;
+			}
+
+			.wayfaron .wrap {
+				border-color: #256fb9;
+			}
+			.wayfaron .content {
+				color: #ffffff;
+				border-color: #000075;
+				background-color: #000035;
 			}
 		</style>
 	</head>

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -147,6 +147,15 @@
 				background-color: #354e35;
 			}
 
+			.operative .wrap {
+				border-color: #1e0101;
+			}
+			.operative .content {
+				color: #ffffff;
+				border-color: #750000;
+				background-color: #350000;
+			}
+
 			.tetramon .wrap {
 				border-color: #2b2b33;
 			}

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -157,12 +157,12 @@
 			}
 
 			.tetramon .wrap {
-				border-color: #2b2b33;
+				border-color: #FFA800;
 			}
 			.tetramon .content {
 				color: #ffa800;
-				border-color: #750000;
-				background-color: #350000;
+				border-color: #38200a;
+				background-color: #1e0101;
 			}
 
 			.wayfaron .wrap {
@@ -170,8 +170,8 @@
 			}
 			.wayfaron .content {
 				color: #ffffff;
-				border-color: #000075;
-				background-color: #000035;
+				border-color: #0a131a;
+				background-color: #111920;
 			}
 		</style>
 	</head>


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет тултипам цвета для соответствующих новых тем из #1842

## Демонстрация изменений
`Tetramoon (Ru)`
<img width="314" height="84" alt="image" src="https://github.com/user-attachments/assets/f6fd55ec-e69d-49cd-9700-7a74724ecb6b" />
`Wayfaron (Goon)`
<img width="317" height="97" alt="image" src="https://github.com/user-attachments/assets/1d1a8249-b6c7-4a91-a464-3322ae4110e5" />


## Список изменений

```yml
🆑
tweak: UI styles - Цвета фона для подсказок (тултипов) при наведении
/🆑
```
