### PR TITLE
RE-BALANCE: Медленные ролики

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -264,7 +264,7 @@
 /obj/vehicle/ridden/scooter/wheelys/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 0
+	D.vehicle_move_delay = 0.15	// [CELADON-EDIT] - CELADON_BALANCE - Замедляем ролики на 15%. Чем выше - тем медленнее	// D.vehicle_move_delay = 0	// ORIGINAL
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -264,7 +264,7 @@
 /obj/vehicle/ridden/scooter/wheelys/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 0.15	// [CELADON-EDIT] - CELADON_BALANCE - Замедляем ролики на 15%. Чем выше - тем медленнее	// D.vehicle_move_delay = 0	// ORIGINAL
+	D.vehicle_move_delay = 0.65	// [CELADON-EDIT] - CELADON_BALANCE - Ускорение роликов теперь не равно 100 а всего на 35%. Чем выше - тем медленнее	// D.vehicle_move_delay = 0	// ORIGINAL
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -107,6 +107,8 @@ EDIT: `code/game/objects/items/storage/backpack.dm`
 
 ADD: `code/modules/overmap/objects/event_datum.dm` : Добавляем дебрисам рандом на безопасную скорость полетов
 
+EDIT: `code/modules/vehicles/scooter.dm` : Ролики замедлены на 15%
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -107,7 +107,7 @@ EDIT: `code/game/objects/items/storage/backpack.dm`
 
 ADD: `code/modules/overmap/objects/event_datum.dm` : Добавляем дебрисам рандом на безопасную скорость полетов
 
-EDIT: `code/modules/vehicles/scooter.dm` : Ролики замедлены на 15%
+EDIT: `code/modules/vehicles/scooter.dm` : Ускорение от роликов равно 35% а не 100% как было
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Этот ПР  ролики - обувь, замедляя их, оставляю всего 35% от бонусной скорости, а не все 100% как было.
По умолчанию скорость стояла сверхбыстрая, что давала преимущество не обоснованное.

## Список изменений

```yml
🆑
balance: Изменена скорость у роликов, бонусная скорость равна +35%
/🆑
```
