### PR TITLE
MAP-FIX: Замена крови U на -O

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_underground_solfed_prison.dmm
+++ b/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_underground_solfed_prison.dmm
@@ -3324,7 +3324,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 6
 	},
-/obj/item/reagent_containers/blood/universal{
+/obj/item/reagent_containers/blood/OMinus{
 	pixel_x = 5;
 	pixel_y = 5
 	},

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -993,7 +993,7 @@
 /obj/structure/closet/crate/freezer,
 /obj/machinery/iv_drip,
 /obj/machinery/light/directional/south,
-/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
 "kx" = (

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_valor.dmm
@@ -4702,9 +4702,9 @@
 "Re" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/patterned/ridged,
 /area/ship/cargo)

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -1102,12 +1102,12 @@
 /area/ship/crew)
 "Ef" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/universal{
+/obj/item/reagent_containers/blood/OMinus{
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal{
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus{
 	pixel_x = -4;
 	pixel_y = -4
 	},

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_hyena.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_hyena.dmm
@@ -608,8 +608,8 @@
 /obj/structure/closet/crate/freezer,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/north,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/universal,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "lt" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Заменяет на всех картах пакеты с кровью с U на -O

## Причина создания ПР / Почему это хорошо для игры
Они нигде не используются в билде, наносят токсины лол.

## Список изменений

```yml
🆑
fix: Карты - Пакеты с кровью U -> -O
/🆑
```
