### PR TITLE
BALANCE: Price increase for Firestorm and .44HP ammo

### DIFF
--- a/mod_celadon/outpost_console/code/supply_pack/independent/gun.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/independent/gun.dm
@@ -108,7 +108,7 @@ MARK: SMGs
 /datum/supply_pack/faction/independent/gun/firestorm
 	name = "Firestorm SMG Crate"
 	desc = "Contains a Hunter's Pride SMG, intended for internal use by hunters and chambered in .44 Roumain."
-	cost = 3000
+	cost = 4000
 	contains = list(/obj/item/storage/guncase/firestorm)
 	crate_name = "SMG crate"
 

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
@@ -89,7 +89,7 @@ MARK: .44
 	name = ".44 Roumain Hollow Point Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a44roum_hp)
-	cost = 395
+	cost = 350
 
 /*
 MARK: .357

--- a/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/ammo.dm
@@ -89,7 +89,7 @@ MARK: .44
 	name = ".44 Roumain Hollow Point Ammo Box Crate"
 	desc = "Contains a 48-round box of .44 roumain hollow point ammo, great against unarmored targets."
 	contains = list(/obj/item/storage/box/ammo/a44roum_hp)
-	cost = 265
+	cost = 395
 
 /*
 MARK: .357


### PR DESCRIPTION
## Описание / Что этот PR делает
Повышает в карго цену на автомат Firestorm и на патроны калибра .44 Hollow Point

## Причина создания ПР / Почему это хорошо для игры
Слишком сильный автомат для текущей ценовой категории. HP пули имеют весьма хорошее соотношение урон/пробитие поэтому на них цена тоже возрастает.

## Список изменений
```yml
🆑
balance: Firestorm cost 3000 -> 4000. 
balance: .44 HP ammo box cost 265 -> 350
/🆑
```
