### PR TITLE
ADD: Добавляет показ музыки в лобби

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -287,9 +287,6 @@ SUBSYSTEM_DEF(ticker)
 	SSredbot.send_discord_message("ooc", "**A new round has begun.**")
 //[CELADON-EDIT]- MUSIC_CELADON
 //	SEND_SOUND(world, sound('sound/roundstart/addiguana.ogg'))//CELADON-EDIT-ORIGINAL
-	if(login_music_name)
-		var/count_name = length(SSticker.login_music_name)
-		to_chat(world, span_redteamradio("<B>Playing lobby music: [copytext(SSticker.login_music_name, 1, count_name-3)].</B>"))
 	SEND_SOUND(world, sound('mod_celadon/_storge_sounds/sound/lobby/sztart.ogg'))
 //[/CELADON-EDIT]
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -212,6 +212,11 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+// [CELADON-ADD]- MUSIC_CELADON
+		if(SSticker.login_music_name)
+			var/count_name = length(SSticker.login_music_name)
+			to_chat(world, span_redteamradio("<B>Playing lobby music: [copytext(SSticker.login_music_name, 1, count_name-3)].</B>"))
+// [/CELADON-ADD]
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь действительно будет писать всегда музыку из лобби.

<img width="643" height="262" alt="image" src="https://github.com/user-attachments/assets/519e0f52-7cd6-400f-9428-6d23023ab258" />

## Список изменений

```yml
🆑
add: Перемещено отображению музыки из окончания Инициализации лобби в само Лобби
/🆑
```
