### PR TITLE
GITHUB: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,11 +32,11 @@
 
 # Map Maintainers
 
-# molnizz
+# Kenfarka
 
-/_maps/_mod_celadon/ @molnizz
-/**/*.dmm @molnizz
-/**/*.json @molnizz
+/_maps/_mod_celadon/ @Kenfarka
+/**/*.dmm @Kenfarka
+/**/*.json @Kenfarka
 
 
 # Sprite Maintainers


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет мейнтенера по картам вместо `molnizz` на нового - `Kenfarka`, так как требуется права для рассмотрения PR`s.
