### PR TITLE
Tweak: changes rigs vanguard to pointmen rig

### DIFF
--- a/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
@@ -1134,7 +1134,7 @@
 /obj/effect/turf_decal/corner/opaque/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
-/obj/item/clothing/suit/space/hardsuit/security/inteq,
+/obj/item/clothing/suit/space/hardsuit/syndi/inteq,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "gj" = (
@@ -3761,8 +3761,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq{
 	pixel_x = -8;
-	pixel_y = 8;
-
+	pixel_y = 8
 	},
 /obj/structure/sign/poster/retro/lasergun_new{
 	pixel_x = -32

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
@@ -3761,7 +3761,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq{
 	pixel_x = -8;
-	pixel_y = 8
+	pixel_y = 8;
+
 	},
 /obj/structure/sign/poster/retro/lasergun_new{
 	pixel_x = -32

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_valor.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_valor.dmm
@@ -218,7 +218,7 @@
 /area/ship/hallway/central)
 "bS" = (
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/security/inteq,
+/obj/item/clothing/suit/space/hardsuit/syndi/inteq,
 /turf/open/floor/carpet/orange,
 /area/ship/bridge)
 "cj" = (

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_vaquero.dmm
@@ -3058,7 +3058,7 @@
 	req_access_txt = "20"
 	},
 /obj/item/tank/internals/oxygen,
-/obj/item/clothing/suit/space/hardsuit/security/inteq,
+/obj/item/clothing/suit/space/hardsuit/syndi/inteq,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "VN" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Замена ригов вангардов на поинтмен риги
## Причина создания ПР / Почему это хорошо для игры
Приказ хед мапера

## Список изменений

```yml
🆑
tweak: замена ригов вангарда для валора, вакьеро и талоса.
/🆑
```
