### PR TITLE
MAP: Delete modsuits from ships

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_alone.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_alone.dmm
@@ -373,7 +373,8 @@
 	},
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/mod/control/pre_equipped/standard,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/eva,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Wp" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
@@ -2334,7 +2334,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/suit_storage_unit/inherit,
-/obj/item/mod/control/pre_equipped/research,
+/obj/item/clothing/suit/space/hardsuit/rd,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "Id" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
@@ -1296,8 +1296,8 @@
 	dir = 1
 	},
 /obj/item/clothing/mask/gas/atmos/captain,
-/obj/item/mod/control/pre_equipped/magnate,
 /obj/item/tank/jetpack/oxygen/captain,
+/obj/item/clothing/suit/space/hardsuit/swat/captain,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm/captain)
 "dR" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_savior.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_savior.dmm
@@ -3709,8 +3709,8 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/mask/breath/medical,
-/obj/item/mod/control/pre_equipped/rescue,
 /obj/item/tank/internals/oxygen,
+/obj/item/clothing/suit/space/hardsuit/medical/cmo,
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "VL" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
@@ -2020,7 +2020,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/mod/control/pre_equipped/engineering,
+/obj/item/clothing/suit/space/solgov{
+	desc = "Originally designed by independent contractors on Luna for the purposes of survival in hazardous environments, the lightweight Tortoise Microlite Armored Suit now sees widespread use by SolFed's exploration teams.";
+	name = "\improper SolFed Vacuum Suit"
+	},
+/obj/item/clothing/head/helmet/space/solgov{
+	name = "\improper SolFed Vacuum Helmet"
+	},
+/obj/item/tank/jetpack/carbondioxide,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "LU" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Удаляет до конца модсьюты с кораблей.
## Причина создания ПР / Почему это хорошо для игры
Вообще, это должно было случиться раньше, поскольку большую часть модсьютов уже удалили. Если кратко, большинство модулей на данный момент сломано. По сути, большая часть модсьютов потеряла смысл. Если их когда-нибудь починят, они снова появятся на кораблях.

## Список изменений

```yml
🆑
del: Удалены остатки модсьютов с кораблей
/🆑
```
