### PR TITLE
MAP: Buff SolFed ships

### DIFF
--- a/_maps/_mod_celadon/shuttles/solfed/solfed_anomaly.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_anomaly.dmm
@@ -1387,6 +1387,29 @@
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/pistol556mm{
+	pixel_x = -12
+	},
+/obj/item/ammo_box/magazine/pistol556mm{
+	pixel_x = -7
+	},
+/obj/item/ammo_box/magazine/pistol556mm{
+	pixel_x = 6
+	},
+/obj/item/ammo_box/magazine/pistol556mm{
+	pixel_x = -7
+	},
+/obj/item/gun/ballistic/automatic/pistol/solgov{
+	pixel_y = 6;
+	layer = 3.2;
+	pixel_x = -6
+	},
+/obj/item/gun/ballistic/automatic/pistol/solgov{
+	pixel_y = 6;
+	layer = 3.2;
+	pixel_x = 5
+	},
 /turf/open/floor/marble/black,
 /area/ship/bridge)
 "vd" = (
@@ -2410,11 +2433,11 @@
 	},
 /area/ship/general/cargo/cargo_bay)
 "MH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/wood/fancy/royalblack,
+/obj/structure/sign/poster/solfed/random{
+	pixel_y = 32
 	},
-/obj/structure/sign/poster/solfed/random,
-/turf/closed/wall/r_wall/syndicate,
+/turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "Nd" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -3751,8 +3774,8 @@ qH
 qH
 qH
 Sf
+Yw
 MH
-Ro
 Ro
 ys
 ys

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
@@ -422,12 +422,13 @@
 /obj/item/storage/box/ammo/ferropellet,
 /obj/item/storage/box/ammo/ferropellet,
 /obj/item/storage/box/ammo/ferropellet,
-/obj/item/storage/box/ammo/c556mm,
-/obj/item/storage/box/ammo/c556mm,
-/obj/item/storage/box/ammo/c556mm,
 /obj/item/ammo_box/magazine/gauss,
 /obj/item/ammo_box/magazine/gauss,
 /obj/item/ammo_box/magazine/gauss,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/storage/box/ammo/a556_box,
 /turf/open/floor/marble/black,
 /area/ship/security)
 "cY" = (
@@ -609,6 +610,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/item/gun/ballistic/automatic/assault/g36,
 /turf/open/floor/marble/black,
 /area/ship/security)
 "fj" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
@@ -1613,9 +1613,9 @@
 /obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/item/gun/ballistic/automatic/pistol/solgov,
-/obj/item/gun/ballistic/automatic/pistol/solgov,
-/obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/machinery/airalarm/directional/south,
+/obj/item/gun/ballistic/automatic/assault/g36,
+/obj/item/gun/ballistic/automatic/assault/g36,
 /turf/open/floor/wood/ebony,
 /area/ship/security/armory)
 "Gq" = (
@@ -2149,10 +2149,16 @@
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/storage/box/ammo/a556_box,
+/obj/item/storage/box/ammo/a556_box,
+/obj/item/storage/box/ammo/a556_box,
+/obj/item/storage/box/ammo/a556_box,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36,
 /turf/open/floor/wood/ebony,
 /area/ship/security/armory)
 "NU" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
@@ -3210,16 +3210,19 @@
 /obj/item/gun/ballistic/automatic/pistol/solgov{
 	pixel_x = -2
 	},
-/obj/item/gun/ballistic/automatic/pistol/solgov{
-	pixel_x = 1
-	},
-/obj/item/gun/ballistic/automatic/pistol/solgov{
-	pixel_x = 4
-	},
 /obj/machinery/newscaster/security_unit/directional/north,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 10
 	},
+/obj/item/gun/ballistic/automatic/pistol/solgov{
+	pixel_x = -2
+	},
+/obj/item/gun/ballistic/automatic/pistol/solgov{
+	pixel_x = -2
+	},
+/obj/item/gun/ballistic/automatic/assault/g36,
+/obj/item/ammo_box/magazine/g36,
+/obj/item/ammo_box/magazine/g36/drum,
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
 "uw" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -560,6 +560,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/item/storage/box/ammo/ferrolance,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "hD" = (
@@ -1402,6 +1403,8 @@
 	},
 /obj/item/gun/ballistic/automatic/powered/gauss/gar,
 /obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "qI" = (
@@ -1945,12 +1948,31 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "xy" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/wall/directional/west{
+	icon_state = "sec_wall";
+	name = "Ammo Locker";
+	dir = 4;
+	pixel_x = 30
+	},
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "xD" = (
@@ -2171,21 +2193,30 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
 "zR" = (
-/obj/machinery/computer/secure_data/laptop{
-	dir = 1;
-	pixel_y = 4
+/obj/structure/closet/secure_closet/security{
+	populate = 0;
+	name = "marine's locker";
+	anchored = 1
 	},
 /obj/structure/window/reinforced,
-/obj/item/stamp/hos{
-	name = "armorer's rubber stamp";
-	pixel_x = -14;
-	pixel_y = 10
-	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/clothing/head/solfed/beret,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "zS" = (
@@ -2354,18 +2385,16 @@
 /obj/item/ammo_box/magazine/modelh,
 /obj/item/ammo_box/magazine/modelh,
 /obj/item/binoculars,
-/obj/item/ammo_box/magazine/gar,
 /obj/item/hatchet/wooden{
 	name = "Tomahawk";
 	force = 20;
 	throwforce = 25
 	},
 /obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/gun/ballistic/automatic/powered/gauss/gar,
-/obj/item/storage/box/ammo/ferrolance,
 /obj/item/storage/backpack/solfed,
 /obj/item/clothing/under/solfed/formal,
 /obj/item/clothing/suit/armor/solfed/formal,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/office)
 "BJ" = (
@@ -2580,6 +2609,11 @@
 /obj/item/clothing/under/solfed,
 /obj/item/clothing/under/solfed/camo,
 /obj/item/clothing/head/helmet/solfed/m11,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/clothing/head/solfed/beret,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "Ef" = (
@@ -2851,15 +2885,28 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Gu" = (
+/obj/structure/closet/secure_closet/security{
+	populate = 0;
+	name = "marine's locker";
+	anchored = 1
+	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/techfloor,
-/obj/structure/closet/cabinet{
-	name = "ammunition"
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/radio{
+	icon_state = "sec_radio"
 	},
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/storage/box/ammo/ferrolance,
-/obj/item/storage/box/ammo/ferrolance,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/clothing/head/solfed/beret,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "Gw" = (
@@ -3770,6 +3817,11 @@
 /obj/item/clothing/under/solfed,
 /obj/item/clothing/under/solfed/camo,
 /obj/item/clothing/head/helmet/solfed/m11,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/clothing/head/solfed/beret,
 /turf/open/floor/plasteel/white,
 /area/ship/security/prison)
 "RT" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Баффает всё вооружение солфедовских шипов(щитспавн шипы не в счёт)
## Причина создания ПР / Почему это хорошо для игры
Почему у нас де факто регулярная армия снаряжена похуже тех же сепаратистов, интеков? Превращаем правительство в более серьёзную силу в системе.

## Список изменений

```yml
🆑
tweak: 
Firetail - +1 г36 патроны к ней
Tomahawk - +1 гар и патроны к ним, мини ремап оружейной, два дополнительных ящика для маринов.
Anomaly - +2 пистолетика и патроны к ним
Inkwell - +1 г36 патроны к ней
Glimpse - -2пистолетика, +2 Г36 и патроны к ним
```
