### PR TITLE
MAP: Buff libertatia

### DIFF
--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -47,6 +47,10 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/item/gun/energy/kinetic_accelerator/crossbow{
+	pixel_x = 5;
+	pixel_y = -4
+	},
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "br" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Даёт мини-арбалет либертатии
## Причина создания ПР / Почему это хорошо для игры
Шип стал очень слабым в связи со множественными нёрфами. Просто даём сильное утилити, которое в опытных руках может полностью изменить геймплей.

## Список изменений

```yml
🆑
tweak: Даёт мини-арбалет либертатии
/🆑
```
