### PR TITLE
MAP: Chem dispenser for shmiedeberg and eva for flower

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
@@ -223,11 +223,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "hn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/suit/space/eva,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "ho" = (
 /obj/structure/cable{
@@ -1495,6 +1502,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/hydroponics)
+"Vh" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/suit_storage_unit/independent,
+/turf/open/floor/plating,
+/area/ship/external)
 "Vi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1766,7 +1782,7 @@ xx
 eR
 "}
 (6,1,1) = {"
-ex
+Vh
 Xy
 Fp
 Fp

--- a/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
@@ -223,18 +223,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "hn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/suit/space/eva,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/ship/engineering)
 "ho" = (
 /obj/structure/cable{
@@ -1502,15 +1494,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/hydroponics)
-"Vh" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar,
-/obj/effect/turf_decal/solarpanel,
-/obj/machinery/suit_storage_unit/independent,
-/turf/open/floor/plating,
-/area/ship/external)
 "Vi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1782,7 +1765,7 @@ xx
 eR
 "}
 (6,1,1) = {"
-Vh
+ex
 Xy
 Fp
 Fp

--- a/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
@@ -226,6 +226,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "ho" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
@@ -15,21 +15,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/chem_jug/sulfur,
-/obj/item/reagent_containers/glass/chem_jug/radium,
-/obj/item/reagent_containers/glass/chem_jug/potassium,
-/obj/item/reagent_containers/glass/chem_jug/oxygen,
-/obj/item/reagent_containers/glass/chem_jug/nitrogen,
-/obj/item/reagent_containers/glass/chem_jug/iodine,
-/obj/item/reagent_containers/glass/chem_jug/hydrogen,
-/obj/item/reagent_containers/glass/chem_jug/hexacrete,
-/obj/item/reagent_containers/glass/chem_jug/copper,
-/obj/item/reagent_containers/glass/chem_jug/chlorine,
-/obj/item/reagent_containers/glass/chem_jug/carbon,
-/obj/item/reagent_containers/glass/chem_jug/bromine,
-/obj/item/reagent_containers/glass/chem_jug/aluminium,
-/obj/item/reagent_containers/glass/chem_jug,
-/obj/structure/closet/crate,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/carpet/nanoweave/beige,
 /area/ship/medical)
 "az" = (
@@ -2629,6 +2615,7 @@
 	color = "#543C30";
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/hydroponics)
 "Ny" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
@@ -2615,7 +2615,6 @@
 	color = "#543C30";
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/hydroponics)
 "Ny" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Даём шмиденбергу хим диспенчер и фловеру еву
## Причина создания ПР / Почему это хорошо для игры
Исправляем косяк описания шмиденберга, потому что из описания байт какой-то выходит, "лучшее химическое оборудование" а на деле там гетто-химия с ящиком канистр химикатов. 
И просто даём еву фловеру. Почему у него вообще не было костюма для выхода в космос?

## Список изменений

```yml
🆑
tweak: Даём шмиденбергу хим диспенчер и фловеру еву
/🆑
```
