### PR TITLE
MAP: Buff skybreaker

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -52,6 +52,19 @@
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun,
+/obj/item/stock_parts/cell/gun/upgraded,
+/obj/item/stock_parts/cell/gun/upgraded,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "ba" = (
@@ -536,7 +549,7 @@
 /obj/item/binoculars,
 /obj/item/tank/jetpack/suit,
 /obj/item/clothing/mask/balaclava/combat,
-/obj/item/clothing/glasses/hud/security/night,
+/obj/item/clothing/glasses/hud/health/night,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm/captain)
 "gK" = (
@@ -1580,14 +1593,11 @@
 	pixel_x = -1;
 	pixel_y = 11
 	},
-/obj/item/gun/energy/e_gun/smg{
-	pixel_x = 0;
-	pixel_y = 4
-	},
 /obj/item/gun/energy/e_gun/iot{
 	pixel_x = 0;
 	pixel_y = -5
 	},
+/obj/item/gun/ballistic/automatic/smg/wt550,
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "uM" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -60,8 +60,6 @@
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun/upgraded,
-/obj/item/stock_parts/cell/gun/upgraded,
 /obj/item/ammo_box/magazine/wt550m9,
 /obj/item/ammo_box/magazine/wt550m9,
 /obj/item/ammo_box/magazine/wt550m9,


### PR DESCRIPTION
## Описание / Что этот PR делает
Баффает скабрейкер
Выдаёт ВТ 
Выдаёт большее кол-во батареек
## Причина создания ПР / Почему это хорошо для игры
Брейкер-брейкер. Слабое судно из-за тех же нёрфов, где на тот же момент 4 батарейки на 4 лазера. Просто даём второе дыхание ему.

## Список изменений

```yml
🆑
tweak: 
Возвращаем ПНВ мед худ капитану
Заменяем ВТшкой етар
Выдаём 8 дополнительных батареек.
/🆑
```
