### PR TITLE
TWEAK: Снижение кол-ва миссий

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -406,7 +406,7 @@
 	min_val = 191
 
 /datum/config_entry/number/max_dynamic_missions
-	config_entry_value = 0.66
+	config_entry_value = 0.33 // [CELADON-EDIT] - OLD config_entry_value = 0.66
 	min_val = 0
 
 /datum/config_entry/number/commendation_percent_poll

--- a/code/controllers/subsystem/missions.dm
+++ b/code/controllers/subsystem/missions.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(missions)
 	flags = SS_NO_INIT
 	priority = FIRE_PRIORITY_MISSIONS
 	wait = 10 SECONDS
-	var/default_mission_count = 3
+	var/default_mission_count = 1 //[CELADON-EDIT] -OLD- var/default_mission_count = 3
 	var/list/obj/effect/landmark/mission_poi/unallocated_pois = list()
 	var/list/datum/mission/ruin/inactive_ruin_missions = list()
 	var/list/datum/mission/ruin/active_ruin_missions = list()

--- a/code/modules/events/high_priority_mission.dm
+++ b/code/modules/events/high_priority_mission.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/high_priority_mission
 	name = "High Priority Mission"
 	typepath = /datum/round_event/high_priority_mission
-	max_occurrences = 3
+	max_occurrences = 0 //[CELADON-EDIT]- OLD - max_occurrences = 3
 	weight = 20
 	earliest_start = 5 MINUTES
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -519,7 +519,7 @@ OVERMAP_GENERATOR_TYPE solar_system
 OVERMAP_ENCOUNTER_SIZE 100
 
 ## Max dynamic mission count active per ship
-MAX_DYNAMIC_MISSIONS 0.66
+MAX_DYNAMIC_MISSIONS 0.33
 
 ## The time required before a ship is allowed to bluespace jump. -1 disables it entirely
 ## In deciseconds, valid values are -1 to INFINITY


### PR DESCRIPTION
## Описание / Что этот PR делает
Так, снижает кол-во раундстартовых миссий с трёх до одного. Снижает появлнение миссий за один корабль с 0.66 до 0.33. Условно за каждый корабль 4 корабля - 1 миссия
Отключает ивент, который отвечал за спавн миссий
## Причина создания ПР / Почему это хорошо для игры

Пока что экспериментально, в будущем дополню.
## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
tweak: Снижение кол-ва миссий
/🆑
```
