### PR TITLE
MAP: Celestis buff

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_celestis.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_celestis.json
@@ -8,7 +8,7 @@
 	"limit": 1,
 	"sensor_range": 6,
 	"starting_funds": 2000,
-	"prefix": "NTSV",
+	"prefix": "NTRSV",
 	"faction": "/datum/faction/nt",
 	"tags": ["Cargo", "Science", "Medical", "Generalist"],
 	"namelists": [

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -1172,7 +1172,7 @@
 /obj/item/clothing/shoes/laceup,
 /obj/item/clothing/gloves/color/white,
 /obj/item/clothing/suit/armor/solgov_trenchcoat{
-	name = "\Nanotrasen Representive trenchcoat"
+	name = "Nanotrasen Representive trenchcoat"
 	},
 /obj/item/clothing/head/beret/black,
 /turf/open/floor/wood,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -3127,6 +3127,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "sf" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -3955,9 +3955,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/clothing/suit/armor/solgov_trenchcoat{
-	name = "\Nanotrasen Representive trenchcoat"
-	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "xf" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -330,6 +330,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/captain,
 /obj/item/clothing/neck/cloak/cap,
 /obj/item/clothing/gloves/color/captain/nt,
+/obj/item/modular_computer/tablet,
 /turf/open/floor/carpet/royalblue,
 /area/ship/general/command_crew)
 "cA" = (
@@ -772,11 +773,22 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/general/science)
 "fc" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 8;
-	pixel_x = 11;
-	pixel_y = 0;
-	density = 0
+/obj/structure/table,
+/obj/item/research_notes/loot/medium{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/obj/item/research_notes/loot/medium{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/research_notes/loot/medium{
+	pixel_y = -1;
+	pixel_x = -6
+	},
+/obj/item/research_notes/loot/medium{
+	pixel_x = 6;
+	pixel_y = -1
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/general/science)
@@ -999,6 +1011,20 @@
 /area/ship/crew/cryo)
 "gC" = (
 /obj/structure/table/wood/reinforced,
+/obj/item/kirbyplants{
+	icon_state = "plant-28";
+	pixel_y = 20;
+	layer = 4.3;
+	pixel_x = 8
+	},
+/obj/item/lighter/zippo/blue{
+	pixel_y = 3;
+	pixel_x = -5
+	},
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 6;
+	pixel_x = 6
+	},
 /turf/open/floor/carpet/executive,
 /area/ship/crew/law_office)
 "gD" = (
@@ -1115,10 +1141,19 @@
 /obj/effect/turf_decal/trimline/opaque/vired/line{
 	dir = 9
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/light/directional/west,
+/obj/structure/closet/wall/red/directional/north,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/storage/box/ammo/c9mm_ap,
+/obj/item/storage/box/ammo/c9mm_ap,
+/obj/item/storage/box/ammo/c9mm_ap,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/ammo_box/magazine/smgm9mm,
+/obj/item/storage/box/ammo/c9mm_ap,
+/obj/item/storage/box/ammo/c9mm_ap,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "hl" = (
@@ -1129,14 +1164,17 @@
 	},
 /obj/item/clothing/under/nanotrasen/affairs,
 /obj/item/clothing/head/nanotrasen,
-/obj/item/stamp/nanotrasen,
 /obj/item/clothing/neck/tie/black,
 /obj/item/clothing/suit/nanotrasen/suitjacket,
 /obj/item/gun/ballistic/automatic/pistol/commander{
 	default_ammo_type = /obj/item/ammo_box/magazine/co9mm/ap
 	},
 /obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/suit/armor/solgov_trenchcoat{
+	name = "\Nanotrasen Representive trenchcoat"
+	},
+/obj/item/clothing/head/beret/black,
 /turf/open/floor/wood,
 /area/ship/crew/law_office)
 "hq" = (
@@ -1483,6 +1521,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
 /area/ship/engineering/engines/port)
 "jf" = (
@@ -2845,10 +2884,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/sign/poster/nanotrasen/vigilitas_nonlethal{
-	pixel_x = -32;
-	pixel_y = 0
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "rc" = (
@@ -2940,10 +2975,6 @@
 /obj/item/aiModule/core/full/paladin{
 	pixel_x = -5;
 	pixel_y = -4
-	},
-/obj/item/aiModule/core/full/asimov{
-	pixel_x = 4;
-	pixel_y = 10
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -3150,6 +3181,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/item/stamp/nanotrasen{
+	pixel_x = 9
 	},
 /turf/open/floor/carpet/executive,
 /area/ship/crew/law_office)
@@ -3920,6 +3954,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/item/clothing/suit/armor/solgov_trenchcoat{
+	name = "\Nanotrasen Representive trenchcoat"
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
@@ -7330,8 +7367,9 @@
 /obj/item/ammo_box/magazine/co9mm,
 /obj/item/stock_parts/cell/gun,
 /obj/item/stock_parts/cell/gun,
-/obj/item/clothing/suit/hooded/wintercoat/security,
 /obj/item/clothing/mask/gas/vigilitas,
+/obj/item/clothing/suit/armor/hos/trenchcoat,
+/obj/item/clothing/head/HoS/beret/syndicate,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Si" = (
@@ -7810,15 +7848,12 @@
 /obj/structure/guncloset{
 	req_access_txt = "2"
 	},
-/obj/item/gun/ballistic/automatic/pistol/commander{
-	pixel_x = 0;
-	pixel_y = 6
-	},
-/obj/item/gun/energy/disabler,
 /obj/item/gun/energy/e_gun/iot{
 	pixel_x = 0;
 	pixel_y = -6
 	},
+/obj/item/gun/ballistic/automatic/smg/vector,
+/obj/item/gun/ballistic/automatic/smg/vector,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Ve" = (
@@ -7981,6 +8016,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "Wy" = (
+/obj/structure/flora/bigplant{
+	pixel_y = -3;
+	pixel_x = -22
+	},
 /turf/open/floor/wood,
 /area/ship/crew/law_office)
 "WB" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -7369,7 +7369,7 @@
 /obj/item/stock_parts/cell/gun,
 /obj/item/clothing/mask/gas/vigilitas,
 /obj/item/clothing/suit/armor/hos/trenchcoat,
-/obj/item/clothing/head/HoS/beret/syndicate,
+/obj/item/clothing/head/beret/sec/officer,
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Si" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Оправдываем описание самого технологичного и продвинутого судна Nanotrasen. 
Меняем префикс на NTRSV - Nanotrasen Research Space Vessel
## Причина создания ПР / Почему это хорошо для игры
Корабль с экипажем в 15 человек, который несет на себе тонну современного оборудования по какой-то причине не доукомплектован снаряжением хотя бы для своей собственной самообороны и не имеет каких-то преимуществ перед НЕ исследовательскими/научными судами.

## Список изменений

```yml
🆑
map: Ship - Celestis
Добавлено два вектора 9мм, и боекомплект к ним.
Добавлено две канистры азота.
Добавлены research notes на 16к РНД очков.
Добавлен дрип НТРу, слегка украшен его унылый кабинет.
Добавлен планшет в шкаф Капитана.
Меняем префикс Целестиса с NTSV на NTRSV
/🆑
```
