### PR TITLE
TWEAK: Автолат - Стопки кратные 15х и 30х

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -119,7 +119,7 @@
 	for(var/datum/design/D in blueprints)
 		var/unbuildable = FALSE // we can't build the design currently
 		var/m10 = FALSE // 10x mult
-// [CELADON-EDIT] -
+// [CELADON-EDIT] - CELADON_QOL - AUTOLATE_MAXSTACK
 //		var/m25 = FALSE // 25x mult
 		var/m15 = FALSE // 15x mult
 		var/m30 = FALSE // 30x mult
@@ -138,7 +138,7 @@
 					max_multiplier = min(D.maxstack, round(mats.get_material_amount(mat)/D.materials[mat]))
 				if (max_multiplier>10 && !disabled)
 					m10 = TRUE
-// [CELADON-EDIT] -
+// [CELADON-EDIT] - CELADON_QOL - AUTOLATE_MAXSTACK
 //				if (max_multiplier>25 && !disabled)
 //					m25 = TRUE
 				if (max_multiplier>15 && !disabled)
@@ -164,7 +164,7 @@
 			buildable = unbuildable,
 			mult5 = m5,
 			mult10 = m10,
-// [CELADON-EDIT] -
+// [CELADON-EDIT] - AUTOLATE_MAXSTACK
 //			mult25 = m25,
 			mult15 = m15,
 			mult30 = m30,
@@ -202,7 +202,7 @@
 		eject(usr)
 
 	if(action == "materialEject")
-// [CELADON-ADD] - FIX_LATHE
+// [CELADON-ADD] - CELADON_QOL - FIX_LATHE
 		if (busy)
 			to_chat(usr, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 			return

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -119,7 +119,11 @@
 	for(var/datum/design/D in blueprints)
 		var/unbuildable = FALSE // we can't build the design currently
 		var/m10 = FALSE // 10x mult
-		var/m25 = FALSE // 25x mult
+// [CELADON-EDIT] -
+//		var/m25 = FALSE // 25x mult
+		var/m15 = FALSE // 15x mult
+		var/m30 = FALSE // 30x mult
+// [/CELADON-EDIT]
 		var/m50 = FALSE // 50x mult
 		var/m5 = FALSE // 5x mult
 		var/sheets = FALSE // sheets or no?
@@ -134,8 +138,14 @@
 					max_multiplier = min(D.maxstack, round(mats.get_material_amount(mat)/D.materials[mat]))
 				if (max_multiplier>10 && !disabled)
 					m10 = TRUE
-				if (max_multiplier>25 && !disabled)
-					m25 = TRUE
+// [CELADON-EDIT] -
+//				if (max_multiplier>25 && !disabled)
+//					m25 = TRUE
+				if (max_multiplier>15 && !disabled)
+					m15 = TRUE
+				if (max_multiplier>30 && !disabled)
+					m30 = TRUE
+// [/CELADON-EDIT]
 		else
 			if(!unbuildable)
 				if(!disabled && can_build(D, 5))
@@ -154,7 +164,11 @@
 			buildable = unbuildable,
 			mult5 = m5,
 			mult10 = m10,
-			mult25 = m25,
+// [CELADON-EDIT] -
+//			mult25 = m25,
+			mult15 = m15,
+			mult30 = m30,
+// [/CELADON-EDIT]
 			mult50 = m50,
 			sheet = sheets,
 			maxmult = max_multiplier,

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -13,6 +13,9 @@
 ## QoL - Улучшения всего и вся
 
 ID мода: CELADON_QOL
+
+FIX_LATHE
+AUTOLATE_MAXSTACK
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -130,6 +133,10 @@ ID мода: CELADON_QOL
 
 - ADD: `code/modules/power/singularity/singularity.dm` - добавляем сингулярность которая не излучает радиацию.
 
+AUTOLATE_MAXSTACK, FIX_LATHE
+- EDIT `code/game/machinery/autolathe.dm` - Добавление/изменения макс стопок в автолате
+- EDIT `code/game/machinery/autolathe.dm` - Удаляет абуз с дюпом
+- EDIT `tgui/packages/tgui/interfaces/Autolathe.js` - Интерфейсы под них
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/tgui/packages/tgui/interfaces/Autolathe.js
+++ b/tgui/packages/tgui/interfaces/Autolathe.js
@@ -164,23 +164,23 @@ export const Autolathe = (props, context) => {
                           <Flex.Item grow={1}>
                             <Button
                               icon="hammer"
-                              content="10"
-                              disabled={!design.mult10}
+                              content="15"
+                              disabled={!design.mult15}
                               onClick={() =>
                                 act('make', {
                                   id: design.id,
-                                  multiplier: '10',
+                                  multiplier: '15',
                                 })
                               }
                             />
                             <Button
                               icon="hammer"
-                              content="25"
-                              disabled={!design.mult25}
+                              content="30"
+                              disabled={!design.mult30}
                               onClick={() =>
                                 act('make', {
                                   id: design.id,
-                                  multiplier: '25',
+                                  multiplier: '30',
                                 })
                               }
                             />
@@ -278,14 +278,14 @@ const MaterialRow = (props, context) => {
               onClick={() => onRelease(5)}
             />
             <Button
-              disabled={material.sheets_amount < 10}
-              content="x10"
-              onClick={() => onRelease(10)}
+              disabled={material.sheets_amount < 15}
+              content="x15"
+              onClick={() => onRelease(15)}
             />
             <Button
-              disabled={material.sheets_amount < 25}
-              content="x25"
-              onClick={() => onRelease(25)}
+              disabled={material.sheets_amount < 30}
+              content="x30"
+              onClick={() => onRelease(30)}
             />
           </Table.Cell>
           <Table.Cell collapsing textAlign="right">

--- a/tgui/packages/tgui/interfaces/Autolathe.js
+++ b/tgui/packages/tgui/interfaces/Autolathe.js
@@ -278,14 +278,14 @@ const MaterialRow = (props, context) => {
               onClick={() => onRelease(5)}
             />
             <Button
-              disabled={material.sheets_amount < 15}
-              content="x15"
-              onClick={() => onRelease(15)}
+              disabled={material.sheets_amount < 10}
+              content="x10"
+              onClick={() => onRelease(10)}
             />
             <Button
-              disabled={material.sheets_amount < 30}
-              content="x30"
-              onClick={() => onRelease(30)}
+              disabled={material.sheets_amount < 25}
+              content="x25"
+              onClick={() => onRelease(25)}
             />
           </Table.Cell>
           <Table.Cell collapsing textAlign="right">


### PR DESCRIPTION
## Описание / Что этот PR делает
Кратные стопки выглядят куда лучше и логичнее, просто удобнее банально.

## Причина создания ПР / Почему это хорошо для игры
Close #1947

## Демонстрация изменений / Тестирование
<img width="600" height="700" alt="image" src="https://github.com/user-attachments/assets/4eca35c1-db63-47ae-8776-968879b3b08e" />



## Список изменений

```yml
🆑
tweak: Автолат - Сортировка создания по стопкам с 10 и 25 -> 10, 15 и 30
/🆑
```
