### PR TITLE
ADD: Show Music Lobby

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -287,9 +287,6 @@ SUBSYSTEM_DEF(ticker)
 	SSredbot.send_discord_message("ooc", "**A new round has begun.**")
 //[CELADON-EDIT]- MUSIC_CELADON
 //	SEND_SOUND(world, sound('sound/roundstart/addiguana.ogg'))//CELADON-EDIT-ORIGINAL
-	if(login_music_name)
-		var/count_name = length(SSticker.login_music_name)
-		to_chat(world, span_redteamradio("<B>Playing lobby music: [copytext(SSticker.login_music_name, 1, count_name-3)].</B>"))
 	SEND_SOUND(world, sound('mod_celadon/_storage_sounds/sound/lobby/sztart.ogg'))
 //[/CELADON-EDIT]
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -213,6 +213,13 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
+	if(SSticker.login_music_name)
+		var/music_name = SSticker.login_music_name
+		var/dot_position = findtext(music_name, ".")
+		if(dot_position)
+			music_name = copytext(music_name, 1, dot_position)
+		to_chat(src, span_redteamradio("<B>Playing lobby music: [music_name]</B>"))
+
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет момент с отображением музыки, 

## Причина создания ПР / Почему это хорошо для игры
Более правильным подход к показу что играет в лобби.

## Список изменений

```yml
🆑
add: Меняет показ музыки с момента Инициализации раунда, на проигрывание в лобби меню
/🆑
```
