### PR TITLE
MAP: Squab - экипировка персонала

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -1040,8 +1040,8 @@
 "ge" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/item/clothing/mask/gas/atmos,
-/obj/item/mod/control/pre_equipped/research,
 /obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/rd,
 /turf/open/floor/carpet/purple,
 /area/ship/general/command_crew/rd)
 "gh" = (
@@ -2133,9 +2133,9 @@
 /area/ship/science/ai_chamber)
 "un" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/item/clothing/suit/space/hardsuit/mining,
 /obj/item/clothing/mask/gas/explorer,
 /obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/mining/heavy,
 /turf/open/floor/carpet/orange,
 /area/ship/general/command_crew)
 "uq" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет шахт риг на хевт шахт риг у КМа. Замена мода на риг у РД. 
## Причина создания ПР / Почему это хорошо для игры
МОДы - плохо. Приятный бонус кэпу.
## Демонстрация изменений / Тестирование
<img width="256" height="335" alt="image" src="https://github.com/user-attachments/assets/1443f15d-b607-46c5-9250-06c4d936fd5d" />
<img width="242" height="321" alt="image" src="https://github.com/user-attachments/assets/e0278c4b-9efa-4bcc-9271-81dff9821ffa" />

## Список изменений

```yml
🆑
map: Скваб - Заменен мод РД на Риг, Хеви Риг у КМа
/🆑
```
