### PR TITLE
TWEAK: убираем дилей снятия/надевания всех рюкзаков и подтипов рюкзаков

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -34,9 +34,9 @@
 
 	equipping_sound = EQUIP_SOUND_VFAST_GENERIC
 	unequipping_sound = UNEQUIP_SOUND_VFAST_GENERIC
-	// [CELADON-EDIT] - CELADON_BALANCE_CD
+	// [CELADON-REMOVE] - CELADON_BALANCE_CD
 	//equip_delay_self = EQUIP_DELAY_BACK
-	// [/CELADON-EDIT]
+	// [/CELADON-REMOVE]
 	equip_delay_other = EQUIP_DELAY_BACK * 1.5
 	strip_delay = EQUIP_DELAY_BACK * 1.5
 	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN
@@ -218,9 +218,9 @@
 
 	equipping_sound = null
 	unequipping_sound = null
-	// [CELADON-EDIT] - CELADON_BALANCE_CD
+	// [CELADON-REMOVE] - CELADON_BALANCE_CD
 	//equip_delay_self = null
-	// [/CELADON-EDIT]
+	// [/CELADON-REMOVE]
 	equip_delay_other = EQUIP_DELAY_BACK
 	strip_delay = EQUIP_DELAY_BACK
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -218,7 +218,9 @@
 
 	equipping_sound = null
 	unequipping_sound = null
-	equip_delay_self = null
+	// [CELADON-EDIT] - CELADON_BALANCE_CD
+	//equip_delay_self = null
+	// [/CELADON-EDIT]
 	equip_delay_other = EQUIP_DELAY_BACK
 	strip_delay = EQUIP_DELAY_BACK
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -34,7 +34,9 @@
 
 	equipping_sound = EQUIP_SOUND_VFAST_GENERIC
 	unequipping_sound = UNEQUIP_SOUND_VFAST_GENERIC
-	equip_delay_self = EQUIP_DELAY_BACK
+	// [CELADON-EDIT] - CELADON_BALANCE_CD
+	//equip_delay_self = EQUIP_DELAY_BACK
+	// [/CELADON-EDIT]
 	equip_delay_other = EQUIP_DELAY_BACK * 1.5
 	strip_delay = EQUIP_DELAY_BACK * 1.5
 	equip_self_flags = EQUIP_ALLOW_MOVEMENT | EQUIP_SLOWDOWN


### PR DESCRIPTION
## Описание / Что этот PR делает
Убираем задержку на снятие и надевания рюкзака на спину
## Причина создания ПР / Почему это хорошо для игры
Цитата хэдкоддера - "По хорошему дилей бы убрать"
Также была проблема, что у дюфелей, рюкзаков и мессенджер была задержка, а у сатчелей задержки не было.
## Демонстрация изменений / Тестирование
Было - 
https://github.com/user-attachments/assets/317dcf49-4ec8-43a9-a257-66e3ddf6da1e

Стало - 
https://github.com/user-attachments/assets/f2660c9b-18f3-44cc-aa82-7923a525cebf


```yml
🆑
tweak: Что-то изменено по мелочи
/🆑
```
