### PR TITLE
REMOVE: Отключаем сокрытие хвостов риолам и таярам

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -989,7 +989,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			bodyparts_to_add -= "riol_hairs"
 
 	if("riol_tail" in mutant_bodyparts)
-		if(!H.dna.features["riol_tail"] || H.dna.features["riol_tail"] == "None" || H.wear_suit && (H.wear_suit.flags_inv & HIDEJUMPSUIT))
+		if(!H.dna.features["riol_tail"] || H.dna.features["riol_tail"] == "None" || (H.wear_suit && (H.wear_suit.flags_inv & HIDETAIL)))
 			bodyparts_to_add -= "riol_tail"
 
 	if("riol_ears" in mutant_bodyparts)

--- a/mod_celadon/mod_celadon.dme
+++ b/mod_celadon/mod_celadon.dme
@@ -85,7 +85,7 @@
 #include "lifeline_minus/_lifeline_minus.dme"
 #include "robotic_honk/_robotic_honk.dme"
 #include "wideband/_wideband.dme"
-#include "fix_tail/_fix_tail.dme"
+// #include "fix_tail/_fix_tail.dme"	-	Отключен по приказу хэда шиптеста
 #include "survey_handheld/_survey_handheld.dme"
 #include "underwear/_underwear.dme"
 #include "increase_weapon_durability/_increase_weapon_durability.dme"


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь риолы и таяры могут лицезреть свои хвосты везде, не пряча их под костюм
А также чинит плохой код риолам на сокрытие хвоста, который работал не от наличия флага на скрыть хвост, а от того есть ли флаг на снятие простого сьюта...

## Причина создания ПР / Почему это хорошо для игры
Сепаратистам стало легче обнаружить ксенорасу

## Демонстрация изменений / Тестирование

<img width="330" height="334" alt="image" src="https://github.com/user-attachments/assets/4e36b833-c31e-46d5-a430-ce1b57a64e39" />

## Список изменений

```yml
🆑
turn off: отключен модпак на сокрытие хвостов сьютам
fix: исправлен код риолам на сокрытие хвоста
/🆑
```
