### PR TITLE
MAP: All RND SHIP UP

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_squab.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_squab.json
@@ -8,7 +8,7 @@
 	"limit": 1,
 	"sensor_range": 5,
 	"starting_funds": 3000,
-	"prefix": "NTDSV",
+	"prefix": "NTRSV",
 	"faction": "/datum/faction/nt",
 	"tags": [
 		"Science",

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -18836,10 +18836,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/plating/grass,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "lfv" = (
 /obj/effect/turf_decal/techfloor/corner{

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -1351,6 +1351,9 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "iT" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
@@ -5021,6 +5021,9 @@
 /obj/machinery/computer/rdconsole/core{
 	dir = 8
 	},
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/small,
 /turf/open/floor/marble,
 /area/ship/science)
 "UU" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_elegia.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_elegia.dmm
@@ -339,6 +339,9 @@
 /obj/machinery/computer/rdconsole{
 	dir = 1
 	},
+/obj/item/research_notes/loot/small,
+/obj/item/research_notes/loot/small,
+/obj/item/research_notes/loot/small,
 /turf/open/floor/plasteel/tech,
 /area/ship/science)
 "fH" = (


### PR DESCRIPTION
## Описание / Что этот PR делает

## Причина создания ПР / Почему это хорошо для игры
Подталкиваем игроков играть на исследовательских суднах через исследования. То есть, теперь Ресерч судна будут ближе к тому чтобы сделать меха, а не купить его.

## Список изменений
Изменяем префикс Скваба с NTDSV -> NTRSV
Количество добавленных ресерч очков на разные судна:
12к  - Скваб
10к - Фаертейл
6к - Элегии
```yml
🆑
map: Изменения на карте
Починили один тайл на снежном аванпосте.
Все изменения описаны выше.
/🆑
```
