### PR TITLE
ADD: Missing syndicate medical meka upgrade module

### DIFF
--- a/mod_celadon/silicon/code/meka/rnd.dm
+++ b/mod_celadon/silicon/code/meka/rnd.dm
@@ -52,12 +52,19 @@
 	module_type = list(/obj/item/robot_module/butler)
 	new_module = /obj/item/robot_module/meka/butler
 
+/obj/item/borg/upgrade/transform/meka/syndicate_medical
+	name = "Syndicate Medical Meka Body"
+	desc = "Makes your syndicate medical cyborg look like Meka"
+	require_module = TRUE
+	module_type = list(/obj/item/robot_module/syndicate_medical)
+	new_module = /obj/item/robot_module/meka/syndicate_medical
+
 /datum/techweb_node/cyborg_upg_meka
 	id = "cyborg_upg_meka"
 	display_name = "Cyborg Upgrades: Meka Body"
 	description = "New, humanised body for your cyborgs."
 	prereq_ids = list("cyborg_upg_util")
-	design_ids = list("borg_upgrade_meka_medical", "borg_upgrade_meka_engineering", "borg_upgrade_meka_security", "borg_upgrade_meka_janitor", "borg_upgrade_meka_peacekeeper", "borg_upgrade_meka_miner", "borg_upgrade_meka_butler")
+	design_ids = list("borg_upgrade_meka_medical", "borg_upgrade_meka_engineering", "borg_upgrade_meka_security", "borg_upgrade_meka_janitor", "borg_upgrade_meka_peacekeeper", "borg_upgrade_meka_miner", "borg_upgrade_meka_butler", "borg_upgrade_meka_syndicate_medical")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 1000
 
@@ -120,6 +127,15 @@
 	id = "borg_upgrade_meka_butler"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/transform/meka/butler
+	materials = list(/datum/material/iron = 1500, /datum/material/glass = 1000, /datum/material/gold = 500, /datum/material/bluespace = 200)
+	construction_time = 80
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_meka_syndicate_medical
+	name = "Cyborg Upgrade (Syndicate Medical Meka Body)"
+	id = "borg_upgrade_meka_syndicate_medical"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/transform/meka/syndicate_medical
 	materials = list(/datum/material/iron = 1500, /datum/material/glass = 1000, /datum/material/gold = 500, /datum/material/bluespace = 200)
 	construction_time = 80
 	category = list("Cyborg Upgrade Modules")


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет недостающий модуль улучшения "Syndicate Medical Meka Body" для синдикатских медицинских киборгов. Теперь синди мед-борги могут трансформироваться в Meka тела наравне с обычными боргами всех других специализаций.
## Технические изменения:
Добавлен модуль улучшения /obj/item/borg/upgrade/transform/meka/syndicate_medical
Создан соответствующий дизайн для R&D системы
Интегрирован в techweb узел "Cyborg Upgrades: Meka Body"
## Причина создания ПР / Почему это хорошо для игры
Проблема: Синдикатские медицинские киборги были единственным типом боргов, для которых отсутствовал модуль улучшения Meka Body, что создавало дисбаланс и ограничивало возможности кастомизации.
Решение: Добавление недостающего модуля обеспечивает:
✅ Равенство возможностей - все типы боргов теперь могут использовать Meka тела
✅ Улучшенная кастомизация - больше вариантов внешнего вида для синди боргов
✅ Логическая завершенность - система модулей улучшения теперь полная
✅ Баланс специализаций - нет исключений в системе трансформации
## Демонстрация изменений / Тестирование
Как протестировать:
Создайте синдикатского медицинского киборга
Исследуйте узел "Cyborg Upgrades: Meka Body" в R&D
Скрафтите "Cyborg Upgrade (Syndicate Medical Meka Body)" в Mech Fabricator
Используйте модуль на синди мед-борге
Выберите внешний вид (Niko/Nika) в радиальном меню
Убедитесь, что борг успешно трансформировался в Meka тело
Требования материалов:
Железо: 1500
Стекло: 1000
Золото: 500
Блюспейс кристалл: 200
## Список изменений
```yml
🆑
add: Добавлен модуль улучшения "Syndicate Medical Meka Body" для синдикатских медицинских киборгов
add: Дизайн "Cyborg Upgrade (Syndicate Medical Meka Body)" в R&D систему
fix: Исправлена проблема с отсутствием модуля трансформации для синди мед-боргов
/🆑
```
