### PR TITLE
MAP: fix maps

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_raided_cargobase.dmm
+++ b/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_raided_cargobase.dmm
@@ -8,19 +8,24 @@
 	dir = 8
 	},
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "aE" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
-/turf/open/floor/plasteel/tech/grid/airless,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "aF" = (
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "bc" = (
@@ -36,7 +41,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/overmap_encounter/planetoid/cave/explored)
 "bx" = (
 /obj/item/holosign_creator/atmos,
@@ -60,12 +67,16 @@
 "bW" = (
 /obj/effect/turf_decal/corner/opaque/brown/half,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "bZ" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "cb" = (
 /turf/template_noop,
@@ -78,7 +89,9 @@
 /area/ruin/powered/shuttle)
 "cU" = (
 /obj/item/toy/plush/moth/punished,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "dE" = (
 /obj/structure/table/wood,
@@ -98,7 +111,9 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/overmap_encounter/planetoid/cave/explored)
 "ey" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -130,7 +145,9 @@
 /area/ruin/unpowered)
 "gN" = (
 /obj/structure/girder,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "gV" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -138,7 +155,9 @@
 	},
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/overmap_encounter/planetoid/cave/explored)
 "ha" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -151,7 +170,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "hd" = (
 /obj/machinery/door/airlock/external,
@@ -159,12 +180,16 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "hw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "hF" = (
 /obj/effect/turf_decal/corner/opaque/brown/half{
@@ -178,7 +203,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "hN" = (
 /obj/machinery/door/airlock/external/glass,
@@ -193,7 +220,9 @@
 "iK" = (
 /obj/effect/turf_decal/corner/opaque/brown/half,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "iL" = (
 /obj/structure/barricade/wooden/crude/snow,
@@ -208,11 +237,15 @@
 	dir = 4
 	},
 /obj/machinery/light/broken/directional/north,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "jQ" = (
 /obj/item/grenade/c4/x4,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "jR" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -223,7 +256,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "kO" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -235,14 +270,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "lD" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "lH" = (
 /mob/living/simple_animal/hostile/human/pirate/ranged,
@@ -276,7 +315,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "mH" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -291,13 +332,15 @@
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/poddoor/preopen,
 /obj/structure/barricade/wooden/crude,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ruin)
 "ng" = (
 /obj/effect/turf_decal/corner/opaque/brown/half,
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/wood/fifty,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "nn" = (
 /turf/closed/wall/r_wall,
@@ -305,8 +348,9 @@
 "nI" = (
 /obj/effect/turf_decal/snow,
 /obj/effect/turf_decal/weather/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin)
 "nR" = (
@@ -318,7 +362,9 @@
 "oe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet/executive{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "op" = (
 /obj/item/screwdriver,
@@ -326,7 +372,9 @@
 /turf/open/floor/carpet/orange,
 /area/ruin/unpowered)
 "ot" = (
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "ou" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -336,7 +384,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/flippedtable,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "oG" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -344,14 +394,18 @@
 	},
 /obj/item/gun/energy/laser/e10,
 /obj/effect/turf_decal/corner/opaque/brown/half,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "oN" = (
 /obj/effect/turf_decal/corner/opaque/brown/half{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "oR" = (
 /obj/structure/chair/comfy/shuttle{
@@ -376,7 +430,9 @@
 	icon_state = "1-2"
 	},
 /obj/item/gun/energy/laser/retro,
-/turf/open/floor/plasteel/tech/grid/airless,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "qx" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/cargo,
@@ -390,7 +446,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "rF" = (
 /obj/machinery/door/airlock,
@@ -424,7 +482,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "sB" = (
 /obj/structure/table,
@@ -449,12 +509,16 @@
 /obj/effect/turf_decal/corner/opaque/brown/half{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "tv" = (
 /obj/effect/turf_decal/corner/opaque/brown/half,
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "tR" = (
 /obj/effect/turf_decal/corner/opaque/brown/half{
@@ -462,7 +526,9 @@
 	},
 /obj/machinery/light/broken/directional/north,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "ub" = (
 /obj/effect/decal/cleanable/blood/squirt,
@@ -472,7 +538,9 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered)
 "ul" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "un" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -482,7 +550,9 @@
 	pixel_x = 0;
 	pixel_y = 7
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "up" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
@@ -499,14 +569,18 @@
 "us" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/corner/opaque/brown/half,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "vb" = (
 /obj/effect/turf_decal/corner/opaque/brown/half{
 	dir = 1
 	},
 /obj/item/storage/backpack/duffelbag/syndie,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "vc" = (
 /obj/machinery/light/directional/north,
@@ -535,13 +609,16 @@
 /area/ruin/unpowered)
 "wh" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "wk" = (
 /obj/effect/turf_decal/snow,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "wD" = (
@@ -556,8 +633,9 @@
 /obj/effect/turf_decal/weather/snow{
 	dir = 1
 	},
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "xj" = (
@@ -578,7 +656,9 @@
 	icon_state = "x";
 	layer = 2.51
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "xo" = (
 /turf/closed/wall/r_wall,
@@ -601,12 +681,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
-"yF" = (
-/obj/machinery/power/shuttle/engine/electric/bad{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/ruin/powered/shuttle)
 "yR" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -633,8 +707,9 @@
 "zq" = (
 /obj/effect/turf_decal/weather/snow,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "zx" = (
@@ -671,7 +746,9 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "AK" = (
 /turf/open/floor/plasteel,
@@ -684,7 +761,9 @@
 /obj/effect/turf_decal/corner/opaque/brown/half{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Bc" = (
 /obj/item/tank/internals/oxygen,
@@ -748,7 +827,9 @@
 	id = "noderiderengine";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "CV" = (
 /obj/structure/lattice,
@@ -780,7 +861,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Em" = (
 /obj/effect/turf_decal/corner/opaque/brown/half{
@@ -792,7 +875,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "EA" = (
 /obj/structure/sign/poster/official/enlist,
@@ -809,7 +894,9 @@
 	icon_state = "1-4"
 	},
 /obj/item/grenade/c4,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Fh" = (
 /obj/machinery/rnd/production/protolathe/department/cargo,
@@ -822,7 +909,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Fq" = (
 /mob/living/simple_animal/hostile/human/pirate/melee,
@@ -834,14 +923,18 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "FO" = (
 /obj/item/bedsheet/nanotrasen,
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet/executive{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "FP" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -867,14 +960,18 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "In" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /obj/effect/turf_decal/corner/opaque/brown/half,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Iy" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -900,7 +997,9 @@
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 1
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "JM" = (
 /obj/effect/decal/cleanable/blood/footprints{
@@ -924,7 +1023,9 @@
 "KV" = (
 /obj/structure/closet/crate,
 /obj/item/toy/balloon/corgi,
-/turf/open/floor/plasteel/tech/grid/airless,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Ld" = (
 /turf/open/floor/plating/asteroid/icerock/cracked,
@@ -978,7 +1079,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech/grid/airless,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "NO" = (
 /obj/machinery/computer,
@@ -990,7 +1093,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Ok" = (
 /obj/machinery/door/airlock{
@@ -1029,23 +1134,29 @@
 	dir = 1
 	},
 /obj/structure/flippedtable,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "QX" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /obj/item/grenade/c4,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Rk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plasteel/tech/grid/airless,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "RX" = (
 /obj/structure/holosign/barrier/atmos/infinite,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "RZ" = (
 /obj/machinery/advanced_airlock_controller,
@@ -1070,8 +1181,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "Tb" = (
@@ -1088,11 +1200,15 @@
 /obj/effect/turf_decal/corner/opaque/brown/half{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Tt" = (
 /obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "Tu" = (
 /obj/structure/cable{
@@ -1104,7 +1220,9 @@
 "TF" = (
 /obj/effect/mob_spawn/human/corpse/cargo_tech,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "TH" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -1116,7 +1234,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "Uf" = (
 /obj/effect/decal/cleanable/blood/squirt,
@@ -1125,8 +1245,9 @@
 "Ut" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/plating/airless{
-	icon_state = "platingdmg3"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin)
 "UO" = (
@@ -1195,7 +1316,9 @@
 /obj/structure/table/wood,
 /obj/item/soap/nanotrasen,
 /obj/effect/turf_decal/snow,
-/turf/open/floor/carpet/executive,
+/turf/open/floor/carpet/executive{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "Yx" = (
 /obj/structure/cable{
@@ -1206,7 +1329,9 @@
 /area/ruin/unpowered)
 "YH" = (
 /obj/structure/girder,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/unpowered)
 "YL" = (
 /obj/structure/holosign/barrier/atmos/infinite,
@@ -1226,7 +1351,9 @@
 	},
 /obj/item/crowbar,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint/airless,
+/turf/open/floor/plasteel/tech/techmaint{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin)
 "ZG" = (
 /obj/effect/turf_decal/corner/opaque/green/half,
@@ -1440,7 +1567,7 @@ DM
 cb
 cb
 YZ
-yF
+cf
 nn
 nn
 nn
@@ -1552,7 +1679,7 @@ DM
 cb
 cb
 YZ
-yF
+cf
 nn
 nn
 nn

--- a/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_nomadcrash.dmm
+++ b/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_nomadcrash.dmm
@@ -135,7 +135,7 @@
 	},
 /obj/structure/frame/machine,
 /turf/open/floor/plating{
-	icon_state = "wet_cracked2"
+	icon_state = "platingdmg3"
 	},
 /area/ruin/rockplanet/nomad)
 "fd" = (
@@ -822,7 +822,7 @@
 	},
 /obj/machinery/telecomms/receiver,
 /turf/open/floor/plating{
-	icon_state = "wet_cracked0"
+	icon_state = "platingdmg3"
 	},
 /area/ruin/rockplanet/nomad)
 "zw" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
@@ -4079,10 +4079,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/dorm/dormthree)
-"Js" = (
-/obj/item/stock_parts/cell/gun,
-/turf/template_noop,
-/area/template_noop)
 "Jw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -6413,7 +6409,7 @@ xz
 (6,1,1) = {"
 xz
 xz
-Js
+xz
 Fm
 Fm
 lc

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_cybersun_kansatsu.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_cybersun_kansatsu.dmm
@@ -1319,9 +1319,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/engineering)
 "DL" = (
-/obj/structure/safe/floor{
-	number_of_tumblers = 3
-	},
+/obj/structure/safe/floor,
 /obj/item/melee/knife/combat,
 /obj/item/paper/crumpled{
 	default_raw_text = "Кажется, эти шприцы не то, чем кажутся.. Надо быть с ними поосторожнее.."


### PR DESCRIPTION
## Описание / Что этот PR делает
Заменяет аирлесс турфы на айсмун атмос руинкина ледяной планете, так же убрал тайлы космоса из под двигателей.
Заменил турфы фикс ми на аналогичные на номад краше.
Убрал миссклик мапера на краинг сане (батарейка лежала в космосе над дормами).
Изменил количество тумблеров на кансатцу под описание.
## Причина создания ПР / Почему это хорошо для игры
Ошибки - плохо.
## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
fix: Исправление турфов на Nomadcrush и Raided_Cargobase, убрал летающую батарейку в космосе у Crying_Sun
map: Изменил количество тумлеров у сейфа Касайу под описание (2)
/🆑
```
