### PR TITLE
FIX: Разные крафт категории

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -70,7 +70,7 @@
 		/obj/item/food/grown/cabbage = 1,
 	)
 	result = /obj/item/food/eggwrap
-	category = CAT_EGG
+	subcategory = CAT_EGG
 
 /datum/crafting_recipe/food/chawanmushi
 	name = "Chawanmushi"
@@ -81,4 +81,4 @@
 		/obj/item/food/grown/mushroom/chanterelle = 1
 	)
 	result = /obj/item/food/chawanmushi
-	category = CAT_EGG
+	subcategory = CAT_EGG

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -8,7 +8,7 @@
 		/obj/item/food/cheese/wedge = 1
 	)
 	result = /obj/item/food/loaded_baked_potato
-	category = CAT_MISCFOOD
+	subcategory = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/miras_potato
 	name = "Miras loaded potato"


### PR DESCRIPTION
## Описание / Что этот PR делает

Убирает визуальный баг, который возникает при открытии меню крафта рецептов. 
Ранее отображались задублированные категории, теперь это исправлено.

<img width="698" height="668" alt="image" src="https://github.com/user-attachments/assets/bfba0d5e-9b73-4497-a369-74d737f345e4" />


## Причина создания ПР / Почему это хорошо для игры
**Closed #1989**

## Список изменений

```yml
🆑
fix: Исправлено дублированние категорий.
/🆑
```
