### PR TITLE
MAP: Tomahawk remapp, some tweak to daggerfall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "+secret"]
+	path = +secret
+	url = https://github.com/CeladonSS13/Shiptest_Secret.git

--- a/_maps/_mod_celadon/configs/solfed_tomahawk.json
+++ b/_maps/_mod_celadon/configs/solfed_tomahawk.json
@@ -23,6 +23,11 @@
 			"officer": true,
 			"slots": 1
 		},
+		"Feldwebel": {
+			"outfit": "/datum/outfit/job/solfed/sergeant",
+			"officer": true,
+			"slots": 1
+		},
 		"Marine": {
 			"outfit": "/datum/outfit/job/solfed/marine",
 			"slots": 3
@@ -38,10 +43,6 @@
 		"Contracted Miner": {
 			"outfit": "/datum/outfit/job/solfed/miner",
 			"slots": 3
-		},
-		"Gehilfe": {
-			"outfit": "/datum/outfit/job/solfed/assistant",
-			"slots" : 2
 		}
 	}
 }

--- a/_maps/_mod_celadon/configs/solfed_tomahawk.json
+++ b/_maps/_mod_celadon/configs/solfed_tomahawk.json
@@ -2,13 +2,13 @@
 	"$schema": "https://raw.githubusercontent.com/CeladonSS13/Shiptest/beta-dev/_maps/_mod_celadon/ship_config_schema.json",
 	"map_name": "Tomahawk-class Scout Vessel",
 	"map_short_name": "Tomahawk",
-	"description": "Корабль Солнечной Федерации класса Томагавк служит для фронтовой разведки с боем. Данный корабль обладает хорошей скоростью, не смотря на свои габариты. На судне предусмотрены рабочие места для двух медиков, трёх полевых инженеров и одного корабельного. С консультациями капитану помогает надзиратель, у которого есть своя каюта",
+	"description": "Корабль Солнечной Федерации класса Томагавк служит для фронтовой разведки с боем, cо временем начала космических экспансий 23 века о чем может подсказывать его обшивка. Данный корабль обладает хорошей скоростью, не смотря на свои габариты. На судне предусмотрены рабочие места для двух медиков, трёх полевых инженеров и одного корабельного.",
 	"map_path": "_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm",
 	"enabled": true,
 	"limit": 1,
 	"sensor_range": 4,
-	"starting_funds": 4000,
-	"prefix": "SFSV",
+	"starting_funds": 2000,
+	"prefix": "BSFSV",
 	"faction": "/datum/faction/solgov",
 	"tags": ["Разведка", "Бой", "Шахтёрство"],
 	"namelists": [
@@ -23,14 +23,9 @@
 			"officer": true,
 			"slots": 1
 		},
-		"Feldwebel": {
-			"outfit": "/datum/outfit/job/solfed/sergeant",
-			"officer": true,
-			"slots": 1
-		},
 		"Marine": {
 			"outfit": "/datum/outfit/job/solfed/marine",
-			"slots": 4
+			"slots": 3
 		},
 		"Meeresarzt": {
 			"outfit": "/datum/outfit/job/solfed/doctor",

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
@@ -246,6 +246,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)
 "dt" = (
@@ -304,6 +305,9 @@
 	pixel_x = 8;
 	pixel_y = 22
 	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = -6
+	},
 /turf/open/floor/suns/hatch/walnut,
 /area/ship/crew)
 "ec" = (
@@ -311,10 +315,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/ntblue/bordercorner,
-/obj/machinery/turretid/ship{
-	pixel_y = -25;
-	id = "tomahawk_turrets"
-	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ei" = (
@@ -594,9 +594,8 @@
 "iA" = (
 /obj/docking_port/stationary{
 	dwidth = 15;
-	width = 30;
 	height = 15;
-	dir = 2
+	width = 30
 	},
 /turf/template_noop,
 /area/space)
@@ -1306,6 +1305,9 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom/wideband/directional/east,
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 40
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "rX" = (
@@ -3239,6 +3241,9 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/pink/line{
 	dir = 4
+	},
+/obj/item/radio/intercom/directional/east{
+	pixel_y = -7
 	},
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
@@ -1302,9 +1302,10 @@
 	},
 /obj/item/kirbyplants/photosynthetic{
 	icon_state = "plant-01";
-	pixel_x = 4;
+	pixel_x = -1;
 	pixel_y = 5
 	},
+/obj/item/radio/intercom/wideband/directional/east,
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "rX" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
@@ -1,68 +1,87 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
 "ac" = (
-/obj/machinery/computer/security/solgov{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"ah" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"av" = (
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"aA" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
-	dir = 4
-	},
-/obj/machinery/meter/atmos/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering/engine)
-"aB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+/turf/open/floor/plasteel/tech,
+/area/space)
+"af" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"ah" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5;
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"av" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"aA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"aB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner,
+/turf/open/floor/carpet/red,
+/area/space)
 "aG" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -78,7 +97,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "aN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -90,219 +109,207 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "aP" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 1
 	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 32
+	},
+/obj/item/toy/plush/celadon/borbplushie{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "aU" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"bd" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew)
-"be" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge";
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"bf" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"bg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/platform/military{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"aX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"bd" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/ebony,
+/area/space)
 "bm" = (
 /obj/effect/turf_decal/solgov/center_left,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "br" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/turf/open/floor/plasteel,
+/area/space)
 "bs" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	network = "SolNet"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	req_one_access = list(61,11)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ship/engineering)
-"bt" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/crewtwo)
+/obj/structure/chair/comfy/purple/directional/east,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "bu" = (
-/obj/machinery/power/shuttle/engine/electric{
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+/obj/item/kirbyplants{
+	icon_state = "plant-27";
+	pixel_y = 22;
+	layer = 4.3;
+	pixel_x = -11
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/engine/hull,
-/area/ship/engineering/engine)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "bw" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
 /obj/machinery/button/door{
 	pixel_y = 11;
 	pixel_x = 22;
 	dir = 8;
 	name = "window shutter control";
-	id = "sgc_dorm"
+	id = "chronicle_dorm"
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"bx" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 5
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "bA" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
 /obj/structure/bed,
-/obj/item/bedsheet/solgov,
-/obj/structure/curtain/cloth,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/obj/structure/curtain/cloth/blacknormal,
+/obj/item/bedsheet/solfed,
+/turf/open/floor/wood/ebony,
+/area/space)
 "bB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 13;
-	pixel_y = -20
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
-"bH" = (
-/obj/structure/closet/secure_closet/captains{
-	populate = 0;
-	anchored = 1
-	},
-/obj/item/clothing/under/solgov/formal/captain,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/head/solgov/captain,
-/obj/item/folder/solgov,
-/obj/item/folder/solgov,
-/obj/item/folder/documents/solgov,
-/obj/item/folder/documents/solgov,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/gloves/combat,
-/obj/item/storage/backpack/captain,
-/obj/item/door_remote/captain,
-/obj/item/storage/belt/sabre/solgov,
-/obj/item/clothing/under/solgov/dress,
-/obj/item/clothing/suit/armor/vest/solgov/captain,
-/obj/item/stamp/solgov,
-/obj/item/clothing/suit/armor/solgov_trenchcoat,
-/obj/item/spacecash/bundle/loadsamoney,
-/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/clothing/neck/cloak/solgovcap,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
-"cg" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-9"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/turf/open/floor/plasteel/freezer,
+/area/space)
+"bP" = (
+/obj/machinery/porta_turret/ship/solfed/heavy{
+	dir = 6;
+	id = "chronicle_turrets"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/turf/open/floor/plasteel,
+/area/space)
+"bS" = (
+/obj/item/storage/box/PDAs,
+/obj/item/storage/box/ids,
+/obj/item/modular_computer/tablet/preset/advanced,
+/obj/item/clothing/suit/solgov/overcoat,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solfed/formal,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/structure/closet/secure_closet/head_of_personnel{
+	anchored = 1;
+	name = "\proper bureaucrat's locker";
+	populate = 0
+	},
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/item/storage/belt/sabre/solgov,
+/obj/machinery/light/colored/blue{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "cp" = (
-/obj/machinery/computer/message_monitor{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/item/stamp/solfed/captain{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/modglass/large{
+	pixel_y = 7;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = 7;
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/engineering)
+/area/space)
 "cw" = (
 /obj/docking_port/mobile{
 	port_direction = 8;
@@ -310,11 +317,11 @@
 	dir = 2
 	},
 /turf/closed/wall/mineral/titanium,
-/area/ship/crew)
+/area/space)
 "cP" = (
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sgc_cargo"
+	id = "chronicle_cargo"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -323,129 +330,106 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"cT" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ship/engineering)
+/area/space)
 "cW" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/pen/solgov{
-	pixel_x = -5
-	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew)
-"da" = (
-/obj/machinery/computer/cargo/solgov{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 6
 	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/vending/boozeomat/all_access{
+	all_items_free = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "dd" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/rack,
 /obj/machinery/firealarm/directional/south,
-/obj/item/stack/sheet/mineral/plasma/twenty,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "dj" = (
-/obj/structure/closet/crate/bin,
-/obj/item/trash/sosjerky,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew)
-"dm" = (
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/ebony,
+/area/space)
+"do" = (
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"du" = (
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "dz" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	pixel_y = -22;
-	pixel_x = -9;
-	id = "sgc_overseer";
-	name = "window shutter control";
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/engine/hull/reinforced,
+/area/space)
 "dA" = (
 /obj/machinery/computer/cryopod/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel,
-/area/ship/crew/dorm)
+/turf/open/floor/wood/ebony,
+/area/space)
 "dC" = (
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov{
+	slowdown = 0.1;
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
+	name = "lightweight SolFed hardsuit";
+	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/wood/ebony,
+/area/space)
+"dG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/freezer,
+/area/space)
+"dR" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Bathroom";
+	id_tag = "sgc_piss"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
-	dir = 4;
-	id = "sgc_airlock2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
-"dR" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel/freezer,
+/area/space)
 "ez" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
@@ -464,123 +448,37 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/crew/dorm)
-"eD" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"eQ" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin,
-/obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -7
-	},
-/obj/item/pen/solgov,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 9
-	},
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"eU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/orange,
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_y = -10;
-	pixel_x = -22;
-	id = "sgc_engine"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"eV" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/area/space)
 "fd" = (
-/obj/structure/table/wood,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew)
-"fe" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/ebony,
+/area/space)
 "fj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor/orange/corner{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Bridge"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"fl" = (
-/obj/structure/closet/secure_closet/miner{
-	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
-	},
-/obj/item/pickaxe/drill/jackhammer,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/hardhat/solgov,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solgov/dress,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/shoes/workboots,
-/obj/item/melee/knife/survival,
-/obj/item/clothing/gloves/combat,
-/obj/item/storage/backpack,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
+/turf/open/floor/plasteel,
+/area/space)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -591,32 +489,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"fw" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"fz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
 	dir = 1
 	},
-/obj/machinery/computer/bookmanagement{
-	pixel_y = 7;
-	icon_state = "laptop";
-	dir = 8
+/turf/open/floor/plasteel/white,
+/area/space)
+"fw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/cable{
+	icon_state = "0-1"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/machinery/door/poddoor/shutters{
+	id = "chronicle_rnd";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/space)
 "fA" = (
 /obj/effect/turf_decal/solgov/center_right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -631,39 +520,46 @@
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
-"fN" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/wood,
-/area/ship/bridge)
+/area/space)
+"fP" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/docking_port/mobile{
+	dir = 4;
+	launch_status = 0;
+	preferred_direction = 4;
+	port_direction = 2
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "fT" = (
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "fW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
+/obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	piping_layer = 2
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/turf/open/floor/engine/o2,
+/area/space)
 "ga" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 1;
@@ -671,57 +567,55 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sgc_cargo"
+	id = "chronicle_cargo"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"gi" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/structure/railing/wood{
-	color = "#543C30"
-	},
+/area/space)
+"ge" = (
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"gk" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/item/solar_assembly,
 /turf/open/floor/plating,
-/area/ship/bridge)
+/area/space)
+"gi" = (
+/obj/effect/turf_decal/corner/opaque/purple/half{
+	dir = 1
+	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/light/colored/purple{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel,
+/area/space)
+"go" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_y = -10;
+	pixel_x = -7
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "gs" = (
-/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "gB" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
 /obj/structure/noticeboard/staff{
 	dir = 4;
 	pixel_x = -26
@@ -729,186 +623,104 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "gK" = (
-/turf/open/floor/plating,
-/area/ship/external)
-"gZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/ship/engineering)
-"hh" = (
-/obj/effect/turf_decal/industrial/warning{
+/obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
-	dir = 4
-	},
-/obj/structure/sign/solgov_seal{
-	pixel_y = -27
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/engineering/engine)
-"hp" = (
-/obj/structure/table/wood,
-/obj/structure/railing/wood{
-	color = "#792f27"
-	},
-/obj/item/food/grown/cabbage{
-	pixel_x = 1;
-	pixel_y = -3
-	},
-/obj/item/food/grown/cabbage{
-	pixel_y = 6;
-	pixel_x = 9
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
-"hr" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/machinery/fax/solgov,
-/obj/item/desk_flag/solgov{
-	pixel_x = 8;
-	pixel_y = 13
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 5
-	},
-/obj/machinery/button/door{
-	pixel_y = 23;
-	pixel_x = 10;
-	id = "sgc_captain";
-	name = "window shutter control"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"hs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 5
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/item/kirbyplants{
-	icon_state = "applebush";
-	pixel_y = 16;
-	pixel_x = 8
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-11";
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_x = -12;
-	pixel_y = 18
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"hw" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"hx" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-11";
-	pixel_x = -12;
-	pixel_y = 19;
-	layer = 2.89
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"hA" = (
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Bridge";
-	req_access = list(19)
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/bridge)
-"hM" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"hS" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/telecomms/bus{
+	id = "bus mainframe";
+	network = "SolNet";
+	autolinkers = list("processor7","solgov")
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"gZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/platform/military/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/techfloor{
+	dir = 10;
+	pixel_x = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"hp" = (
+/obj/structure/table,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
+/turf/open/floor/wood/ebony,
+/area/space)
+"hw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/machinery/door/airlock/vault,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"hH" = (
+/turf/open/floor/wood/ebony,
+/area/space)
+"hM" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/machinery/light/colored/red,
+/turf/open/floor/plasteel/white,
+/area/space)
+"hS" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 8
+	},
+/obj/machinery/turretid/ship{
+	id = "chronicle_turrets";
+	pixel_x = 32;
+	pixel_y = 6
+	},
+/obj/structure/table/glass,
+/obj/machinery/light/colored/blue{
+	dir = 1
+	},
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_y = 10
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_y = -7;
+	pixel_x = 23;
+	id = "chronicle_bridge"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "hU" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06";
@@ -919,22 +731,20 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "hX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "2-5"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel,
+/area/space)
 "id" = (
 /obj/structure/closet/secure_closet/security{
 	populate = 0;
@@ -961,8 +771,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/outline/red,
+/obj/item/melee/baton/loaded{
+	pixel_x = 3;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
+/area/space)
 "ie" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -975,53 +789,39 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"if" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	pixel_y = 22;
-	pixel_x = 9;
-	id = "sgc_engi";
-	name = "window shutter control"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/wood/ebony,
+/area/space)
 "ip" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/crew/crewtwo)
+/area/space)
 "iA" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/light/small/directional/east,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"ja" = (
+/turf/open/floor/engine/o2,
+/area/space)
+"iL" = (
+/obj/machinery/porta_turret/ship/solfed/heavy{
+	dir = 5;
+	id = "chronicle_turrets"
+	},
 /turf/closed/wall/mineral/titanium,
-/area/ship/crew/dorm)
+/area/space)
+"ja" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "jb" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -1033,278 +833,247 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "jd" = (
-/obj/structure/table/wood,
-/obj/structure/railing/wood{
-	dir = 6;
-	color = "#792f27"
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
-	},
-/obj/item/food/grown/cabbage{
-	pixel_y = 4
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
-"ju" = (
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
-"jz" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/engine)
-"jJ" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_y = -8;
-	pixel_x = -22;
-	id = "sgc_airlock2";
-	req_one_access = list(20,19);
-	name = "blast door control"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 7
-	},
-/obj/machinery/light/small/directional/west{
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"jS" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"jU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 8;
+	pixel_y = -1
 	},
+/turf/open/floor/carpet/red,
+/area/space)
+"jh" = (
+/obj/effect/turf_decal/corner/opaque/purple/half{
+	dir = 4
+	},
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/box/white,
+/obj/machinery/light/colored/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"ju" = (
+/obj/effect/turf_decal/corner/opaque/purple/half,
+/obj/structure/table/glass,
+/obj/item/food/donut/berry,
+/obj/item/food/donut/apple{
+	pixel_y = 4
+	},
+/obj/item/food/donut/blumpkin{
+	pixel_y = 9
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/carpet/purple,
+/area/space)
+"jz" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"jU" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"ke" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"ka" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 11;
 	pixel_y = -16
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"ke" = (
+/turf/open/floor/carpet/purple,
+/area/space)
 "kg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/solgov_seal{
+	pixel_y = 0;
+	pixel_x = 28
+	},
+/obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/machinery/bookbinder,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel/tech,
+/area/space)
 "kl" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/machinery/computer/secure_data/laptop{
-	dir = 8;
-	pixel_y = 5;
-	pixel_x = 4
-	},
 /obj/effect/turf_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "kp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew)
-"kw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"kz" = (
-/obj/machinery/telecomms/hub{
-	autolinkers = list("solgov","broadcasterA","receiverA","solgovPDA","SolHub");
-	network = "SolNet";
-	id = "Solgov Hub"
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/engineering)
+/turf/open/floor/carpet/red,
+/area/space)
+"kz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 8;
+	pixel_y = -16
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/tech,
+/area/space)
 "kI" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/machinery/telecomms/server/presets/solgov{
+	autolinkers = list("solgov","sproingle");
+	network = "SolNet"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
-	dir = 4
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering/engine)
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#2d2a4e"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "kN" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/dorm)
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "kT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/chair/comfy/purple/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/space)
+"lc" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
+/turf/open/floor/wood/ebony,
+/area/space)
+"lJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"lR" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"lc" = (
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"lA" = (
-/obj/effect/turf_decal/atmos/nitrogen{
-	dir = 1;
-	layer = 2.04
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/orange,
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"lJ" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew)
-"lP" = (
-/obj/structure/cable{
-	icon_state = "1-6"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"lZ" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/sign/warning{
-	pixel_y = 9;
-	pixel_x = -23
-	},
 /obj/machinery/camera/autoname{
-	dir = 5
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "ma" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"mc" = (
+/obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
+/obj/structure/noticeboard/staff{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"mf" = (
+/obj/structure/chair/office/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "ml" = (
 /obj/effect/turf_decal/industrial/warning/dust{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/ship/external)
+/area/space)
 "mz" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/structure/chair/office,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/item/desk_flag/solfed{
+	pixel_y = 1;
+	pixel_x = -8
+	},
+/obj/structure/table/wood/fancy/purple,
+/obj/item/folder/solfed{
+	pixel_x = 5
+	},
+/obj/item/pen/solgov{
+	pixel_x = 4
+	},
+/obj/item/dice/d20,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "mA" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -1323,25 +1092,17 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/space)
 "mG" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/crew)
+/turf/open/floor/carpet/red,
+/area/space)
 "mN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -1354,42 +1115,56 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"mP" = (
-/obj/structure/filingcabinet/double,
-/obj/item/documents/solgov,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 6
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"mZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"nb" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"mX" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/machinery/light/colored/blue,
+/turf/open/floor/plasteel/tech,
+/area/space)
+"nb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "nd" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner,
+/turf/open/floor/carpet/red,
+/area/space)
 "ne" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -1399,44 +1174,70 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "ng" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
 /turf/open/floor/engine/o2,
-/area/ship/engineering/engine)
+/area/space)
 "nj" = (
 /obj/structure/bed,
-/obj/item/bedsheet/solgov,
-/obj/structure/curtain/cloth,
 /obj/structure/sign/solgov_flag{
 	dir = 1;
 	pixel_y = -27
 	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/obj/structure/curtain/cloth/blacknormal,
+/obj/item/bedsheet/solfed,
+/turf/open/floor/wood/ebony,
+/area/space)
+"nD" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "nF" = (
-/obj/structure/closet/crate/wooden,
 /obj/machinery/light/directional/south,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/soap,
-/obj/item/soap,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "nH" = (
-/obj/structure/chair/sofa/brown/right/directional/east,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "nP" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "nR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1452,67 +1253,39 @@
 	dir = 8
 	},
 /obj/effect/landmark/observer_start,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "nU" = (
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
+/obj/structure/mirror{
+	pixel_y = 26
 	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
+/obj/structure/sink{
+	pixel_y = 19
 	},
-/obj/item/pen/solgov{
-	pixel_x = -4
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = -9;
+	id = "sgc_piss";
+	specialfunctions = 3;
+	name = "bathroom lock"
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"nW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/freezer,
+/area/space)
 "ol" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_dorm"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "chronicle_dorm";
+	name = "Blast Shutters"
+	},
 /turf/open/floor/plating,
-/area/ship/crew)
+/area/space)
 "oz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1521,78 +1294,76 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/turf/open/floor/plasteel,
+/area/space)
 "oC" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"oH" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11)
-	},
-/obj/machinery/telecomms/bus{
-	id = "bus mainframe";
-	network = "SolNet";
-	autolinkers = list("processor7","solgov")
-	},
-/turf/open/floor/circuit,
-/area/ship/engineering)
-"oK" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 1
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"oY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
-	dir = 5
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 6
+/turf/open/floor/plasteel,
+/area/space)
+"oH" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/area/space)
+"oK" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/structure/sign/poster/solgov/mars{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
+"oY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/space)
+"pe" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "pi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_dorm"
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1602,60 +1373,58 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "chronicle_dorm";
+	name = "Blast Shutters"
+	},
+/obj/machinery/button/door{
+	pixel_y = 11;
+	pixel_x = 22;
+	dir = 8;
+	name = "window shutter control";
+	id = "chronicle_dorm"
+	},
+/obj/machinery/button/door{
+	pixel_y = 11;
+	pixel_x = 22;
+	dir = 8;
+	name = "window shutter control";
+	id = "chronicle_dorm"
+	},
 /turf/open/floor/plating,
-/area/ship/crew)
+/area/space)
 "pl" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/rack,
 /obj/item/radio/intercom/directional/north,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/metal/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/stack/sheet/glass/five,
-/obj/item/stack/sheet/glass/five,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"pC" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/modular_computer/console/preset/command{
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"pR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"pD" = (
+/obj/structure/sign/flag/solfed/directional/north,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"pF" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "pS" = (
-/turf/template_noop,
-/area/template_noop)
-"qe" = (
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "qg" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/solgov/dress,
@@ -1666,154 +1435,151 @@
 /obj/item/radio/headset,
 /obj/item/radio,
 /obj/item/radio,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/light/small/directional/east,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov/dress,
 /obj/item/clothing/under/solgov/dress,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/ebony,
+/area/space)
+"qt" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "qz" = (
-/obj/machinery/photocopier,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
+/turf/open/floor/wood/ebony,
+/area/space)
 "qH" = (
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -16
+	},
+/obj/machinery/camera/autoname{
+	dir = 10
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"rq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"rw" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	network = "SolNet"
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
+	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"rq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	req_access = list(11);
-	name = "Equipment Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"rw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "rD" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/office)
+/turf/template_noop,
+/area/space)
+"rH" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "rJ" = (
-/obj/machinery/suit_storage_unit/solgov,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/techfloor,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#2d2a4e"
+	},
+/obj/item/clothing/suit/space/hardsuit/solgov{
+	slowdown = 0.1;
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
+	name = "lightweight SolFed hardsuit";
+	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/sechailer,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"rK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/bridge)
+/area/space)
 "rO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel,
+/area/space)
 "rS" = (
-/obj/machinery/autolathe,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/grenade/stingbang{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/grenade/stingbang{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/grenade/frag{
+	pixel_y = 5;
+	pixel_x = 8
+	},
+/obj/item/grenade/frag{
+	pixel_y = 5;
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
+/area/space)
 "rZ" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/filingcabinet/double,
+/obj/item/documents/solfed,
+/obj/machinery/light/colored/blue{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"sa" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"sa" = (
-/obj/machinery/computer/telecomms/monitor/solgov{
-	dir = 1;
-	network = "SolNet"
-	},
-/obj/structure/railing,
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
+/turf/open/floor/plasteel,
+/area/space)
 "sd" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/machinery/mech_bay_recharge_port{
+	icon_state = "recharge_port";
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "sf" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -1827,26 +1593,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/ship/cargo)
-"sq" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/area/space)
 "sx" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -1869,23 +1621,50 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
-"sz" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/structure/railing/wood{
-	color = "#543C30"
-	},
+/area/space)
+"sy" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/bridge)
+/obj/structure/chair/comfy/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/machinery/button/door{
+	pixel_y = 6;
+	pixel_x = 22;
+	dir = 8;
+	name = "window shutter control";
+	id = "chronicle_rnd"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"sz" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/plasteel,
+/area/space)
 "sA" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Bridge"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "sE" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24;
@@ -1900,9 +1679,12 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
+/area/space)
+"sF" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "sL" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1912,30 +1694,49 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"sM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 6
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/space)
+"sM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/computer/solar_control{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/sign/warning/incident{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/light/colored/orange{
+	dir = 4
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "sS" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "sU" = (
 /obj/machinery/shower{
 	dir = 1
@@ -1944,164 +1745,117 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
+/area/space)
+"ta" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"td" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "ti" = (
 /obj/item/melee/duelenergy/halberd/purple,
 /obj/item/melee/duelenergy/halberd/purple,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/closet/cabinet{
-	name = "energy halbreds"
-	},
+/obj/structure/rack,
+/obj/item/melee/duelenergy/halberd/purple,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"tl" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#543C30";
-	dir = 8
-	},
-/obj/structure/railing/corner/wood{
-	color = "#543C30";
-	dir = 8
+/area/space)
+"tr" = (
+/obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
+/turf/open/floor/wood/ebony,
+/area/space)
+"ty" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"tr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/ship/crew)
-"ty" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"tC" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 8;
-	req_one_access = list(61,11)
-	},
-/obj/machinery/telecomms/message_server{
-	autolinkers = list("solgovPDA");
-	network = "SolNet";
-	calibrating = 0
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/circuit/red,
-/area/ship/engineering)
-"tJ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew)
-"tQ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/pen/solgov{
-	pixel_x = -5
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"tV" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/office)
-"um" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"un" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"uA" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"uC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/engine/o2,
+/area/space)
+"tC" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/obj/machinery/computer/cargo{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"tJ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/space)
+"tV" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/plasteel,
+/area/space)
+"tZ" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/obj/structure/weightmachine/stacklifter,
+/turf/open/floor/plasteel,
+/area/space)
+"ub" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/item/solar_assembly,
 /turf/open/floor/plating,
-/area/ship/bridge)
-"uD" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold{
-	dir = 9
+/area/space)
+"um" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	name = "ship engineer's locker";
+	populate = 0
 	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"uK" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"uW" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 1
-	},
-/obj/structure/fluff/hedge,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
-"ve" = (
+/obj/item/storage/backpack/industrial,
+/obj/item/folder/solgov,
+/obj/item/clipboard,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding,
+/obj/item/pen/solgov,
+/obj/item/clothing/suit/hazardvest/solgov,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/sunglasses,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"un" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4
 	},
@@ -2111,14 +1865,62 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/engine/hull,
-/area/ship/engineering/engine)
-"vo" = (
+/area/space)
+"uA" = (
+/obj/machinery/telecomms/processor{
+	autolinkers = list("processor7");
+	network = "SolNet";
+	id = "Processor"
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
+	},
+/obj/machinery/light/colored/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/space)
+"vd" = (
+/obj/machinery/porta_turret/ship/solfed/heavy{
+	dir = 10;
+	id = "chronicle_turrets"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"ve" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/sign/solgov_seal{
+	pixel_y = -27
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/space)
+"vj" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating,
+/area/space)
+"vr" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2126,39 +1928,30 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
-"vr" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel/tech,
+/area/space)
 "vx" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew)
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/space)
 "vO" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/binoculars{
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel,
+/area/space)
 "vR" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -2172,18 +1965,48 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"wt" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
+/turf/open/floor/wood/ebony,
+/area/space)
+"vS" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+/obj/structure/table/wood,
+/obj/machinery/jukebox/boombox,
+/turf/open/floor/plasteel,
+/area/space)
+"wi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/sign/solgov_seal,
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/engineering/engine)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"ws" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/item/bedsheet/solfed,
+/obj/structure/bed,
+/obj/structure/curtain/cloth/blacknormal,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"wt" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull,
+/area/space)
 "wK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2195,7 +2018,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "wP" = (
 /obj/effect/turf_decal/industrial/warning/dust/corner{
 	dir = 1
@@ -2207,197 +2030,153 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/ship/external)
+/area/space)
 "wT" = (
 /obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"wU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"wV" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"wW" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-11";
-	pixel_x = 10;
-	layer = 2.89
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper/crumpled,
-/obj/item/pen/fountain/solgov,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"xf" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/orange/corner{
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor/orange{
+/obj/machinery/camera/autoname{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer4,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"xt" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"xu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"xI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/wood,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"xL" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Command Wing"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
-"xM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_captain";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/office)
-"xO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"ya" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"yj" = (
-/obj/structure/chair/sofa/brown/corner/directional/east,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
-"yu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 8
+/area/space)
+"wW" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "science";
+	name = "scientist's locker";
+	req_access_txt = "7"
+	},
+/obj/item/analyzer,
+/obj/item/clothing/under/nanotrasen/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/effect/turf_decal/box/white,
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
+/turf/open/floor/plasteel,
+/area/space)
+"xt" = (
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/turf/open/floor/engine/o2,
+/area/space)
+"xu" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"xF" = (
+/obj/machinery/porta_turret/ship/solfed/heavy{
+	dir = 9;
+	id = "chronicle_turrets"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"xL" = (
+/obj/structure/dresser,
+/obj/item/kirbyplants/photosynthetic{
+	icon_state = "plant-01";
+	pixel_y = 15
+	},
+/obj/machinery/light/colored/blue{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"xN" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 4;
+	pixel_x = -5;
+	pixel_y = 4;
+	layer = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/item/desk_flag/solfed{
+	pixel_y = 15;
+	pixel_x = -2
 	},
-/turf/open/floor/plating,
-/area/ship/bridge)
-"yv" = (
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/crew)
-"yw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"xO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"ya" = (
+/obj/structure/sign/warning{
+	pixel_y = 9;
+	pixel_x = -23
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"yj" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 9
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/wood/ebony,
+/area/space)
+"yu" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = -10;
+	pixel_x = -22;
+	id = "sgc_engine"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/space)
+"yv" = (
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
 "yA" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -2421,9 +2200,78 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/dorm)
-"yD" = (
+/turf/open/floor/wood/ebony,
+/area/space)
+"yE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/purple,
+/area/space)
+"yY" = (
+/obj/structure/closet/secure_closet/freezer{
+	name = "fridge";
+	anchored = 1
+	},
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/reagent_containers/condiment/enzyme,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/space_cola{
+	pixel_y = 32;
+	pixel_x = -4
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"zh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"zk" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/machinery/light/colored/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"zm" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/recharger{
+	pixel_x = 10
+	},
+/obj/machinery/recharger{
+	pixel_x = -10
+	},
+/obj/machinery/recharger{
+	pixel_y = 6
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/tech/grid,
+/area/space)
+"zs" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -2433,159 +2281,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"yE" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"yQ" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-17";
-	pixel_y = 23;
-	pixel_x = -7
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"yY" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/structure/railing/wood{
-	dir = 4;
-	color = "#792f27"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
-	},
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
-"zh" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/orange{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "sgc_engine";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"zi" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"zk" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/structure/closet/crate/secure/gear{
-	populate = 0;
-	name = "emergency sauerkraut supplies";
-	desc = "For emergency use only";
-	req_access = list(19)
-	},
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/structure/sign/warning/incident{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"zm" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/structure/table/wood,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"zq" = (
-/obj/effect/turf_decal/atmos/oxygen{
-	layer = 2.04
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/orange,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"zs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel,
+/area/space)
 "zu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2599,49 +2299,69 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
 "zv" = (
-/obj/structure/chair/sofa/brown/directional/east,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "zw" = (
 /obj/effect/turf_decal/solgov/bottom_right,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/machinery/light/colored/red,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
-"zM" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering)
+/area/space)
 "zR" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"Ad" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+	dir = 1
 	},
+/turf/open/floor/plasteel/white,
+/area/space)
+"Ad" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/item/cigbutt{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/cigbutt{
+	pixel_x = -12;
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
+/turf/open/floor/engine/o2,
+/area/space)
 "Ag" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -2655,46 +2375,21 @@
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
-"Ah" = (
-/obj/structure/railing/corner/wood{
-	color = "#543C30"
-	},
-/obj/machinery/computer/helm/solgov{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/area/space)
 "As" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
 	},
-/obj/structure/closet/secure_closet/engineering_personal{
-	name = "ship engineer's locker";
-	populate = 0
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
-/obj/item/storage/backpack/industrial,
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/item/clothing/head/hardhat/solgov,
-/obj/item/folder/solgov,
-/obj/item/clipboard,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/accessory/armband/engine,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding,
-/obj/item/pen/solgov,
-/obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
-/obj/machinery/light/directional/west,
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "Au" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/solgov/dress,
@@ -2720,15 +2415,14 @@
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/turf/open/floor/wood/ebony,
+/area/space)
 "Ax" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "Az" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
 	dir = 4
@@ -2738,7 +2432,27 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
+/area/space)
+"AA" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "science";
+	name = "scientist's locker";
+	req_access_txt = "7"
+	},
+/obj/item/analyzer,
+/obj/item/clothing/under/nanotrasen/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/effect/turf_decal/corner/opaque/purple/half,
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/corner/opaque/purple/three_quarters{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
+/turf/open/floor/plasteel,
+/area/space)
 "AK" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -2750,7 +2464,7 @@
 	dir = 1;
 	pixel_y = -22;
 	pixel_x = 8;
-	id = "sgc_cargo";
+	id = "chronicle_cargo";
 	name = "blast door control"
 	},
 /obj/machinery/button/shieldwallgen{
@@ -2759,8 +2473,12 @@
 	pixel_x = -2;
 	id = "sgc_cs"
 	},
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "AM" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
@@ -2768,19 +2486,19 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "AN" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering/engine)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
 "AQ" = (
 /obj/effect/turf_decal/techfloor/corner,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "AR" = (
 /obj/structure/mirror{
 	pixel_y = 24
@@ -2789,199 +2507,124 @@
 	pixel_y = 19
 	},
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
-"AV" = (
-/obj/machinery/telecomms/processor{
-	autolinkers = list("processor7");
-	network = "SolNet";
-	id = "Processor"
+/area/space)
+"Bg" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/sign/poster/bay/bay_20{
+	pixel_x = -32
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/westleft{
-	dir = 4;
-	req_one_access = list(61,11)
-	},
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/circuit/green,
-/area/ship/engineering)
-"AZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"Be" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/wood/ebony,
+/area/space)
 "Bn" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -10
 	},
+/obj/machinery/power/terminal,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Bs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Bz" = (
 /obj/effect/turf_decal/techfloor{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/engine/o2,
-/area/ship/engineering/engine)
+/area/space)
 "BE" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
-"BZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
+/area/space)
+"BO" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/turf/open/floor/carpet/purple,
+/area/space)
+"BQ" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/space)
 "Cb" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering/engine)
-"Cd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/colored/orange,
+/turf/open/floor/engine/o2,
+/area/space)
 "Cf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Cm" = (
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Captain's Quarters";
-	req_access = list(20)
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/office)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Cs" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"CC" = (
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Overseer's Quarters";
-	req_access = list(57)
-	},
+/obj/effect/turf_decal/techfloor,
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/five,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"Cw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
+/turf/open/floor/engine/o2,
+/area/space)
 "CE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
-/area/ship/security/armory)
+/area/space)
+"CF" = (
+/obj/effect/turf_decal/corner/opaque/purple/three_quarters,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/structure/sign/poster/bay/bay_49{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "CK" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
+/obj/machinery/rnd/production/protolathe/department/science,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel,
+/area/space)
 "CM" = (
 /obj/effect/turf_decal/techfloor,
 /obj/structure/cable{
@@ -2995,86 +2638,81 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "CU" = (
-/obj/machinery/fax/solgov,
-/obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 6
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"Da" = (
+/obj/structure/platform/military{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/light/colored/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Dn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "Ds" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
+/obj/effect/turf_decal/techfloor{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "Du" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
 "DC" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"DN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/rack,
+/obj/item/aiModule/supplied/freeform{
+	pixel_y = 4
 	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/item/aicard,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"DN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"DW" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 10
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "Ef" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -3094,7 +2732,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
+/area/space)
 "Ep" = (
 /obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
 	dir = 1
@@ -3113,33 +2751,17 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "Er" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"Ex" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine/n2,
-/area/ship/engineering/engine)
-"Ez" = (
-/obj/structure/closet/secure_closet/wall/directional/north{
-	name = "bridge supplies"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
-/obj/item/binoculars,
-/obj/item/binoculars{
-	pixel_y = 6
-	},
-/obj/item/gps{
-	gpstag = "SFSV Chronicle"
-	},
-/obj/item/pen/fountain/solgov,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/bridge)
+/obj/machinery/holopad,
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "EC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3151,53 +2773,40 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
-"EF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/item/kirbyplants{
-	icon_state = "applebush";
-	pixel_y = 19;
-	pixel_x = -8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/wood/ebony,
+/area/space)
 "EX" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"EZ" = (
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+	dir = 1
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/structure/sign/warning/firingrange{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"EZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_x = 7;
-	pixel_y = 18
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_x = 8;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 11;
-	pixel_x = -6
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/turf/open/floor/plasteel,
+/area/space)
 "Fa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Fg" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -3211,14 +2820,7 @@
 	pixel_x = -12
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
-"Fh" = (
-/obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = 28
-	},
-/turf/open/floor/plating,
-/area/ship/external)
+/area/space)
 "Fl" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -3227,56 +2829,33 @@
 	width = 30
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Fm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"FC" = (
-/obj/structure/bed,
-/obj/item/bedsheet/solgov,
-/obj/structure/sign/solgov_flag{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/crewtwo)
-"FG" = (
-/obj/structure/railing/wood{
-	dir = 6;
-	color = "#543C30"
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_y = 5
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/turf/open/floor/plasteel,
+/area/space)
 "FM" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "FO" = (
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3289,8 +2868,13 @@
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/space)
 "FX" = (
 /obj/structure/noticeboard/staff{
 	dir = 4;
@@ -3304,8 +2888,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/ship/crew/dorm)
+/turf/open/floor/wood/ebony,
+/area/space)
+"Gi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/purple,
+/obj/item/lighter/zippo/sol{
+	pixel_y = 5;
+	pixel_x = -4;
+	layer = 3.1
+	},
+/obj/item/storage/fancy/cigarettes/cigars{
+	pixel_y = 8;
+	pixel_x = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "Gk" = (
 /obj/effect/turf_decal/techfloor,
 /obj/structure/cable{
@@ -3319,48 +2919,56 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
+"Gs" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "Gt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 10;
-	pixel_x = -30
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/closet/firecloset/wall/directional/south,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/machinery/porta_turret/ship/solfed/heavy{
+	dir = 10;
+	id = "chronicle_turrets"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "Gv" = (
-/obj/machinery/atmospherics/components/unary/thermomachine{
-	piping_layer = 2
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering/engine)
-"Gw" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"GH" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/template_noop,
-/area/template_noop)
+/obj/structure/sign/poster/bay/bay_52{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"GH" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "GP" = (
 /obj/machinery/door/airlock/solgov{
 	dir = 4;
@@ -3389,178 +2997,145 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ship/security/armory)
+/area/space)
 "GT" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"Hb" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
-	},
+/area/space)
+"GX" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
+	dir = 8
 	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/table/wood/fancy/blue,
-/obj/machinery/camera/autoname,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Hd" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/turf/open/floor/plasteel,
+/area/space)
+"Hn" = (
+/obj/structure/sign/solfed{
+	pixel_y = 32
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/item/bedsheet/solfed,
+/obj/structure/curtain/cloth/blacknormal,
+/obj/item/toy/plush/blahaj,
+/obj/structure/bed,
+/turf/open/floor/wood/ebony,
+/area/space)
 "Ho" = (
-/obj/effect/turf_decal/techfloor,
+/obj/structure/closet/crate/cyborg,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
 /obj/machinery/camera/autoname{
-	dir = 1
+	dir = 10
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "Hp" = (
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/jetpack/oxygen,
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/obj/effect/turf_decal/corner/opaque/purple/half{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/healthanalyzer/advanced,
+/obj/item/surgicaldrill/advanced,
+/obj/item/retractor/advanced{
+	pixel_y = 5
+	},
+/obj/item/scalpel/advanced{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Hz" = (
+/turf/open/floor/plasteel,
+/area/space)
 "HA" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "HM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ship/crew)
-"Id" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_overseer";
+/turf/open/floor/carpet/red,
+/area/space)
+"HP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"HT" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 "Ii" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/machinery/fax/solgov,
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/plasteel/tech,
+/area/space)
 "Im" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/industrial/outline/orange,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"In" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"Io" = (
+/obj/structure/rack,
+/obj/item/borg/upgrade/ai,
+/obj/item/borg/upgrade/ai,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/machinery/light/colored/blue,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"Iu" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/turf/open/floor/plasteel,
+/area/space)
+"IH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/crewtwo)
-"Iv" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/structure/cable{
-	icon_state = "1-8"
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = 7
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"ID" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"IH" = (
-/obj/machinery/telecomms/server/presets/solgov{
-	autolinkers = list("solgov","sproingle");
-	network = "SolNet"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11)
-	},
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ship/engineering)
-"II" = (
-/obj/structure/railing/wood{
-	color = "#543C30"
-	},
-/obj/structure/table/wood,
-/obj/machinery/light/directional/west,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/pen/solgov{
-	pixel_x = -5
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "Ja" = (
-/obj/structure/chair/sofa/brown/directional/south,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Jd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -3569,128 +3144,126 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
-"Jh" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/machinery/fax/solgov,
-/obj/item/desk_flag/solgov{
-	pixel_x = -9;
-	pixel_y = 14
+/area/space)
+"Je" = (
+/obj/structure/closet/secure_closet/miner{
+	name = "field engineer's locker";
+	populate = 0;
+	anchored = 1
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/obj/item/pickaxe/drill/jackhammer,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/suit/hazardvest/solgov,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/shoes/workboots,
+/obj/item/melee/knife/survival,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/backpack,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/item/clothing/glasses/meson/night,
+/turf/open/floor/plasteel/tech/grid,
+/area/space)
 "Jn" = (
-/obj/item/bedsheet/double/solgov{
-	dir = 1
-	},
-/obj/structure/bed/double{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/solgov_flag{
-	dir = 4;
-	pixel_x = -27
-	},
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
+/area/space)
 "Ju" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_x = 9;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "JH" = (
-/obj/machinery/computer/telecomms/server/solgov{
-	dir = 1;
-	network = "SolNet"
+/obj/structure/platform/military{
+	dir = 1
 	},
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"JI" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#543C30";
-	dir = 8
-	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"JJ" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
+/turf/open/floor/carpet/purple,
+/area/space)
+"JN" = (
+/obj/machinery/telecomms/hub{
+	autolinkers = list("solgov","broadcasterA","receiverA","solgovPDA","SolHub");
+	network = "SolNet";
+	id = "Solgov Hub"
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#2d2a4e"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
+	},
+/obj/structure/sign/poster/bay/bay_21{
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"JQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel,
+/area/space)
+"JS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "chronicle_dorm";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/space)
+"Ka" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"JJ" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"JN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ship/engineering)
-"JQ" = (
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 5
-	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
-"JS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_dorm"
-	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/ship/crew)
-"Ka" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_captain";
+/obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/office)
+/turf/open/floor/carpet/purple,
+/area/space)
 "Kb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/obj/effect/turf_decal/corner/opaque/solgovgold{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3700,37 +3273,28 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel,
+/area/space)
 "Kc" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#543C30"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/ebony,
+/area/space)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Kh" = (
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/end,
-/obj/structure/fluff/hedge,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "Ks" = (
 /obj/structure/guncloset{
 	desc = "A locker that holds weapons.";
@@ -3743,104 +3307,55 @@
 	dir = 1
 	},
 /obj/item/gun/ballistic/automatic/powered/gauss/claris,
+/obj/item/gun/ballistic/automatic/powered/gauss/claris,
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"Kv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"Ky" = (
-/obj/structure/closet/crate/bin,
-/obj/item/trash/semki,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"KG" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"KN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_captain";
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/crew/office)
+/area/space)
 "KU" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/solgov,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"KZ" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/ship/external)
+/turf/open/floor/plasteel,
+/area/space)
+"La" = (
+/obj/structure/chair/office/purple,
+/turf/open/floor/carpet/purple,
+/area/space)
 "Lb" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/turf/open/floor/plasteel,
+/area/space)
 "Lc" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#543C30";
+/obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/railing/wood{
-	color = "#543C30";
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/obj/item/radio/intercom/table,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
+/obj/effect/turf_decal/techfloor{
+	dir = 8
 	},
-/obj/machinery/light/small/directional/south,
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood,
-/area/ship/bridge)
+/turf/open/floor/engine/o2,
+/area/space)
 "Lk" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 1
@@ -3853,127 +3368,63 @@
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "LB" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/power/ship_gravity,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering/engine)
-"LE" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
-"Md" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/closet/firecloset/wall/directional/south,
-/turf/open/floor/wood,
-/area/ship/bridge)
+/area/space)
 "Me" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
-	},
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/ship/crew/dorm)
-"Mx" = (
-/obj/structure/filingcabinet/double,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"MC" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
+/turf/open/floor/wood/ebony,
+/area/space)
+"Mo" = (
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = -9;
+	id = "HOP_Chronicle"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
 "ME" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"MH" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 8;
-	piping_layer = 2
-	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering/engine)
-"MT" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/machinery/light/directional/west,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"MZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	id = "sgc_bridge"
+	dir = 4;
+	id = "sgc_airlock2"
 	},
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
-"Nb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2,
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
-/obj/effect/turf_decal/techfloor/corner{
+/obj/machinery/door/airlock/external{
 	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/turf/open/space/basic,
+/area/space)
+"MY" = (
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
 	},
-/obj/structure/closet/firecloset/wall/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering/engine)
+/obj/machinery/vending/coffee{
+	all_items_free = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Nm" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable{
@@ -3987,41 +3438,49 @@
 	pixel_x = 11;
 	pixel_y = -16
 	},
-/turf/open/floor/plasteel,
-/area/ship/crew/dorm)
+/turf/open/floor/wood/ebony,
+/area/space)
 "Ns" = (
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Nu" = (
-/obj/structure/table/wood,
-/obj/structure/railing/wood{
-	color = "#792f27"
-	},
-/obj/machinery/light/small/directional/west,
-/obj/item/pestle,
-/obj/structure/large_mortar,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
-"Nw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_overseer";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 7;
+	pixel_x = -1
 	},
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Nz" = (
-/obj/structure/chair/sofa/brown/left/directional/south,
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "NH" = (
 /obj/machinery/shower{
 	dir = 1
@@ -4035,9 +3494,9 @@
 	name = "shower chair";
 	desc = "Welcome to the shower"
 	},
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
+/area/space)
 "Ob" = (
 /obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
 	dir = 8
@@ -4054,127 +3513,86 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "Of" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer5,
-/obj/effect/turf_decal/techfloor/orange{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	req_access = list(11);
+	name = "Engineering"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor/orange{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"Oo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge";
+/obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ship/bridge)
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Oq" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
+/obj/effect/turf_decal/corner/opaque/purple,
+/turf/open/floor/plasteel,
+/area/space)
+"Ot" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/folder/solgov{
-	pixel_x = 4
-	},
-/obj/item/pen/solgov{
-	pixel_x = 2
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"OU" = (
-/obj/item/clothing/neck/cloak/overseer,
-/obj/item/clothing/suit/armor/vest/solgov/overseer,
-/obj/structure/closet/secure_closet/head_of_personnel{
-	anchored = 1;
-	name = "\proper overseer's locker";
-	populate = 0
-	},
-/obj/item/clothing/gloves/combat,
-/obj/item/folder/solgov,
-/obj/item/folder/solgov,
-/obj/item/folder/documents/solgov,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/head/solgov,
-/obj/item/storage/belt/sabre/solgov,
-/obj/item/storage/backpack,
-/obj/item/pen/solgov,
-/obj/item/clothing/under/solgov/dress,
-/obj/item/stamp/solgov,
-/obj/machinery/light/directional/south,
-/obj/item/clothing/suit/armor/solgov_trenchcoat,
 /turf/open/floor/carpet/royalblue,
-/area/ship/crew/crewtwo)
+/area/space)
 "OX" = (
-/obj/structure/noticeboard/captain{
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"OZ" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Pa" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"Pb" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	pixel_y = 9;
-	pixel_x = 6;
-	id = "sgc_bridge";
-	name = "bridge window lockdown"
-	},
-/obj/item/reagent_containers/glass/maunamug{
-	pixel_x = -3
-	},
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Pb" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/light/directional/north,
 /turf/open/floor/engine/o2,
-/area/ship/engineering/engine)
-"Pc" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/space)
 "Pf" = (
 /obj/effect/turf_decal/industrial/warning/dust/corner{
 	dir = 8
@@ -4186,7 +3604,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/ship/external)
+/area/space)
 "Pk" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -4201,12 +3619,8 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "Pm" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners,
 /obj/structure/closet/crate/wooden,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
@@ -4217,190 +3631,180 @@
 /obj/item/paper_bin/bundlenatural,
 /obj/item/paper_bin/bundlenatural,
 /obj/item/paper_bin/bundlenatural,
-/obj/machinery/light/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/clipboard,
 /obj/item/clipboard,
 /obj/item/clipboard,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "Pq" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/autolathe,
-/obj/structure/sign/poster/solgov/random{
-	pixel_x = 28
+/obj/structure/AIcore,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "AI Core Access";
+	req_one_access_txt = "16";
+	color = "#2d2a4e"
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/item/mmi/posibrain,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/rglass,
+/obj/item/circuitboard/aicore,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "PT" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor{
-	dir = 4;
-	id = "sgc_engi"
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Bridge"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "PY" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"Qi" = (
-/obj/item/radio/intercom/wideband/table,
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Qk" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"Qm" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"Qy" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/t_scanner{
-	pixel_x = -6
-	},
-/obj/item/t_scanner{
-	pixel_x = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
-"QA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"QM" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/fluff/hedge/opaque,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"Rb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	req_access = list(11);
-	name = "Engine Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"Rw" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"RC" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/area/space)
+"Qa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/railing,
+/turf/open/floor/plasteel,
+/area/space)
+"Qk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"Ql" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/o2,
+/area/space)
+"Qm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/space)
+"Qy" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"QM" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"Rb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "HOP_Chronicle";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/space)
+"Rm" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Rs" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"RC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"RL" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"RL" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -4424,27 +3828,28 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"RV" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
+/turf/open/floor/plasteel/tech,
+/area/space)
 "RX" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
-/obj/machinery/newscaster/directional/north,
 /obj/structure/sink{
 	pixel_y = 20;
 	pixel_x = -15;
 	layer = 2.79
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Sd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4452,127 +3857,88 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
-"Sg" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 1
 	},
-/obj/structure/chair/office{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/space)
+"Sn" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"So" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
-"Sv" = (
-/obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
+/obj/item/kirbyplants{
+	icon_state = "plant-28";
 	pixel_y = 3;
+	layer = 4.3;
 	pixel_x = -4
 	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = 10
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"So" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/space)
+"Sv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
+/area/space)
 "SA" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/engineering_personal{
-	name = "ship engineer's locker";
-	populate = 0
-	},
-/obj/item/storage/backpack/industrial,
-/obj/effect/turf_decal/industrial/outline/orange,
-/obj/item/clothing/head/hardhat/solgov,
-/obj/item/folder/solgov,
-/obj/item/clipboard,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/accessory/armband/engine,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding,
-/obj/item/pen/solgov,
-/obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
-"SH" = (
-/obj/machinery/cryopod,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/computer/mech_bay_power_console,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 5
 	},
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
+/obj/machinery/light/colored/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/ship/crew/dorm)
+/obj/structure/sign/poster/bay/bay_2{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"SH" = (
+/obj/machinery/cryopod,
+/turf/open/floor/wood/ebony,
+/area/space)
 "SJ" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	network = "SolNet";
-	id = "Receiver"
+/obj/effect/turf_decal/solarpanel,
+/turf/open/floor/plating,
+/area/space)
+"SM" = (
+/obj/structure/chair/plastic{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/westright{
-	dir = 4;
-	req_one_access = list(61,11)
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/circuit/green,
-/area/ship/engineering)
-"SL" = (
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/folder/solgov{
-	pixel_x = 4
-	},
-/obj/item/pen/solgov{
-	pixel_x = 2
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/table/wood/fancy/blue,
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
+/turf/open/floor/wood/ebony,
+/area/space)
 "SQ" = (
 /obj/effect/turf_decal/solgov/bottom_center,
 /obj/structure/cable{
@@ -4580,11 +3946,43 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "ST" = (
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey,
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"SZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/turf/open/floor/plasteel,
+/area/space)
 "Td" = (
 /obj/effect/turf_decal/solgov/top,
 /obj/structure/cable{
@@ -4596,28 +3994,73 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "Tk" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/platform/military{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/white,
-/area/ship/engineering)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack/dark,
+/area/space)
+"Tn" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
 "Tr" = (
 /obj/effect/turf_decal/techfloor/corner,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/closet/cabinet{
-	name = "ammunition"
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/storage/box/ammo/c556mm_ap{
+	pixel_y = 4;
+	pixel_x = 8
 	},
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/storage/box/ammo/c556mm_ap{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/item/storage/box/ammo/c556mm_ap{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/item/storage/box/ammo/c556mm_ap{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/item/storage/box/ammo/c556mm_ap{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/item/storage/box/ammo/ferropellet/hc{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/ferropellet/hc{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/ferropellet/hc{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/storage/box/ammo/ferropellet/hc{
+	pixel_y = 4;
+	pixel_x = -8
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
+/area/space)
 "TA" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
@@ -4636,17 +4079,18 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/space)
 "TE" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/engine/n2,
-/area/ship/engineering/engine)
+/obj/structure/closet/wall/orange/directional/east,
+/obj/item/stack/sheet/mineral/plasma/ten,
+/turf/open/floor/engine/o2,
+/area/space)
 "TH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4655,34 +4099,39 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "TN" = (
-/obj/structure/mirror{
-	pixel_y = 26
+/obj/item/clothing/suit/armor/vest/solgov/captain,
+/obj/item/clothing/under/solgov/formal/captain,
+/obj/item/clothing/gloves/combat,
+/obj/item/door_remote/captain,
+/obj/item/storage/belt/sabre/solgov,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/folder/documents/solgov,
+/obj/item/pen/fountain/solgov,
+/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/clothing/neck/cloak/solgovcap,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/storage/box/ammo/ferroslug,
+/obj/item/clothing/head/beret/solgov,
+/obj/item/radio/headset/solgov/alt/captain,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/solgov_trenchcoat{
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	},
-/obj/structure/sink{
-	pixel_y = 19
+/obj/item/clothing/shoes/combat,
+/obj/item/sharpener,
+/obj/structure/closet/wall/blue/directional/west,
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/item/binoculars{
+	pixel_y = 7
 	},
-/obj/structure/urinal{
-	dir = 4;
-	pixel_x = -32
-	},
-/obj/machinery/button/door{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = -9;
-	id = "sgc_piss";
-	specialfunctions = 3;
-	name = "bathroom lock"
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
-"TV" = (
-/obj/item/radio/intercom/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/turf/open/floor/plasteel/tech,
+/area/space)
 "Ue" = (
 /obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4692,60 +4141,96 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "Uh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 10
 	},
-/turf/open/floor/wood,
-/area/ship/crew)
+/turf/open/floor/wood/ebony,
+/area/space)
 "Ut" = (
 /obj/effect/turf_decal/solgov/top_right,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/machinery/light/colored/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ship/cargo)
-"UB" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 5
+/area/space)
+"Ux" = (
+/obj/effect/turf_decal/corner/opaque/purple/three_quarters{
+	dir = 4
 	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/structure/flora/bigplant{
+	pixel_y = 1;
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"UB" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/poster/solgov/random{
 	pixel_x = -28
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew)
-"UD" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
+	dir = 9
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"UH" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/structure/chair/office{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
+"UJ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "chronicle_bridge";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"UM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"UJ" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
+/area/space)
 "UQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4753,17 +4238,35 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/landmark/start/captain,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"US" = (
-/obj/structure/table/wood,
-/obj/item/desk_flag/solgov{
-	pixel_y = 2;
-	pixel_x = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/carpet/blue,
-/area/ship/crew)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/purple,
+/area/space)
+"US" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table,
+/obj/item/kirbyplants/photosynthetic{
+	icon_state = "plant-06";
+	pixel_y = 14
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"UT" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "Vg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -4776,192 +4279,261 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/security/armory)
+/area/space)
 "Vi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/engineering)
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Vm" = (
-/obj/structure/chair/wood{
+/obj/item/radio/intercom/directional/west,
+/obj/structure/chair/plastic{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood,
-/area/ship/crew)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 9
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
 "Vo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
-/area/ship/crew/dorm)
-"Vy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/area/space)
+"VF" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/solar_assembly,
+/turf/open/floor/plating,
+/area/space)
+"VM" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/corner/opaque/solgovgold/half,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Wn" = (
+/obj/machinery/light_switch{
+	pixel_x = 20;
+	dir = 8;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/cigarette/robustgold{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/storage/ashtray{
+	pixel_y = 9;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_y = -3;
+	pixel_x = 21;
+	id = "chronicle_engine"
+	},
+/turf/open/floor/engine/o2,
+/area/space)
+"Wo" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#2d2a4e"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
+	},
+/obj/item/clothing/suit/space/hardsuit/solgov{
+	slowdown = 0.1;
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
+	name = "lightweight SolFed hardsuit";
+	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/tech/grid,
+/area/space)
+"WG" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad/secure,
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"VM" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
-"VR" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "External Atmosphere to Waste"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/orange,
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"Wn" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 8;
-	name = "Waste To External Atmosphere"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor/orange,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"Wo" = (
-/obj/machinery/suit_storage_unit/solgov,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/techfloor/corner,
-/obj/structure/window/reinforced{
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
+/turf/open/floor/plasteel,
+/area/space)
+"WI" = (
+/obj/structure/sign/flag/solfed/directional/south,
+/turf/open/floor/wood/ebony,
+/area/space)
 "WM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+/obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering/engine)
-"WX" = (
-/obj/machinery/suit_storage_unit/solgov,
-/obj/machinery/light/directional/south,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/security/armory)
-"WY" = (
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 9
-	},
-/obj/structure/bookcase/random,
-/turf/open/floor/wood/walnut,
-/area/ship/crew/crewtwo)
-"Xa" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	color = "#543C30"
-	},
-/obj/structure/railing/corner/wood{
-	color = "#543C30"
+/obj/machinery/door/poddoor{
+	id = "chronicle_engine";
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/o2,
+/area/space)
+"WQ" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	network = "SolNet";
+	id = "Receiver"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11);
+	color = "#2d2a4e"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/space)
+"WX" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/structure/window/reinforced{
+	dir = 8;
+	color = "#2d2a4e"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	color = "#2d2a4e"
+	},
+/obj/item/clothing/suit/space/hardsuit/solgov{
+	slowdown = 0.1;
+	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
+	name = "lightweight SolFed hardsuit";
+	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/tech/grid,
+/area/space)
+"Xa" = (
+/obj/structure/sign/poster/solgov/paperwork{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"Xe" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/firealarm/directional/west{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -15
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	icon_state = "pipe11-4";
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Xg" = (
 /obj/effect/turf_decal/solgov/bottom_left,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
-"Xi" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/ship/bridge)
+/area/space)
 "Xj" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering)
+/obj/effect/turf_decal/rechargefloor,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
+	},
+/obj/structure/mecha_wreckage/durand/zeus,
+/turf/open/floor/plasteel/strongdark,
+/area/space)
 "Xm" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/space)
+"Xn" = (
+/obj/effect/turf_decal/corner/opaque/purple/half,
+/obj/structure/table/glass,
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_y = -32
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/light/colored/purple,
+/turf/open/floor/carpet/purple,
+/area/space)
 "Xu" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer5,
-/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
-	dir = 4
+/obj/effect/turf_decal/techfloor{
+	dir = 6
 	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/outline/orange,
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
+/turf/closed/wall/mineral/titanium,
+/area/space)
 "Xv" = (
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sgc_cargo"
+	id = "chronicle_cargo"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4970,104 +4542,89 @@
 	id = "sgc_cs"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/space)
 "Xy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 4
+/obj/structure/sign/solgov_flag{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+/obj/effect/turf_decal/corner/opaque/purple/mono,
+/obj/machinery/rnd/server,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plasteel,
+/area/space)
+"XG" = (
+/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/techfloor/orange,
-/obj/effect/turf_decal/techfloor/orange{
-	dir = 1
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/ebony,
+/area/space)
+"XW" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin{
+	pixel_y = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/sign/poster/bay/bay_15{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/ebony,
+/area/space)
+"Yh" = (
+/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = -10
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/engineering/engine)
-"XA" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/security/armory)
-"XE" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/ship/bridge)
-"XG" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
-	},
-/turf/open/floor/wood,
-/area/ship/crew)
-"Yo" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/engine/n2,
-/area/ship/engineering/engine)
-"Yr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge";
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+/obj/item/solar_assembly,
 /turf/open/floor/plating,
-/area/ship/bridge)
+/area/space)
 "YC" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/photocopier,
+/turf/open/floor/wood/ebony,
+/area/space)
+"YK" = (
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/grey{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/carpet/red,
+/area/space)
+"YY" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"Za" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 8;
-	pixel_y = -22
+/obj/effect/turf_decal/corner/opaque/purple/half{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"Zd" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/spline/fancy/wood,
-/obj/machinery/light/small/directional/south,
-/obj/item/paper/crumpled,
-/obj/item/pen/solgov{
-	pixel_x = -5
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/carpet/purple,
+/area/space)
 "Zh" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
@@ -5082,48 +4639,46 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/ship/security/armory)
+/area/space)
 "Zm" = (
-/obj/effect/turf_decal/industrial/warning{
+/obj/machinery/light/directional/east{
+	dir = 8;
+	pixel_x = 2
+	},
+/turf/closed/wall/mineral/titanium,
+/area/space)
+"Zr" = (
+/obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
+/obj/structure/sign/poster/bay/bay_48{
+	pixel_x = 32
 	},
-/obj/machinery/door/airlock{
-	dir = 4;
-	name = "Bathroom";
-	id_tag = "sgc_piss"
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/item/storage/belt/utility/full{
+	pixel_x = -5;
+	pixel_y = -4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/item/weldingtool/electric{
+	pixel_x = -4;
+	pixel_y = -1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew)
+/turf/open/floor/plasteel,
+/area/space)
 "Zt" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
+/obj/effect/turf_decal/corner/opaque/solgovgold/half{
 	dir = 1
 	},
-/obj/structure/closet/crate/medical,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/rxglasses,
-/obj/structure/sign/poster/solgov/random{
-	pixel_y = 30
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/structure/sign/poster/solgov/solgov_enlist{
+	pixel_y = 32
 	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/medical,
-/obj/item/storage/pill_bottle/charcoal,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/turf/open/floor/plasteel,
+/area/space)
 "Zx" = (
 /obj/effect/turf_decal/solgov,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -5137,550 +4692,517 @@
 	pixel_y = 22;
 	pixel_x = -12
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/ship/cargo)
+/area/space)
 "ZC" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/table/wood,
-/obj/item/radio/intercom/wideband/table{
-	dir = 8;
-	pixel_x = -4
+/obj/effect/turf_decal/corner/opaque/purple/half{
+	dir = 1
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/bridge)
-"ZE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/machinery/door/poddoor{
-	id = "sgc_bridge"
+/obj/machinery/computer/rdconsole/core,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/item/research_notes/loot/medium,
+/obj/structure/sign/poster/solgov/terra{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/ship/bridge)
-"ZP" = (
-/obj/effect/turf_decal/industrial/warning{
+/turf/open/floor/plasteel,
+/area/space)
+"ZN" = (
+/obj/effect/turf_decal/corner/opaque/purple/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/obj/machinery/door/poddoor{
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch{
 	dir = 4;
-	id = "sgc_airlock2"
+	pixel_x = -22;
+	pixel_y = -11
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/turf/open/floor/plasteel,
+/area/space)
+"ZP" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/colored/orange{
+	dir = 1
+	},
+/turf/open/floor/engine/o2,
+/area/space)
 
 (1,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-AN
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+dz
+un
 wt
-bu
+wt
+un
 ve
-ve
-bu
-hh
-AN
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (2,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-AN
-AN
-WM
-zh
-zh
-zh
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+xF
+ip
 zh
 WM
-AN
-AN
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+WM
+WM
+WM
+UM
+ip
+vd
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (3,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-AN
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ja
+yu
 ng
-eU
+Ql
+Lc
+ng
 Bn
-Bn
-Bn
-Bn
-Xy
-Yo
-AN
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+xt
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (4,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-AN
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ZP
+ty
 Pb
-zq
+go
 Ad
 sS
-sS
+iA
 Cb
-lA
-Ex
-AN
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (5,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-KZ
-KZ
-GH
+rD
+rD
+rD
+rD
+rD
+rD
 AN
-Bz
+AN
+rD
+ip
+GH
+TE
+HT
 Wn
 sM
-yw
+Cw
 oY
 fW
-VR
-TE
+ip
+rD
 AN
-pS
-KZ
-KZ
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+AN
+rD
+rD
+rD
+rD
+rD
 "}
 (6,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-gK
-pS
-AN
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+nD
+rD
+ip
+tJ
+Ds
 jz
-fj
-fw
+jz
+ip
 Of
 Xu
-ID
-xf
-jz
-AN
-pS
-gK
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+tJ
+ip
+rD
+nD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (7,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-KZ
-pS
-gK
-pS
-pS
+rD
+rD
+rD
+rD
+rD
 AN
+rD
+pS
+rD
+rD
+ip
+WQ
+TN
+ws
+ip
+UH
+Xe
+ip
+rD
+rD
+Yh
+rD
 AN
-AN
-jz
-LB
-aA
-MH
-AN
-pS
-pS
-gK
-pS
-KZ
-pS
-pS
-pS
-pS
-pS
-pS
+rD
+rD
+rD
+rD
 "}
 (8,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-KZ
-gK
-gK
-pS
-Xm
-So
-AV
-SJ
-Xm
-Gv
-kI
-Nb
+rD
+rD
+rD
+rD
+rD
 AN
-pS
-pS
-gK
-gK
-KZ
-pS
-pS
-pS
-pS
-pS
-pS
+Pa
+do
+rD
+ip
+tJ
+uA
+LB
+mX
+ip
+aA
+Gv
+ip
+rD
+rD
+VF
+Tn
+AN
+rD
+rD
+rD
+rD
 "}
 (9,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-KZ
-pS
+rD
+rD
+rD
+rD
+rD
+AN
+rD
+ub
+Rs
+HP
 gK
-gK
-Xm
+bu
 oH
-Gw
-ke
-So
-Xm
-So
-Rb
-So
-Xm
-gK
-gK
-pS
-KZ
-pS
-pS
-pS
-pS
-pS
-pS
+ka
+ip
+Cf
+nP
+tJ
+ip
+SJ
+pe
+rD
+AN
+rD
+rD
+rD
+rD
 "}
 (10,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-gK
-pS
-Xm
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ta
+rD
+ip
+kI
+ac
 IH
 Tk
 aU
 gZ
 ah
 ya
-uD
-lZ
-Xm
-pS
-gK
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
+rD
+Yh
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (11,1,1) = {"
-pS
-pS
-pS
-pS
-KZ
-pS
-pS
-gK
-pS
-Xm
+rD
+rD
+rD
+rD
+AN
+rD
+As
+rH
+rD
+ip
+JN
+xu
 kz
 Ax
 Ii
 JH
 fT
 Cs
-cT
-jS
-Xm
-pS
-gK
-pS
-pS
-KZ
-pS
-pS
-pS
-pS
-pS
+ip
+vj
+av
+Gs
+rD
+AN
+rD
+rD
+rD
 "}
 (12,1,1) = {"
-pS
-pS
-pS
-pS
-KZ
-gK
-gK
-vx
-vx
+rD
+rD
+rD
+rD
+AN
+pF
+rH
+ip
+ip
+ip
+rw
 Xm
 bs
 kT
 mz
-sa
+JH
 RC
 Qy
-JN
+ip
 ME
-Xm
-pS
-Fh
-gK
-gK
-KZ
-pS
-pS
-pS
-pS
-pS
+ip
+ge
+Tn
+AN
+rD
+rD
+rD
 "}
 (13,1,1) = {"
-pS
-pS
-pS
-pS
-KZ
-pS
-vx
+rD
+rD
+rD
+rD
+AN
+rD
+ip
 tJ
-RV
-Xm
+vx
+ip
+ip
+hS
 So
 tC
 cp
-So
+Da
 Qk
 um
-zM
-PY
-Xm
-ZP
-bt
 ip
-pS
-KZ
-pS
-pS
-pS
-pS
-pS
+PY
+tJ
+ip
+rD
+AN
+rD
+rD
+rD
 "}
 (14,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-vx
-TN
-bB
-UJ
-UJ
-UJ
-UJ
-Xm
-if
-qH
-dR
-vr
-Xm
-vo
-LE
+rD
+rD
+rD
+rD
+rD
+rD
 ip
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+nU
+dG
+bB
+ip
+ip
+UJ
+UJ
+UJ
+ip
+RC
+qH
+ip
+vr
+kg
+ip
+rD
+rD
+rD
+rD
+rD
 "}
 (15,1,1) = {"
-pS
-pS
-pS
-pS
-vx
-vx
-vx
-vx
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ip
+ip
+dR
 Zm
-UJ
+ip
 br
-TV
+gs
 Pm
-So
+ip
 PT
-PT
-Xm
+sA
+ip
 RL
-Xm
-Io
-dC
 ip
 ip
-ip
-pS
-pS
-pS
-pS
-pS
+rD
+rD
+rD
+rD
+rD
 "}
 (16,1,1) = {"
-pS
-vx
-vx
-vx
+rD
+rD
+rD
+xF
+ip
+ip
 tJ
 yj
 zv
 nH
 Uh
-UJ
+ip
 Zx
 bm
 Xg
-UJ
+ip
 Lb
-eD
+sa
 gB
 oC
-So
-jJ
-Be
+ip
+ip
+ip
 Gt
-ip
-ip
-Nw
-Id
-ip
-pS
-pS
+rD
+rD
+rD
 "}
 (17,1,1) = {"
-pS
-vx
+rD
+rD
+rD
+ip
 UB
 Ns
 Nu
@@ -5699,79 +5221,73 @@ FM
 sL
 KU
 zs
-bg
-Ky
+Rm
 ip
-eQ
-UD
-dz
-ip
-pS
-pS
+rD
+rD
+rD
 "}
 (18,1,1) = {"
-pS
-vx
+rD
+rD
+rD
+ip
 RX
 ST
 hp
 Nz
-nd
+SM
 HM
 lc
-UJ
+ip
 Ut
 fA
 zw
-UJ
-Xm
+ip
+lR
 rq
-Xm
-So
-So
+af
+qt
+UT
+oz
+Iu
 ip
-xL
-sA
-ip
-bf
-Hd
-OU
-ip
-pS
-pS
+rD
+rD
+rD
 "}
 (19,1,1) = {"
+rD
+rD
 cw
 tJ
 yY
 aB
 jd
-rZ
 mG
+YK
 yv
 dj
-UJ
+ip
 Zt
-fq
+aX
 oK
-UJ
-As
+ip
+ip
 hw
-MT
-Xm
-WY
-EF
-rw
-uA
+sF
 ip
-hx
-fe
-FC
+YY
+oz
+Iu
 ip
-pS
-pS
+ip
+rD
+rD
 "}
 (20,1,1) = {"
+rD
+rD
 JS
 Vm
 Fa
@@ -5781,737 +5297,687 @@ bd
 Ju
 fd
 cW
-UJ
+ip
 wT
-fq
+bR
 nF
-UJ
+ip
 pl
 Vi
 dd
-Xm
-aP
-In
-xI
-Zd
-sA
-CC
 ip
-ip
-ip
-pS
-pS
+tZ
+EZ
+GX
+WG
+fw
+rD
+rD
 "}
 (21,1,1) = {"
+rD
+rD
 pi
 Sv
 kp
 zu
 qz
-kN
-ja
-ja
-ja
-UJ
+tJ
+ip
+ip
+ip
+ip
 EX
 fq
 VM
-UJ
+ip
 SA
 nb
 Im
-Xm
+ip
 JQ
 Fm
 hX
-dm
-xu
-lP
-wV
-ip
-pS
-pS
-pS
+vS
+fw
+rD
+rD
 "}
 (22,1,1) = {"
+rD
+rD
 ol
 bw
 xO
 Du
 CU
-kN
+tJ
 AR
 Vo
 NH
-UJ
+ip
 zk
-fq
+SZ
 hM
-UJ
+ip
 Xj
 ma
 Ho
-So
-So
-OX
+ip
+sz
+Qa
 rO
-uW
-Kh
-pR
-cg
-MZ
-pS
-pS
-pS
+sy
+fw
+rD
+rD
 "}
 (23,1,1) = {"
-vx
+rD
+rD
+ip
 tJ
 hU
 FO
-kN
-kN
+tJ
+tJ
 LL
 Sy
 sU
-UJ
+ip
 zR
 sf
 AK
-UJ
+ip
 sd
 Pq
 DC
-av
-So
-Cm
-rD
-rD
-tV
-hs
-qe
 ip
-pS
-pS
-pS
+BQ
+OX
+Jn
+ip
+ip
+rD
+rD
 "}
 (24,1,1) = {"
-pS
-vx
+rD
+rD
+ip
+ip
 XG
 mN
 ez
 FX
 vR
 bA
-kN
-UJ
+tJ
+ip
 Xv
 cP
 ga
-Pc
-Xm
-Xm
-Xm
-Xm
-So
+tJ
+ip
+ip
+ip
+ip
+tJ
 DN
 QM
-Jn
-tV
+ip
+ip
 rD
-nW
-ip
-ip
-pS
-pS
+rD
 "}
 (25,1,1) = {"
-XA
-XA
-XA
+rD
+rD
+ip
+ip
+ip
 GP
-XA
+ip
 Au
 EC
 nj
-ja
+ip
 Pf
 ml
-ml
+fP
 ml
 wP
-pS
-pS
-pS
-rD
-Hp
-oz
-mZ
-ju
-bH
-rD
-zi
-yD
 ip
-pS
-pS
+Xy
+Ux
+ZN
+Hp
+Za
+mc
+AA
+ip
+rD
+rD
 "}
 (26,1,1) = {"
-XA
-fl
+rD
+rD
+ip
+Je
 HA
 Ep
-XA
+ip
 qg
 ie
-ja
-ja
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
+bP
 rD
-mP
+rD
+rD
+rD
+rD
+iL
+ip
+aP
+mf
+Hz
 UQ
 JJ
 ju
-nP
-rD
-kg
-QA
 ip
-pS
-pS
+rD
+rD
 "}
 (27,1,1) = {"
-XA
+rD
+rD
+ip
 id
 gs
 Gk
-XA
-ja
+ip
+ip
 yA
-ja
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
 rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+gi
+tV
 vO
 yE
 Qm
-Vy
+Xn
 Dn
 rD
-Sg
-hS
-ip
-pS
-pS
+rD
 "}
 (28,1,1) = {"
-XA
-fl
+rD
+rD
+ip
+Je
 AM
 CM
-XA
+ip
 Me
 Nm
-ja
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
+ip
 rD
-hr
-EZ
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ZC
+La
+ke
+BO
 Oq
 wW
 kl
 rD
-fz
-Cd
-ip
-pS
-pS
+rD
 "}
 (29,1,1) = {"
-XA
-CK
+rD
+rD
+ip
+tJ
 ne
 Ue
-XA
+ip
 SH
 dA
-ja
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-rD
-xM
-Ka
-KN
-rD
-rD
-rD
-iA
-YC
 ip
-pS
-pS
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+CK
+Zr
+jh
+Ka
+CF
+ip
+ip
+rD
+rD
 "}
 (30,1,1) = {"
-pS
-CK
+rD
+rD
+rD
+tJ
 Fg
 Ue
-CK
-XA
-ja
-ja
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-MC
-MC
-hA
-MC
-MC
-pS
+tJ
+ip
+ip
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ip
+ip
+ip
+fj
+ip
+ip
+rD
+rD
+rD
 "}
 (31,1,1) = {"
-XA
-CK
+rD
+rD
+ip
+tJ
 Pk
 jb
 zm
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-Jh
-yQ
-sq
-DW
-MC
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+rZ
+wi
+Bg
+ip
+ip
+rD
+rD
 "}
 (32,1,1) = {"
-XA
+rD
+rD
+ip
 ti
 Lk
 BE
 rJ
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-SL
-wU
-uK
-bx
-MC
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+XW
+wi
+hH
+MY
+Rb
+rD
+rD
 "}
 (33,1,1) = {"
-XA
+rD
+rD
+ip
 rS
 aN
 TH
 WX
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-Mx
-un
-Ds
-Rw
-MC
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+YC
+Kh
+Ot
+Sn
+Rb
+rD
+rD
 "}
 (34,1,1) = {"
-XA
+rD
+rD
+ip
 Ks
 wK
 Jd
 Wo
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+Kc
 Er
-xt
-JI
-Er
-MC
-pS
+Gi
+xN
+Rb
+rD
+rD
 "}
 (35,1,1) = {"
-XA
+rD
+rD
+ip
 Tr
 Zh
 AQ
 GT
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-Ez
-Md
-MC
-pS
-pS
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+bS
+du
+td
+kN
+ip
+rD
+rD
 "}
 (36,1,1) = {"
-XA
-CK
+rD
+rD
+ip
+tJ
 Ob
 aG
-CK
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-MC
-Er
-ty
-Xa
-Er
-MC
-MC
+tJ
+bP
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+iL
+ip
+WI
+Mo
+ip
+ip
+rD
+rD
 "}
 (37,1,1) = {"
-pS
-XA
+rD
+rD
+rD
+ip
 sx
-XA
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-uC
-ZC
-II
-Bs
-gi
-pC
-da
-uC
+ip
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+Hn
+Xa
+ip
+rD
+rD
+rD
 "}
 (38,1,1) = {"
-pS
-XA
+rD
+rD
+rD
+ip
 Vg
 Ag
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-gk
-eV
-kw
-BZ
-Kc
-Kv
-KG
-AZ
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+xL
+pD
+ip
+rD
+rD
+rD
 "}
 (39,1,1) = {"
-pS
-XA
+rD
+rD
+rD
+ip
 sE
 Az
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-Xi
-Ah
-FG
-Cf
-sz
-ac
-tQ
-Xi
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+dC
+du
+ip
+rD
+rD
+rD
 "}
 (40,1,1) = {"
-pS
-XA
+rD
+rD
+rD
+ip
 CE
 Ef
-XA
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-MC
-Er
-Hb
-aa
-tl
-Lc
-Er
-MC
+ip
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+ip
+ip
+ip
+ip
+rD
+rD
+rD
 "}
 (41,1,1) = {"
-pS
-pS
-pS
+rD
+rD
+rD
+rD
+rD
 Fl
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-uC
-OZ
-fN
-XE
-Qi
-uC
-pS
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (42,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-yu
-ZE
-nU
-Iv
-rK
-be
-pS
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}
 (43,1,1) = {"
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-pS
-yu
-Oo
-Yr
-be
-pS
-pS
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
+rD
 "}

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
@@ -1,87 +1,68 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
 "ac" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
-"af" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/computer/security/solgov{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-	},
-/obj/structure/fluff/hedge/opaque{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "ah" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 5;
-	pixel_x = -16;
-	pixel_y = -16
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "av" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-1"
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"aA" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/machinery/meter/atmos/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"aA" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering/engine)
 "aB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner,
-/turf/open/floor/carpet/red,
-/area/space)
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
 "aG" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -97,7 +78,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "aN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -109,207 +90,219 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "aP" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 32
-	},
-/obj/item/toy/plush/celadon/borbplushie{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "aU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/solgovgold{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/platform/military{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"aX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"bd" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"bd" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
+"be" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"bf" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"bg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "bm" = (
 /obj/effect/turf_decal/solgov/center_left,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "br" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/turf/open/floor/plasteel,
-/area/space)
-"bs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/chair/comfy/purple/directional/east,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"bu" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-27";
-	pixel_y = 22;
-	layer = 4.3;
-	pixel_x = -11
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"bs" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	network = "SolNet"
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	req_one_access = list(61,11)
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ship/engineering)
+"bt" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/crewtwo)
+"bu" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull,
+/area/ship/engineering/engine)
 "bw" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/button/door{
 	pixel_y = 11;
 	pixel_x = 22;
 	dir = 8;
 	name = "window shutter control";
-	id = "chronicle_dorm"
+	id = "sgc_dorm"
 	},
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 5
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
+"bx" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "bA" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
 /obj/structure/bed,
-/obj/structure/curtain/cloth/blacknormal,
-/obj/item/bedsheet/solfed,
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/item/bedsheet/solgov,
+/obj/structure/curtain/cloth,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "bB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/machinery/light/small/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 13;
+	pixel_y = -20
 	},
 /turf/open/floor/plasteel/freezer,
-/area/space)
-"bP" = (
-/obj/machinery/porta_turret/ship/solfed/heavy{
-	dir = 6;
-	id = "chronicle_turrets"
+/area/ship/crew)
+"bH" = (
+/obj/structure/closet/secure_closet/captains{
+	populate = 0;
+	anchored = 1
 	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"bR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/item/clothing/under/solgov/formal/captain,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/head/solgov/captain,
+/obj/item/folder/solgov,
+/obj/item/folder/solgov,
+/obj/item/folder/documents/solgov,
+/obj/item/folder/documents/solgov,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/backpack/captain,
+/obj/item/door_remote/captain,
+/obj/item/storage/belt/sabre/solgov,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/suit/armor/vest/solgov/captain,
+/obj/item/stamp/solgov,
+/obj/item/clothing/suit/armor/solgov_trenchcoat,
+/obj/item/spacecash/bundle/loadsamoney,
+/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/clothing/neck/cloak/solgovcap,
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/office)
+"cg" = (
+/obj/structure/chair/wood{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/turf/open/floor/plasteel,
-/area/space)
-"bS" = (
-/obj/item/storage/box/PDAs,
-/obj/item/storage/box/ids,
-/obj/item/modular_computer/tablet/preset/advanced,
-/obj/item/clothing/suit/solgov/overcoat,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solfed/formal,
-/obj/item/clothing/head/solfed/beret,
-/obj/item/clothing/gloves/combat/solfed,
-/obj/structure/closet/secure_closet/head_of_personnel{
-	anchored = 1;
-	name = "\proper bureaucrat's locker";
-	populate = 0
-	},
-/obj/item/clothing/neck/cloak/gezena{
-	desc = "dark cape of a marine scout of the Solar Federation";
-	name = "\improper dark cape"
-	},
-/obj/item/storage/belt/sabre/solgov,
-/obj/machinery/light/colored/blue{
-	dir = 1
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "cp" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/machinery/computer/message_monitor{
+	dir = 8
 	},
-/obj/item/stamp/solfed/captain{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/food/drinks/modglass/large{
-	pixel_y = 7;
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 7;
-	pixel_x = 6
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/engineering)
 "cw" = (
 /obj/docking_port/mobile{
 	port_direction = 8;
@@ -317,11 +310,11 @@
 	dir = 2
 	},
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/ship/crew)
 "cP" = (
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "chronicle_cargo"
+	id = "sgc_cargo"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -330,106 +323,129 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
-"cW" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 6
-	},
-/obj/machinery/newscaster/directional/east,
-/obj/machinery/vending/boozeomat/all_access{
-	all_items_free = 1
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"dd" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/area/ship/cargo)
+"cT" = (
+/obj/machinery/power/terminal{
 	dir = 1
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"dj" = (
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/ebony,
-/area/space)
-"do" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/solar_assembly,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/space)
-"du" = (
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"dz" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
+/area/ship/engineering)
+"cW" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/pen/solgov{
+	pixel_x = -5
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew)
+"da" = (
+/obj/machinery/computer/cargo/solgov{
 	dir = 4
 	},
-/obj/structure/sign/solgov_seal,
-/turf/open/floor/engine/hull/reinforced,
-/area/space)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"dd" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/rack,
+/obj/machinery/firealarm/directional/south,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"dj" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/sosjerky,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew)
+"dm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"dz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	pixel_y = -22;
+	pixel_x = -9;
+	id = "sgc_overseer";
+	name = "window shutter control";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "dA" = (
 /obj/machinery/computer/cryopod/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/plasteel,
+/area/ship/crew/dorm)
 "dC" = (
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov{
-	slowdown = 0.1;
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
-	name = "lightweight SolFed hardsuit";
-	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
-	},
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/wood/ebony,
-/area/space)
-"dG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/freezer,
-/area/space)
-"dR" = (
-/obj/machinery/door/airlock{
-	dir = 4;
-	name = "Bathroom";
-	id_tag = "sgc_piss"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "sgc_airlock2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
+"dR" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "ez" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
@@ -448,37 +464,123 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
-"fd" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
+/area/ship/crew/dorm)
+"eD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"eQ" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin,
+/obj/item/desk_flag/solgov{
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/obj/item/pen/solgov,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"eU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood/ebony,
-/area/space)
-"fj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = -10;
+	pixel_x = -22;
+	id = "sgc_engine"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"eV" = (
+/obj/structure/chair/office{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"fd" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew)
+"fe" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"fj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 5
+	},
+/obj/effect/turf_decal/techfloor/orange/corner{
 	dir = 8
 	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Bridge"
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"fl" = (
+/obj/structure/closet/secure_closet/miner{
+	name = "field engineer's locker";
+	populate = 0;
+	anchored = 1
+	},
+/obj/item/pickaxe/drill/jackhammer,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/hardhat/solgov,
+/obj/item/radio{
+	icon_state = "sec_radio"
+	},
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/suit/hazardvest/solgov,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/shoes/workboots,
+/obj/item/melee/knife/survival,
+/obj/item/clothing/gloves/combat,
+/obj/item/storage/backpack,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security/armory)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -489,23 +591,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"fw" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"fz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/space)
-"fw" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/cable{
-	icon_state = "0-1"
+/obj/machinery/computer/bookmanagement{
+	pixel_y = 7;
+	icon_state = "laptop";
+	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "chronicle_rnd";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "fA" = (
 /obj/effect/turf_decal/solgov/center_right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -520,46 +631,39 @@
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
-"fP" = (
-/obj/effect/turf_decal/industrial/warning/dust{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/docking_port/mobile{
-	dir = 4;
-	launch_status = 0;
-	preferred_direction = 4;
-	port_direction = 2
-	},
-/turf/open/floor/engine/hull,
-/area/space)
+/area/ship/cargo)
+"fN" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "fT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "fW" = (
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4;
-	piping_layer = 2
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
+	dir = 4
 	},
-/turf/open/floor/engine/o2,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "ga" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 1;
@@ -567,55 +671,57 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "chronicle_cargo"
+	id = "sgc_cargo"
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/tech,
-/area/space)
-"ge" = (
-/obj/effect/turf_decal/solarpanel,
+/area/ship/cargo)
+"gi" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
+	},
+/obj/structure/railing/wood{
+	color = "#543C30"
+	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
+"gk" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/item/solar_assembly,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
-/area/space)
-"gi" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
-	dir = 1
-	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/effect/turf_decal/box/white,
-/obj/machinery/light/colored/purple{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel,
-/area/space)
-"go" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/cigbutt,
-/obj/item/cigbutt{
-	pixel_y = -10;
-	pixel_x = -7
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/area/ship/bridge)
 "gs" = (
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "gB" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 9
+	},
 /obj/structure/noticeboard/staff{
 	dir = 4;
 	pixel_x = -26
@@ -623,104 +729,186 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "gK" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/obj/machinery/telecomms/bus{
-	id = "bus mainframe";
-	network = "SolNet";
-	autolinkers = list("processor7","solgov")
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/plating,
+/area/ship/external)
 "gZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/platform/military/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/techfloor{
-	dir = 10;
-	pixel_x = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/stairs{
 	dir = 1
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/area/ship/engineering)
+"hh" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 4
+	},
+/obj/structure/sign/solgov_seal{
+	pixel_y = -27
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/engineering/engine)
 "hp" = (
-/obj/structure/table,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/structure/table/wood,
+/obj/structure/railing/wood{
+	color = "#792f27"
+	},
+/obj/item/food/grown/cabbage{
+	pixel_x = 1;
+	pixel_y = -3
+	},
+/obj/item/food/grown/cabbage{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
+"hr" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/fax/solgov,
+/obj/item/desk_flag/solgov{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/machinery/button/door{
+	pixel_y = 23;
+	pixel_x = 10;
+	id = "sgc_captain";
+	name = "window shutter control"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"hs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/item/kirbyplants{
+	icon_state = "applebush";
+	pixel_y = 16;
+	pixel_x = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-11";
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -12;
+	pixel_y = 18
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "hw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/airlock/vault,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"hH" = (
-/turf/open/floor/wood/ebony,
-/area/space)
-"hM" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/machinery/light/colored/red,
-/turf/open/floor/plasteel/white,
-/area/space)
-"hS" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 8
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"hx" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-11";
+	pixel_x = -12;
+	pixel_y = 19;
+	layer = 2.89
 	},
-/obj/machinery/turretid/ship{
-	id = "chronicle_turrets";
-	pixel_x = 32;
-	pixel_y = 6
-	},
-/obj/structure/table/glass,
-/obj/machinery/light/colored/blue{
+/obj/effect/turf_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/item/radio/intercom/wideband/directional/north{
-	pixel_y = 10
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/button/door{
-	dir = 8;
-	pixel_y = -7;
-	pixel_x = 23;
-	id = "chronicle_bridge"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"hA" = (
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Bridge";
+	req_access = list(19)
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"hM" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"hS" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "hU" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06";
@@ -731,20 +919,22 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 1
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "hX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-5"
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "id" = (
 /obj/structure/closet/secure_closet/security{
 	populate = 0;
@@ -771,12 +961,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/industrial/outline/red,
-/obj/item/melee/baton/loaded{
-	pixel_x = 3;
-	pixel_y = -2
-	},
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
+/area/ship/security/armory)
 "ie" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -789,39 +975,53 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/ebony,
-/area/space)
-"ip" = (
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"iA" = (
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"if" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/engine/o2,
-/area/space)
-"iL" = (
-/obj/machinery/porta_turret/ship/solfed/heavy{
-	dir = 5;
-	id = "chronicle_turrets"
+/obj/machinery/button/door{
+	pixel_y = 22;
+	pixel_x = 9;
+	id = "sgc_engi";
+	name = "window shutter control"
 	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"ip" = (
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/ship/crew/crewtwo)
+"iA" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "ja" = (
-/obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/dorm)
 "jb" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -833,247 +1033,278 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "jd" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
+/obj/structure/table/wood,
+/obj/structure/railing/wood{
+	dir = 6;
+	color = "#792f27"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8;
-	pixel_y = -1
-	},
-/turf/open/floor/carpet/red,
-/area/space)
-"jh" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
-	dir = 4
-	},
-/obj/machinery/mecha_part_fabricator,
-/obj/effect/turf_decal/box/white,
-/obj/machinery/light/colored/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"ju" = (
-/obj/effect/turf_decal/corner/opaque/purple/half,
-/obj/structure/table/glass,
-/obj/item/food/donut/berry,
-/obj/item/food/donut/apple{
+/obj/item/food/grown/cabbage{
 	pixel_y = 4
 	},
-/obj/item/food/donut/blumpkin{
-	pixel_y = 9
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/carpet/purple,
-/area/space)
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
+"ju" = (
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/office)
 "jz" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/engine)
+"jJ" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = -8;
+	pixel_x = -22;
+	id = "sgc_airlock2";
+	req_one_access = list(20,19);
+	name = "blast door control"
 	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = 7
+	},
+/obj/machinery/light/small/directional/west{
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"jS" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "jU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/space)
-"ka" = (
+/turf/open/floor/wood,
+/area/ship/crew)
+"ke" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 11;
 	pixel_y = -16
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"ke" = (
-/turf/open/floor/carpet/purple,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "kg" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/solgov_seal{
-	pixel_y = 0;
-	pixel_x = 28
-	},
-/obj/structure/chair/handrail{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
-/area/space)
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "kl" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 8;
+	pixel_y = 5;
+	pixel_x = 4
+	},
 /obj/effect/turf_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "kp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ship/crew)
+"kw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/space)
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "kz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8;
-	pixel_y = -16
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/tech,
-/area/space)
-"kI" = (
-/obj/machinery/telecomms/server/presets/solgov{
-	autolinkers = list("solgov","sproingle");
-	network = "SolNet"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
+/obj/machinery/telecomms/hub{
+	autolinkers = list("solgov","broadcasterA","receiverA","solgovPDA","SolHub");
+	network = "SolNet";
+	id = "Solgov Hub"
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	color = "#2d2a4e"
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/area/ship/engineering)
+"kI" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering/engine)
 "kN" = (
-/obj/machinery/modular_computer/console/preset/command{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
 "kT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/structure/chair/comfy/purple/directional/east,
-/turf/open/floor/plasteel/tech,
-/area/space)
-"lc" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
-/turf/open/floor/wood/ebony,
-/area/space)
-"lJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/space)
-"lR" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"lc" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
+"lA" = (
+/obj/effect/turf_decal/atmos/nitrogen{
+	dir = 1;
+	layer = 2.04
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"lJ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 5;
-	pixel_x = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ship/crew)
+"lP" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"lZ" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/sign/warning{
+	pixel_y = 9;
+	pixel_x = -23
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "ma" = (
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"mc" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/structure/noticeboard/staff{
-	dir = 4;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"mf" = (
-/obj/structure/chair/office/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
 "ml" = (
 /obj/effect/turf_decal/industrial/warning/dust{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/space)
+/area/ship/external)
 "mz" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/item/desk_flag/solfed{
-	pixel_y = 1;
-	pixel_x = -8
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/folder/solfed{
-	pixel_x = 5
-	},
-/obj/item/pen/solgov{
-	pixel_x = 4
-	},
-/obj/item/dice/d20,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/structure/chair/office,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "mA" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -1092,17 +1323,25 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/cargo)
 "mG" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/space)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/crew)
 "mN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -1115,56 +1354,42 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
+/turf/open/floor/wood,
+/area/ship/crew)
+"mP" = (
+/obj/structure/filingcabinet/double,
+/obj/item/documents/solgov,
+/obj/effect/turf_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
-/area/space)
-"mX" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/machinery/light/colored/blue,
-/turf/open/floor/plasteel/tech,
-/area/space)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"mZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "nb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
 "nd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner,
-/turf/open/floor/carpet/red,
-/area/space)
+/obj/structure/table/wood,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "ne" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -1174,70 +1399,44 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "ng" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/structure/window/reinforced,
 /obj/effect/turf_decal/techfloor{
-	dir = 8
+	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine/o2,
-/area/space)
+/area/ship/engineering/engine)
 "nj" = (
 /obj/structure/bed,
+/obj/item/bedsheet/solgov,
+/obj/structure/curtain/cloth,
 /obj/structure/sign/solgov_flag{
 	dir = 1;
 	pixel_y = -27
 	},
-/obj/structure/curtain/cloth/blacknormal,
-/obj/item/bedsheet/solfed,
-/turf/open/floor/wood/ebony,
-/area/space)
-"nD" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "nF" = (
+/obj/structure/closet/crate/wooden,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/soap,
+/obj/item/soap,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "nH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/structure/chair/sofa/brown/right/directional/east,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "nP" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/structure/dresser,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/office)
 "nR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1253,39 +1452,67 @@
 	dir = 8
 	},
 /obj/effect/landmark/observer_start,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "nU" = (
-/obj/structure/mirror{
-	pixel_y = 26
+/obj/item/paper_bin/carbon{
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/structure/sink{
-	pixel_y = 19
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
 	},
-/obj/machinery/button/door{
-	dir = 8;
-	pixel_x = 22;
-	pixel_y = -9;
-	id = "sgc_piss";
-	specialfunctions = 3;
-	name = "bathroom lock"
+/obj/item/pen/solgov{
+	pixel_x = -4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plasteel/freezer,
-/area/space)
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"nW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
 "ol" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_dorm"
+	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "chronicle_dorm";
-	name = "Blast Shutters"
-	},
 /turf/open/floor/plating,
-/area/space)
+/area/ship/crew)
 "oz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1294,76 +1521,78 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "oC" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/sign/warning/vacuum{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"oH" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
-"oK" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/structure/sign/poster/solgov/mars{
-	pixel_y = -32
+/obj/machinery/light/small/directional/south,
+/obj/machinery/camera/autoname{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
-"oY" = (
-/obj/effect/turf_decal/techfloor{
+/area/ship/engineering)
+"oH" = (
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
 	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
-	},
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
-/turf/open/floor/engine/o2,
-/area/space)
-"pe" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11)
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/telecomms/bus{
+	id = "bus mainframe";
+	network = "SolNet";
+	autolinkers = list("processor7","solgov")
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/circuit,
+/area/ship/engineering)
+"oK" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"oY" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "pi" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_dorm"
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -1373,58 +1602,60 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "chronicle_dorm";
-	name = "Blast Shutters"
-	},
-/obj/machinery/button/door{
-	pixel_y = 11;
-	pixel_x = 22;
-	dir = 8;
-	name = "window shutter control";
-	id = "chronicle_dorm"
-	},
-/obj/machinery/button/door{
-	pixel_y = 11;
-	pixel_x = 22;
-	dir = 8;
-	name = "window shutter control";
-	id = "chronicle_dorm"
-	},
 /turf/open/floor/plating,
-/area/space)
+/area/ship/crew)
 "pl" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/rack,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/metal/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/glass/five,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"pC" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"pD" = (
-/obj/structure/sign/flag/solfed/directional/north,
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"pF" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"pR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "pS" = (
-/obj/effect/turf_decal/solarpanel,
+/turf/template_noop,
+/area/template_noop)
+"qe" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "qg" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/solgov/dress,
@@ -1435,151 +1666,154 @@
 /obj/item/radio/headset,
 /obj/item/radio,
 /obj/item/radio,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/light/small/directional/east,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov/dress,
 /obj/item/clothing/under/solgov/dress,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/ebony,
-/area/space)
-"qt" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"qz" = (
+/obj/machinery/photocopier,
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew)
+"qH" = (
+/obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"qz" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
-/turf/open/floor/wood/ebony,
-/area/space)
-"qH" = (
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -16
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/camera/autoname{
-	dir = 10
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "rq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	req_access = list(11);
+	name = "Equipment Room"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "rw" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	network = "SolNet"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "rD" = (
-/turf/template_noop,
-/area/space)
-"rH" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/office)
 "rJ" = (
+/obj/machinery/suit_storage_unit/solgov,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/suit_storage_unit/inherit,
 /obj/structure/window/reinforced{
-	dir = 8;
-	color = "#2d2a4e"
+	dir = 8
 	},
-/obj/item/clothing/suit/space/hardsuit/solgov{
-	slowdown = 0.1;
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
-	name = "lightweight SolFed hardsuit";
-	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
+/obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
-"rO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/area/ship/security/armory)
+"rK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"rO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "rS" = (
+/obj/machinery/autolathe,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/grenade/stingbang{
-	pixel_y = 6;
-	pixel_x = -8
-	},
-/obj/item/grenade/stingbang{
-	pixel_y = 6;
-	pixel_x = -8
-	},
-/obj/item/grenade/frag{
-	pixel_y = 5;
-	pixel_x = 8
-	},
-/obj/item/grenade/frag{
-	pixel_y = 5;
-	pixel_x = 8
-	},
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
+/area/ship/security/armory)
 "rZ" = (
-/obj/structure/filingcabinet/double,
-/obj/item/documents/solfed,
-/obj/machinery/light/colored/blue{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
 "sa" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8
+/obj/machinery/computer/telecomms/monitor/solgov{
+	dir = 1;
+	network = "SolNet"
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/railing,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
 "sd" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/directional/east,
-/obj/machinery/mech_bay_recharge_port{
-	icon_state = "recharge_port";
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 8
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "sf" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -1593,12 +1827,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
+"sq" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
 "sx" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -1621,50 +1869,23 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
-"sy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/machinery/button/door{
-	pixel_y = 6;
-	pixel_x = 22;
-	dir = 8;
-	name = "window shutter control";
-	id = "chronicle_rnd"
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/area/ship/security/armory)
 "sz" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
 	},
-/obj/structure/weightmachine/weightlifter,
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/railing/wood{
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "sA" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Bridge"
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/crewtwo)
 "sE" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24;
@@ -1679,12 +1900,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
-"sF" = (
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/area/ship/security/armory)
 "sL" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1694,49 +1912,30 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "sM" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 6
 	},
-/obj/machinery/computer/solar_control{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/sign/warning/incident{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/light/colored/orange{
-	dir = 4
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "sS" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "sU" = (
 /obj/machinery/shower{
 	dir = 1
@@ -1745,117 +1944,164 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/freezer,
-/area/space)
-"ta" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"td" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ship/crew/dorm)
 "ti" = (
 /obj/item/melee/duelenergy/halberd/purple,
 /obj/item/melee/duelenergy/halberd/purple,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/melee/duelenergy/halberd/purple,
+/obj/structure/closet/cabinet{
+	name = "energy halbreds"
+	},
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
-"tr" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
-/turf/open/floor/wood/ebony,
-/area/space)
-"ty" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/area/ship/security/armory)
+"tl" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/structure/railing/corner/wood{
+	color = "#543C30";
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/turf/open/floor/wood,
+/area/ship/bridge)
+"tr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/engine/o2,
-/area/space)
-"tC" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/ship/crew)
+"ty" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/machinery/computer/cargo{
-	dir = 8
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/bridge)
+"tC" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 8;
+	req_one_access = list(61,11)
+	},
+/obj/machinery/telecomms/message_server{
+	autolinkers = list("solgovPDA");
+	network = "SolNet";
+	calibrating = 0
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/circuit/red,
+/area/ship/engineering)
 "tJ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/space)
+/area/ship/crew)
+"tQ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/pen/solgov{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "tV" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/plasteel,
-/area/space)
-"tZ" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/office)
+"um" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/outline/orange,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"un" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"uA" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"uC" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"uD" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner{
 	dir = 1
 	},
-/obj/structure/weightmachine/stacklifter,
-/turf/open/floor/plasteel,
-/area/space)
-"ub" = (
-/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
-	icon_state = "2-4";
-	tag = null
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"uK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"um" = (
-/obj/structure/closet/secure_closet/engineering_personal{
-	name = "ship engineer's locker";
-	populate = 0
+/turf/open/floor/wood,
+/area/ship/bridge)
+"uW" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
 	},
-/obj/item/storage/backpack/industrial,
-/obj/item/folder/solgov,
-/obj/item/clipboard,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/accessory/armband/engine,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding,
-/obj/item/pen/solgov,
-/obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/sunglasses,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"un" = (
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"ve" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 4
 	},
@@ -1865,62 +2111,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/engine/hull,
-/area/space)
-"uA" = (
-/obj/machinery/telecomms/processor{
-	autolinkers = list("processor7");
-	network = "SolNet";
-	id = "Processor"
-	},
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/obj/machinery/light/colored/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
-"vd" = (
-/obj/machinery/porta_turret/ship/solfed/heavy{
-	dir = 10;
-	id = "chronicle_turrets"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"ve" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/structure/sign/solgov_seal{
-	pixel_y = -27
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space)
-"vj" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating,
-/area/space)
-"vr" = (
+/area/ship/engineering/engine)
+"vo" = (
 /obj/machinery/advanced_airlock_controller{
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1928,30 +2126,39 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/structure/cable{
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
+"vr" = (
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "vx" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/newscaster/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/space)
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew)
 "vO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/rnd/production/protolathe/department/science,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/table/wood/fancy/purple,
+/obj/item/binoculars{
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "vR" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -1965,48 +2172,18 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/wood/ebony,
-/area/space)
-"vS" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table/wood,
-/obj/machinery/jukebox/boombox,
-/turf/open/floor/plasteel,
-/area/space)
-"wi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"ws" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/item/bedsheet/solfed,
-/obj/structure/bed,
-/obj/structure/curtain/cloth/blacknormal,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "wt" = (
-/obj/machinery/power/shuttle/engine/electric{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/engine/hull,
-/area/space)
+/obj/structure/sign/solgov_seal,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/engineering/engine)
 "wK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2018,7 +2195,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "wP" = (
 /obj/effect/turf_decal/industrial/warning/dust/corner{
 	dir = 1
@@ -2030,153 +2207,197 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/space)
+/area/ship/external)
 "wT" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"wU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
-"wW" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "science";
-	name = "scientist's locker";
-	req_access_txt = "7"
-	},
-/obj/item/analyzer,
-/obj/item/clothing/under/nanotrasen/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/suit/hooded/wintercoat/science,
-/obj/effect/turf_decal/box/white,
-/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
-/turf/open/floor/plasteel,
-/area/space)
-"xt" = (
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"wV" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "0-1"
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"wW" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-11";
+	pixel_x = 10;
+	layer = 2.89
 	},
-/turf/open/floor/engine/o2,
-/area/space)
-"xu" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper/crumpled,
+/obj/item/pen/fountain/solgov,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"xF" = (
-/obj/machinery/porta_turret/ship/solfed/heavy{
-	dir = 9;
-	id = "chronicle_turrets"
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"xf" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 4
 	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"xL" = (
-/obj/structure/dresser,
-/obj/item/kirbyplants/photosynthetic{
-	icon_state = "plant-01";
-	pixel_y = 15
-	},
-/obj/machinery/light/colored/blue{
+/obj/effect/turf_decal/techfloor/orange/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"xN" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/machinery/computer/secure_data/laptop{
-	dir = 4;
-	pixel_x = -5;
-	pixel_y = 4;
-	layer = 4
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/item/desk_flag/solfed{
-	pixel_y = 15;
-	pixel_x = -2
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"xt" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
 	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"xu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"xI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"xL" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Command Wing"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
+"xM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_captain";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/office)
 "xO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "ya" = (
-/obj/structure/sign/warning{
-	pixel_y = 9;
-	pixel_x = -23
-	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/machinery/autolathe/hacked,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"yj" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 9
-	},
-/obj/machinery/jukebox,
-/turf/open/floor/wood/ebony,
-/area/space)
-"yu" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_y = -10;
-	pixel_x = -22;
-	id = "sgc_engine"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/o2,
-/area/space)
-"yv" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"yj" = (
+/obj/structure/chair/sofa/brown/corner/directional/east,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
+"yu" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"yv" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
-/area/space)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/crew)
+"yw" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "yA" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -2200,78 +2421,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"yE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/purple,
-/area/space)
-"yY" = (
-/obj/structure/closet/secure_closet/freezer{
-	name = "fridge";
-	anchored = 1
-	},
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/food/meat/slab/monkey,
-/obj/item/food/meat/slab/monkey,
-/obj/item/reagent_containers/condiment/enzyme,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/space_cola{
-	pixel_y = 32;
-	pixel_x = -4
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"zh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"zk" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/machinery/light/colored/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"zm" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/machinery/recharger{
-	pixel_x = 10
-	},
-/obj/machinery/recharger{
-	pixel_x = -10
-	},
-/obj/machinery/recharger{
-	pixel_y = 6
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/tech/grid,
-/area/space)
-"zs" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/dorm)
+"yD" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -2281,11 +2433,159 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"yE" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"yQ" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-17";
+	pixel_y = 23;
+	pixel_x = -7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"yY" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/structure/railing/wood{
+	dir = 4;
+	color = "#792f27"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
+"zh" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor{
+	id = "sgc_engine";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"zi" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"zk" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/reagent_containers/condiment/saltshaker,
+/obj/item/reagent_containers/condiment/saltshaker,
+/obj/item/reagent_containers/condiment/saltshaker,
+/obj/item/reagent_containers/condiment/saltshaker,
+/obj/structure/closet/crate/secure/gear{
+	populate = 0;
+	name = "emergency sauerkraut supplies";
+	desc = "For emergency use only";
+	req_access = list(19)
+	},
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/structure/sign/warning/incident{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"zm" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security/armory)
+"zq" = (
+/obj/effect/turf_decal/atmos/oxygen{
+	layer = 2.04
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/orange,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"zs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "zu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -2299,69 +2599,49 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "zv" = (
+/obj/structure/chair/sofa/brown/directional/east,
 /obj/machinery/light/small/directional/west,
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "zw" = (
 /obj/effect/turf_decal/solgov/bottom_right,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/machinery/light/colored/red,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
+"zM" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
 "zR" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "Ad" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 9
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/item/cigbutt{
-	pixel_x = 10;
-	pixel_y = -3
-	},
-/obj/item/cigbutt{
-	pixel_x = -12;
-	pixel_y = -9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
 "Ag" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -2375,21 +2655,46 @@
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/security/armory)
+"Ah" = (
+/obj/structure/railing/corner/wood{
+	color = "#543C30"
+	},
+/obj/machinery/computer/helm/solgov{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "As" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "2-4";
-	tag = null
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+/obj/structure/closet/secure_closet/engineering_personal{
+	name = "ship engineer's locker";
+	populate = 0
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/obj/item/storage/backpack/industrial,
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/item/clothing/head/hardhat/solgov,
+/obj/item/folder/solgov,
+/obj/item/clipboard,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding,
+/obj/item/pen/solgov,
+/obj/item/clothing/suit/hazardvest/solgov,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/gloves/combat,
+/obj/machinery/light/directional/west,
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "Au" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/suit/solgov/dress,
@@ -2415,14 +2720,15 @@
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "Ax" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "Az" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
 	dir = 4
@@ -2432,27 +2738,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/space)
-"AA" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "science";
-	name = "scientist's locker";
-	req_access_txt = "7"
-	},
-/obj/item/analyzer,
-/obj/item/clothing/under/nanotrasen/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/suit/hooded/wintercoat/science,
-/obj/effect/turf_decal/corner/opaque/purple/half,
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/corner/opaque/purple/three_quarters{
-	dir = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/hud/diagnostic/sunglasses,
-/turf/open/floor/plasteel,
-/area/space)
+/area/ship/security/armory)
 "AK" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -2464,7 +2750,7 @@
 	dir = 1;
 	pixel_y = -22;
 	pixel_x = 8;
-	id = "chronicle_cargo";
+	id = "sgc_cargo";
 	name = "blast door control"
 	},
 /obj/machinery/button/shieldwallgen{
@@ -2473,12 +2759,8 @@
 	pixel_x = -2;
 	id = "sgc_cs"
 	},
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "AM" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
@@ -2486,19 +2768,19 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "AN" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/space)
+/turf/closed/wall/mineral/titanium,
+/area/ship/engineering/engine)
 "AQ" = (
 /obj/effect/turf_decal/techfloor/corner,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "AR" = (
 /obj/structure/mirror{
 	pixel_y = 24
@@ -2507,124 +2789,199 @@
 	pixel_y = 19
 	},
 /turf/open/floor/plasteel/freezer,
-/area/space)
-"Bg" = (
-/obj/structure/closet/crate/bin,
-/obj/structure/sign/poster/bay/bay_20{
-	pixel_x = -32
+/area/ship/crew/dorm)
+"AV" = (
+/obj/machinery/telecomms/processor{
+	autolinkers = list("processor7");
+	network = "SolNet";
+	id = "Processor"
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"Bn" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/light_switch{
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/westleft{
 	dir = 4;
-	pixel_x = -20;
-	pixel_y = -10
+	req_one_access = list(61,11)
 	},
-/obj/machinery/power/terminal,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/circuit/green,
+/area/ship/engineering)
+"AZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Be" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Bn" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Bs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Bz" = (
 /obj/effect/turf_decal/techfloor{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2,
 /turf/open/floor/engine/o2,
-/area/space)
+/area/ship/engineering/engine)
 "BE" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
-"BO" = (
+/area/ship/security/armory)
+"BZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Cb" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering/engine)
+"Cd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Cf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/carpet/purple,
-/area/space)
-"BQ" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 8
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Cm" = (
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Captain's Quarters";
+	req_access = list(20)
 	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
-/area/space)
-"Cb" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/colored/orange,
-/turf/open/floor/engine/o2,
-/area/space)
-"Cf" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Cs" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor,
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/five,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Cw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/turf/open/floor/engine/o2,
-/area/space)
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/office)
+"Cs" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/industrial/outline/orange,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"CC" = (
+/obj/machinery/door/airlock/solgov{
+	dir = 4;
+	name = "Overseer's Quarters";
+	req_access = list(57)
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
 "CE" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
-/area/space)
-"CF" = (
-/obj/effect/turf_decal/corner/opaque/purple/three_quarters,
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/structure/sign/poster/bay/bay_49{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/area/ship/security/armory)
 "CK" = (
-/obj/machinery/rnd/production/protolathe/department/science,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel,
-/area/space)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
 "CM" = (
 /obj/effect/turf_decal/techfloor,
 /obj/structure/cable{
@@ -2638,81 +2995,86 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "CU" = (
+/obj/machinery/fax/solgov,
+/obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 6
+/turf/open/floor/wood,
+/area/ship/crew)
+"Dn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"Da" = (
-/obj/structure/platform/military{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/light/colored/blue{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Dn" = (
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "Ds" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
 	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
 "Du" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "DC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/directional/east,
-/obj/structure/rack,
-/obj/item/aiModule/supplied/freeform{
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -8
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/item/aicard,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "DN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = -12
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"DW" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 10
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "Ef" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -2732,7 +3094,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/security/armory)
 "Ep" = (
 /obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
 	dir = 1
@@ -2751,17 +3113,33 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "Er" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"Ex" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine/n2,
+/area/ship/engineering/engine)
+"Ez" = (
+/obj/structure/closet/secure_closet/wall/directional/north{
+	name = "bridge supplies"
 	},
-/obj/machinery/holopad,
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_y = 6
+	},
+/obj/item/gps{
+	gpstag = "SFSV Chronicle"
+	},
+/obj/item/pen/fountain/solgov,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "EC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2773,40 +3151,53 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
+"EF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/item/kirbyplants{
+	icon_state = "applebush";
+	pixel_y = 19;
+	pixel_x = -8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "EX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/structure/sign/warning/firingrange{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "EZ" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = 7;
+	pixel_y = 18
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_y = 11;
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "Fa" = (
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ship/crew)
 "Fg" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -2820,7 +3211,14 @@
 	pixel_x = -12
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
+"Fh" = (
+/obj/structure/sign/solgov_seal{
+	pixel_y = 0;
+	pixel_x = 28
+	},
+/turf/open/floor/plating,
+/area/ship/external)
 "Fl" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -2829,33 +3227,56 @@
 	width = 30
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Fm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"FC" = (
+/obj/structure/bed,
+/obj/item/bedsheet/solgov,
+/obj/structure/sign/solgov_flag{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/crewtwo)
+"FG" = (
+/obj/structure/railing/wood{
+	dir = 6;
+	color = "#543C30"
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "FM" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "FO" = (
+/obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -2868,13 +3289,8 @@
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line,
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "FX" = (
 /obj/structure/noticeboard/staff{
 	dir = 4;
@@ -2888,24 +3304,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood/ebony,
-/area/space)
-"Gi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/lighter/zippo/sol{
-	pixel_y = 5;
-	pixel_x = -4;
-	layer = 3.1
-	},
-/obj/item/storage/fancy/cigarettes/cigars{
-	pixel_y = 8;
-	pixel_x = 1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/dorm)
 "Gk" = (
 /obj/effect/turf_decal/techfloor,
 /obj/structure/cable{
@@ -2919,56 +3319,48 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/white,
-/area/space)
-"Gs" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/area/ship/security/armory)
 "Gt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 10;
+	pixel_x = -30
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/closet/firecloset/wall/directional/south,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/porta_turret/ship/solfed/heavy{
-	dir = 10;
-	id = "chronicle_turrets"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "Gv" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/thermomachine{
+	piping_layer = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering/engine)
+"Gw" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/sign/poster/bay/bay_52{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "GH" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
+/obj/effect/turf_decal/corner/opaque/solgovgold{
+	dir = 6
 	},
-/obj/machinery/power/ship_gravity,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "GP" = (
 /obj/machinery/door/airlock/solgov{
 	dir = 4;
@@ -2997,145 +3389,178 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ship/security/armory)
 "GT" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
-"GX" = (
+/area/ship/security/armory)
+"Hb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
 /obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 8
+	dir = 5
 	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/camera/autoname,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Hd" = (
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"Hn" = (
-/obj/structure/sign/solfed{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/bedsheet/solfed,
-/obj/structure/curtain/cloth/blacknormal,
-/obj/item/toy/plush/blahaj,
-/obj/structure/bed,
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "Ho" = (
-/obj/structure/closet/crate/cyborg,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/effect/turf_decal/techfloor,
 /obj/machinery/camera/autoname{
-	dir = 10
+	dir = 1
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "Hp" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/corner/opaque/purple/half{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/healthanalyzer/advanced,
-/obj/item/surgicaldrill/advanced,
-/obj/item/retractor/advanced{
-	pixel_y = 5
-	},
-/obj/item/scalpel/advanced{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Hz" = (
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/jetpack/oxygen,
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "HA" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "HM" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/turf/open/floor/carpet/red,
-/area/space)
-"HP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"HT" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/techfloor{
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ship/crew)
+"Id" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_overseer";
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "Ii" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 1
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
 	},
-/obj/machinery/fax/solgov,
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/plasteel/tech,
-/area/space)
-"Im" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/borg/upgrade/ai,
-/obj/item/borg/upgrade/ai,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/machinery/light/colored/blue,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Iu" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/turf/open/floor/plasteel,
-/area/space)
-"IH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"Im" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/outline/orange,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"In" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Io" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"Ja" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/crewtwo)
+"Iv" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 7
+	},
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"ID" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"IH" = (
+/obj/machinery/telecomms/server/presets/solgov{
+	autolinkers = list("solgov","sproingle");
+	network = "SolNet"
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 2;
+	req_one_access = list(61,11)
+	},
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ship/engineering)
+"II" = (
+/obj/structure/railing/wood{
+	color = "#543C30"
+	},
+/obj/structure/table/wood,
+/obj/machinery/light/directional/west,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/pen/solgov{
+	pixel_x = -5
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"Ja" = (
+/obj/structure/chair/sofa/brown/directional/south,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "Jd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -3144,126 +3569,128 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
-"Je" = (
-/obj/structure/closet/secure_closet/miner{
-	name = "field engineer's locker";
-	populate = 0;
-	anchored = 1
+/area/ship/security/armory)
+"Jh" = (
+/obj/structure/table/wood/fancy/blue,
+/obj/machinery/fax/solgov,
+/obj/item/desk_flag/solgov{
+	pixel_x = -9;
+	pixel_y = 14
 	},
-/obj/item/pickaxe/drill/jackhammer,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/under/solgov/dress,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/accessory/armband/cargo,
-/obj/item/clothing/shoes/workboots,
-/obj/item/melee/knife/survival,
-/obj/item/clothing/gloves/combat,
-/obj/item/storage/backpack,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"Jn" = (
+/obj/item/bedsheet/double/solgov{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/outline/red,
-/obj/item/clothing/glasses/meson/night,
-/turf/open/floor/plasteel/tech/grid,
-/area/space)
-"Jn" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel,
-/area/space)
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/solgov_flag{
+	dir = 4;
+	pixel_x = -27
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/office)
 "Ju" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 4
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "JH" = (
-/obj/structure/platform/military{
-	dir = 1
+/obj/machinery/computer/telecomms/server/solgov{
+	dir = 1;
+	network = "SolNet"
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"JJ" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"JI" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/carpet/purple,
-/area/space)
-"JN" = (
-/obj/machinery/telecomms/hub{
-	autolinkers = list("solgov","broadcasterA","receiverA","solgovPDA","SolHub");
-	network = "SolNet";
-	id = "Solgov Hub"
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	color = "#2d2a4e"
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/obj/structure/sign/poster/bay/bay_21{
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"JQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/obj/structure/punching_bag,
-/turf/open/floor/plasteel,
-/area/space)
-"JS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "chronicle_dorm";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/space)
-"Ka" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"JJ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/purple/half{
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"JN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"JQ" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"JS" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_dorm"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/crew)
+"Ka" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_captain";
 	dir = 4
 	},
-/turf/open/floor/carpet/purple,
-/area/space)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/office)
 "Kb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/corner/opaque/solgovgold{
+	dir = 6
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3273,28 +3700,37 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "Kc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/ebony,
-/area/space)
-"Kh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Kh" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/end,
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
 "Ks" = (
 /obj/structure/guncloset{
 	desc = "A locker that holds weapons.";
@@ -3307,55 +3743,104 @@
 	dir = 1
 	},
 /obj/item/gun/ballistic/automatic/powered/gauss/claris,
-/obj/item/gun/ballistic/automatic/powered/gauss/claris,
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
+/area/ship/security/armory)
+"Kv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"Ky" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/semki,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"KG" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"KN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_captain";
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/office)
 "KU" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8
+/obj/machinery/door/airlock/solgov,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"La" = (
-/obj/structure/chair/office/purple,
-/turf/open/floor/carpet/purple,
-/area/space)
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"KZ" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ship/external)
 "Lb" = (
 /obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "Lc" = (
-/obj/machinery/power/terminal{
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/structure/railing/wood{
+	color = "#543C30";
 	dir = 8
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/obj/item/radio/intercom/table,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
 	},
-/turf/open/floor/engine/o2,
-/area/space)
+/obj/machinery/light/small/directional/south,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "Lk" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 1
@@ -3368,63 +3853,127 @@
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "LB" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering/engine)
+"LE" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
 "LL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plasteel/freezer,
-/area/space)
+/area/ship/crew/dorm)
+"Md" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/wall/directional/south,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "Me" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
+	},
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"Mo" = (
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_y = -22;
-	pixel_x = -9;
-	id = "HOP_Chronicle"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
+/turf/open/floor/plasteel,
+/area/ship/crew/dorm)
+"Mx" = (
+/obj/structure/filingcabinet/double,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"MC" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
 "ME" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"MH" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 8;
+	piping_layer = 2
+	},
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering/engine)
+"MT" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"MZ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /obj/machinery/door/poddoor{
-	dir = 4;
-	id = "sgc_airlock2"
+	id = "sgc_bridge"
 	},
-/obj/machinery/door/airlock/external{
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
+"Nb" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2,
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters,
+/obj/effect/turf_decal/techfloor/corner{
 	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/space/basic,
-/area/space)
-"MY" = (
-/obj/structure/cable{
-	icon_state = "2-4";
-	tag = null
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/vending/coffee{
-	all_items_free = 1
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/structure/closet/firecloset/wall/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering/engine)
 "Nm" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable{
@@ -3438,49 +3987,41 @@
 	pixel_x = 11;
 	pixel_y = -16
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/plasteel,
+/area/ship/crew/dorm)
 "Ns" = (
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4";
-	tag = null
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
 "Nu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/table/wood,
+/obj/structure/railing/wood{
+	color = "#792f27"
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/pestle,
+/obj/structure/large_mortar,
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
+"Nw" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_overseer";
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7;
-	pixel_x = -1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/plating,
+/area/ship/crew/crewtwo)
 "Nz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/structure/chair/sofa/brown/left/directional/south,
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "NH" = (
 /obj/machinery/shower{
 	dir = 1
@@ -3494,9 +4035,9 @@
 	name = "shower chair";
 	desc = "Welcome to the shower"
 	},
-/obj/machinery/light/directional/west,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/freezer,
-/area/space)
+/area/ship/crew/dorm)
 "Ob" = (
 /obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
 	dir = 8
@@ -3513,86 +4054,127 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "Of" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	req_access = list(11);
-	name = "Engineering"
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer5,
+/obj/effect/turf_decal/techfloor/orange{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Oq" = (
-/obj/effect/turf_decal/corner/opaque/purple,
-/turf/open/floor/plasteel,
-/area/space)
-"Ot" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"OX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"Oo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge";
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Pa" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"Pb" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Oq" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin/carbon{
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/folder/solgov{
+	pixel_x = 4
+	},
+/obj/item/pen/solgov{
+	pixel_x = 2
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"OU" = (
+/obj/item/clothing/neck/cloak/overseer,
+/obj/item/clothing/suit/armor/vest/solgov/overseer,
+/obj/structure/closet/secure_closet/head_of_personnel{
+	anchored = 1;
+	name = "\proper overseer's locker";
+	populate = 0
+	},
+/obj/item/clothing/gloves/combat,
+/obj/item/folder/solgov,
+/obj/item/folder/solgov,
+/obj/item/folder/documents/solgov,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/head/solgov,
+/obj/item/storage/belt/sabre/solgov,
+/obj/item/storage/backpack,
+/obj/item/pen/solgov,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/stamp/solgov,
+/obj/machinery/light/directional/south,
+/obj/item/clothing/suit/armor/solgov_trenchcoat,
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/crewtwo)
+"OX" = (
+/obj/structure/noticeboard/captain{
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"OZ" = (
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	pixel_y = 9;
+	pixel_x = 6;
+	id = "sgc_bridge";
+	name = "bridge window lockdown"
+	},
+/obj/item/reagent_containers/glass/maunamug{
+	pixel_x = -3
+	},
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Pb" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine/o2,
-/area/space)
+/area/ship/engineering/engine)
+"Pc" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo)
 "Pf" = (
 /obj/effect/turf_decal/industrial/warning/dust/corner{
 	dir = 8
@@ -3604,7 +4186,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull,
-/area/space)
+/area/ship/external)
 "Pk" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -3619,8 +4201,12 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "Pm" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners,
 /obj/structure/closet/crate/wooden,
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/fancy/candle_box,
@@ -3631,180 +4217,190 @@
 /obj/item/paper_bin/bundlenatural,
 /obj/item/paper_bin/bundlenatural,
 /obj/item/paper_bin/bundlenatural,
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /obj/item/clipboard,
 /obj/item/clipboard,
 /obj/item/clipboard,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Pq" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/AIcore,
-/obj/machinery/door/window/brigdoor/westleft{
-	name = "AI Core Access";
-	req_one_access_txt = "16";
-	color = "#2d2a4e"
+/obj/machinery/autolathe,
+/obj/structure/sign/poster/solgov/random{
+	pixel_x = 28
 	},
-/obj/item/mmi/posibrain,
-/obj/item/stack/sheet/rglass,
-/obj/item/stack/sheet/rglass,
-/obj/item/stack/sheet/rglass,
-/obj/item/stack/sheet/rglass,
-/obj/item/stack/sheet/rglass,
-/obj/item/circuitboard/aicore,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 4
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
 "PT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Bridge"
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"PY" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
-"Qa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Qk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Ql" = (
-/obj/machinery/power/terminal{
-	dir = 8
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "sgc_engi"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/engine/o2,
-/area/space)
-"Qm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/space)
-"Qy" = (
-/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"PY" = (
 /obj/effect/turf_decal/techfloor,
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"QM" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"Rb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/cable{
-	icon_state = "0-1"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/shutters{
-	id = "HOP_Chronicle";
-	name = "Blast Shutters"
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/space)
-"Rm" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"Qi" = (
+/obj/item/radio/intercom/wideband/table,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"Qk" = (
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-	},
-/obj/structure/fluff/hedge/opaque{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Rs" = (
-/obj/effect/turf_decal/solarpanel,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"RC" = (
+/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"Qm" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"Qy" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/t_scanner{
+	pixel_x = -6
+	},
+/obj/item/t_scanner{
+	pixel_x = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
+"QA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"QM" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/fluff/hedge/opaque,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"Rb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	req_access = list(11);
+	name = "Engine Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"Rw" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"RC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "RL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
@@ -3828,28 +4424,27 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/engineering)
+"RV" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
 "RX" = (
+/obj/structure/table/wood,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
+/obj/machinery/newscaster/directional/north,
 /obj/structure/sink{
 	pixel_y = 20;
 	pixel_x = -15;
 	layer = 2.79
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
 "Sd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3857,88 +4452,127 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/corner/opaque/solgovgold/three_quarters{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
+"Sg" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"Sn" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-28";
-	pixel_y = 3;
-	layer = 4.3;
-	pixel_x = -4
-	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"So" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 4
-	},
-/obj/machinery/computer/helm{
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
-/area/space)
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = -12
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"So" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering)
 "Sv" = (
+/obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 1
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_y = 3;
+	pixel_x = -4
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 10
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
-/area/space)
+/area/ship/crew/dorm)
 "SA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/computer/mech_bay_power_console,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/engineering_personal{
+	name = "ship engineer's locker";
+	populate = 0
+	},
+/obj/item/storage/backpack/industrial,
+/obj/effect/turf_decal/industrial/outline/orange,
+/obj/item/clothing/head/hardhat/solgov,
+/obj/item/folder/solgov,
+/obj/item/clipboard,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/head/welding,
+/obj/item/pen/solgov,
+/obj/item/clothing/suit/hazardvest/solgov,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"SH" = (
+/obj/machinery/cryopod,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 5
 	},
-/obj/machinery/light/colored/blue{
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/dorm)
+"SJ" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	network = "SolNet";
+	id = "Receiver"
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/sign/poster/bay/bay_2{
-	pixel_y = 32
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 4;
+	req_one_access = list(61,11)
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"SH" = (
-/obj/machinery/cryopod,
-/turf/open/floor/wood/ebony,
-/area/space)
-"SJ" = (
-/obj/effect/turf_decal/solarpanel,
-/turf/open/floor/plating,
-/area/space)
-"SM" = (
-/obj/structure/chair/plastic{
-	dir = 8
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/circuit/green,
+/area/ship/engineering)
+"SL" = (
+/obj/item/paper_bin/carbon{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/folder/solgov{
+	pixel_x = 4
+	},
+/obj/item/pen/solgov{
+	pixel_x = 2
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/wood/fancy/blue,
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
 "SQ" = (
 /obj/effect/turf_decal/solgov/bottom_center,
 /obj/structure/cable{
@@ -3946,43 +4580,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "ST" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey,
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/space)
-"SZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
 "Td" = (
 /obj/effect/turf_decal/solgov/top,
 /obj/structure/cable{
@@ -3994,73 +4596,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "Tk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/platform/military{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/stairs_pack/dark,
-/area/space)
-"Tn" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/white,
+/area/ship/engineering)
 "Tr" = (
 /obj/effect/turf_decal/techfloor/corner,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
+/obj/structure/closet/cabinet{
+	name = "ammunition"
+	},
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/storage/box/ammo/c556mm_ap{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/obj/item/storage/box/ammo/c556mm_ap{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/obj/item/storage/box/ammo/c556mm_ap{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/obj/item/storage/box/ammo/c556mm_ap{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/obj/item/storage/box/ammo/c556mm_ap{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/obj/item/storage/box/ammo/ferropellet/hc{
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/storage/box/ammo/ferropellet/hc{
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/storage/box/ammo/ferropellet/hc{
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/storage/box/ammo/ferropellet/hc{
-	pixel_y = 4;
-	pixel_x = -8
-	},
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
+/area/ship/security/armory)
 "TA" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/warning{
@@ -4079,18 +4636,17 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/cargo)
 "TE" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/effect/turf_decal/techfloor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
+	dir = 1
 	},
-/obj/structure/closet/wall/orange/directional/east,
-/obj/item/stack/sheet/mineral/plasma/ten,
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/open/floor/engine/n2,
+/area/ship/engineering/engine)
 "TH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4099,39 +4655,34 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "TN" = (
-/obj/item/clothing/suit/armor/vest/solgov/captain,
-/obj/item/clothing/under/solgov/formal/captain,
-/obj/item/clothing/gloves/combat,
-/obj/item/door_remote/captain,
-/obj/item/storage/belt/sabre/solgov,
-/obj/item/clothing/under/solgov,
-/obj/item/clothing/under/solgov/dress,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/folder/documents/solgov,
-/obj/item/pen/fountain/solgov,
-/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/clothing/neck/cloak/solgovcap,
-/obj/item/storage/backpack/satchel/leather,
-/obj/item/storage/box/ammo/ferroslug,
-/obj/item/clothing/head/beret/solgov,
-/obj/item/radio/headset/solgov/alt/captain,
-/obj/item/storage/belt/military/assault,
-/obj/item/clothing/suit/armor/solgov_trenchcoat{
-	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+/obj/structure/mirror{
+	pixel_y = 26
 	},
-/obj/item/clothing/shoes/combat,
-/obj/item/sharpener,
-/obj/structure/closet/wall/blue/directional/west,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/item/binoculars{
-	pixel_y = 7
+/obj/structure/sink{
+	pixel_y = 19
 	},
-/turf/open/floor/plasteel/tech,
-/area/space)
+/obj/structure/urinal{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = -9;
+	id = "sgc_piss";
+	specialfunctions = 3;
+	name = "bathroom lock"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/freezer,
+/area/ship/crew)
+"TV" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Ue" = (
 /obj/effect/turf_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4141,96 +4692,60 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "Uh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/turf/open/floor/wood,
+/area/ship/crew)
 "Ut" = (
 /obj/effect/turf_decal/solgov/top_right,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/obj/machinery/light/colored/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Ux" = (
-/obj/effect/turf_decal/corner/opaque/purple/three_quarters{
-	dir = 4
-	},
 /obj/machinery/camera/autoname{
-	dir = 5
-	},
-/obj/structure/flora/bigplant{
-	pixel_y = 1;
-	pixel_x = -26
+	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "UB" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/poster/solgov/random{
 	pixel_x = -28
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/line{
-	dir = 9
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"UH" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
+/turf/open/floor/wood/mahogany,
+/area/ship/crew)
+"UD" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 6
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"UJ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/shuttle,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "chronicle_bridge";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
-"UM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/chair/office{
 	dir = 8
 	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"UJ" = (
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/ship/cargo)
 "UQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4238,35 +4753,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet/purple,
-/area/space)
+/obj/effect/landmark/start/captain,
+/turf/open/floor/wood,
+/area/ship/crew/office)
 "US" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/desk_flag/solgov{
+	pixel_y = 2;
+	pixel_x = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/table,
-/obj/item/kirbyplants/photosynthetic{
-	icon_state = "plant-06";
-	pixel_y = 14
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"UT" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/carpet/blue,
+/area/ship/crew)
 "Vg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -4279,261 +4776,192 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/security/armory)
 "Vi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 8
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ship/engineering)
 "Vm" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/chair/plastic{
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 9
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/ship/crew)
 "Vo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
-/area/space)
-"VF" = (
-/obj/effect/turf_decal/solarpanel,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"VM" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"Wn" = (
-/obj/machinery/light_switch{
-	pixel_x = 20;
-	dir = 8;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_y = 7;
-	pixel_x = -5
-	},
-/obj/item/clothing/mask/cigarette/robustgold{
-	pixel_y = 5;
-	pixel_x = 5
-	},
-/obj/item/storage/ashtray{
-	pixel_y = 9;
-	pixel_x = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/button/door{
-	dir = 8;
-	pixel_y = -3;
-	pixel_x = 21;
-	id = "chronicle_engine"
-	},
-/turf/open/floor/engine/o2,
-/area/space)
-"Wo" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/structure/window/reinforced{
-	dir = 8;
-	color = "#2d2a4e"
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/item/clothing/suit/space/hardsuit/solgov{
-	slowdown = 0.1;
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
-	name = "lightweight SolFed hardsuit";
-	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel/tech/grid,
-/area/space)
-"WG" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
-	dir = 1
+/area/ship/crew/dorm)
+"Vy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/comfy/red{
-	dir = 4
+/obj/machinery/holopad/secure,
+/turf/open/floor/wood,
+/area/ship/crew/office)
+"VM" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
+"VR" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 4;
+	name = "External Atmosphere to Waste"
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"WI" = (
-/obj/structure/sign/flag/solfed/directional/south,
-/turf/open/floor/wood/ebony,
-/area/space)
-"WM" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/orange,
 /obj/effect/turf_decal/techfloor/orange{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/poddoor{
-	id = "chronicle_engine";
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine/o2,
-/area/space)
-"WQ" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	network = "SolNet";
-	id = "Receiver"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_one_access = list(61,11);
-	color = "#2d2a4e"
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/space)
-"WX" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/structure/window/reinforced{
-	dir = 8;
-	color = "#2d2a4e"
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	color = "#2d2a4e"
-	},
-/obj/item/clothing/suit/space/hardsuit/solgov{
-	slowdown = 0.1;
-	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 20, "bomb" = 60, "bio" = 100, "rad" = 60, "fire" = 90, "acid" = 75);
-	name = "lightweight SolFed hardsuit";
-	desc = "A lightly armored spaceproof suit. A powered exoskeleton keeps the suit light and mobile. This one is specially issued to SolFed Expeditionary Corps, and is designed to be even more mobile that its' twin brother."
-	},
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/sechailer,
 /turf/open/floor/plasteel/tech/grid,
-/area/space)
-"Xa" = (
-/obj/structure/sign/poster/solgov/paperwork{
-	pixel_y = -32
+/area/ship/engineering/engine)
+"Wn" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 8;
+	name = "Waste To External Atmosphere"
 	},
-/turf/open/floor/carpet/royalblue,
-/area/space)
-"Xe" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/techfloor{
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/west{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -15
+/obj/effect/turf_decal/techfloor/orange,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"Wo" = (
+/obj/machinery/suit_storage_unit/solgov,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/techfloor/corner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security/armory)
+"WM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/engineering/engine)
+"WX" = (
+/obj/machinery/suit_storage_unit/solgov,
+/obj/machinery/light/directional/south,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/security/armory)
+"WY" = (
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/walnut,
+/area/ship/crew/crewtwo)
+"Xa" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/structure/railing/corner/wood{
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	icon_state = "pipe11-4";
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plasteel/strongdark,
-/area/space)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
 "Xg" = (
 /obj/effect/turf_decal/solgov/bottom_left,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/spline/fancy/opaque/grey{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
+"Xi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
 "Xj" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/rechargefloor,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
-	},
-/obj/structure/mecha_wreckage/durand/zeus,
-/turf/open/floor/plasteel/strongdark,
-/area/space)
-"Xm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
-"Xn" = (
-/obj/effect/turf_decal/corner/opaque/purple/half,
-/obj/structure/table/glass,
-/obj/structure/sign/poster/contraband/donut_corp{
-	pixel_y = -32
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/machinery/light/colored/purple,
-/turf/open/floor/carpet/purple,
-/area/space)
-"Xu" = (
 /obj/effect/turf_decal/techfloor{
-	dir = 6
+	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering)
+"Xm" = (
 /turf/closed/wall/mineral/titanium,
-/area/space)
+/area/ship/engineering)
+"Xu" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer5,
+/obj/machinery/atmospherics/pipe/simple/orange/visible/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/outline/orange,
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
 "Xv" = (
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "chronicle_cargo"
+	id = "sgc_cargo"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -4542,89 +4970,104 @@
 	id = "sgc_cs"
 	},
 /turf/open/floor/plasteel/tech,
-/area/space)
+/area/ship/cargo)
 "Xy" = (
-/obj/structure/sign/solgov_flag{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/purple/mono,
-/obj/machinery/rnd/server,
-/obj/effect/turf_decal/box/white,
-/turf/open/floor/plasteel,
-/area/space)
-"XG" = (
-/obj/effect/turf_decal/trimline/opaque/solgovblue/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/ebony,
-/area/space)
-"XW" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin{
-	pixel_y = 6
+/obj/effect/turf_decal/techfloor/orange,
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 1
 	},
-/obj/structure/sign/poster/bay/bay_15{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/ebony,
-/area/space)
-"Yh" = (
-/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -10
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ship/engineering/engine)
+"XA" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/security/armory)
+"XE" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/space)
-"YC" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/floor/wood,
+/area/ship/bridge)
+"XG" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/photocopier,
-/turf/open/floor/wood/ebony,
-/area/space)
-"YK" = (
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/grey{
-	dir = 8
-	},
-/obj/machinery/holopad,
-/turf/open/floor/carpet/red,
-/area/space)
-"YY" = (
-/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+/turf/open/floor/wood,
+/area/ship/crew)
+"Yo" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
 	},
-/obj/structure/fluff/hedge/opaque{
-	pixel_y = 4
+/turf/open/floor/engine/n2,
+/area/ship/engineering/engine)
+"Yr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge";
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"Za" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"YC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/purple/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/carpet/purple,
-/area/space)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 8;
+	pixel_y = -22
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
+"Zd" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood,
+/obj/machinery/light/small/directional/south,
+/obj/item/paper/crumpled,
+/obj/item/pen/solgov{
+	pixel_x = -5
+	},
+/turf/open/floor/wood,
+/area/ship/crew/crewtwo)
 "Zh" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
@@ -4639,46 +5082,48 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/ship/security/armory)
 "Zm" = (
-/obj/machinery/light/directional/east{
-	dir = 8;
-	pixel_x = 2
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space)
-"Zr" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
+/obj/effect/turf_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/sign/poster/bay/bay_48{
-	pixel_x = 32
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Bathroom";
+	id_tag = "sgc_piss"
 	},
-/obj/item/storage/belt/utility/full{
-	pixel_x = -5;
-	pixel_y = -4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/weldingtool/electric{
-	pixel_x = -4;
-	pixel_y = -1
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew)
 "Zt" = (
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/half,
-/obj/structure/sign/poster/solgov/solgov_enlist{
-	pixel_y = 32
+/obj/structure/closet/crate/medical,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/rxglasses,
+/obj/structure/sign/poster/solgov/random{
+	pixel_y = 30
 	},
-/turf/open/floor/plasteel,
-/area/space)
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/medical,
+/obj/item/storage/pill_bottle/charcoal,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ship/cargo)
 "Zx" = (
 /obj/effect/turf_decal/solgov,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -4692,517 +5137,550 @@
 	pixel_y = 22;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel,
-/area/space)
+/area/ship/cargo)
 "ZC" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
-	dir = 1
+/obj/item/radio/intercom/directional/west,
+/obj/structure/table/wood,
+/obj/item/radio/intercom/wideband/table{
+	dir = 8;
+	pixel_x = -4
 	},
-/obj/machinery/computer/rdconsole/core,
-/obj/item/research_notes/loot/medium,
-/obj/item/research_notes/loot/medium,
-/obj/item/research_notes/loot/medium,
-/obj/item/research_notes/loot/medium,
-/obj/item/research_notes/loot/medium,
-/obj/structure/sign/poster/solgov/terra{
-	pixel_y = 32
+/turf/open/floor/wood/walnut,
+/area/ship/bridge)
+"ZE" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor{
+	id = "sgc_bridge"
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"ZN" = (
-/obj/effect/turf_decal/corner/opaque/purple/half{
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"ZP" = (
+/obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light_switch{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = -11
+	id = "sgc_airlock2"
 	},
-/turf/open/floor/plasteel,
-/area/space)
-"ZP" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/colored/orange{
-	dir = 1
-	},
-/turf/open/floor/engine/o2,
-/area/space)
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/crewtwo)
 
 (1,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-dz
-un
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+AN
 wt
-wt
-un
+bu
 ve
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+ve
+bu
+hh
+AN
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (2,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-xF
-ip
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+AN
+AN
+WM
+zh
+zh
+zh
 zh
 WM
-WM
-WM
-WM
-UM
-ip
-vd
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+AN
+AN
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (3,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ja
-yu
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+AN
 ng
-Ql
-Lc
-ng
+eU
 Bn
-xt
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+Bn
+Bn
+Bn
+Xy
+Yo
+AN
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (4,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ZP
-ty
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+AN
 Pb
-go
+zq
 Ad
 sS
-iA
+sS
 Cb
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+lA
+Ex
+AN
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (5,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-AN
-AN
-rD
-ip
+pS
+pS
+pS
+pS
+pS
+pS
+KZ
+KZ
 GH
-TE
-HT
+AN
+Bz
 Wn
 sM
-Cw
+yw
 oY
 fW
-ip
-rD
+VR
+TE
 AN
-AN
-rD
-rD
-rD
-rD
-rD
+pS
+KZ
+KZ
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (6,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-nD
-rD
-ip
-tJ
-Ds
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+gK
+pS
+AN
 jz
-jz
-ip
+fj
+fw
 Of
 Xu
-tJ
-ip
-rD
-nD
-rD
-rD
-rD
-rD
-rD
-rD
+ID
+xf
+jz
+AN
+pS
+gK
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (7,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-AN
-rD
 pS
-rD
-rD
-ip
-WQ
-TN
-ws
-ip
-UH
-Xe
-ip
-rD
-rD
-Yh
-rD
+pS
+pS
+pS
+pS
+KZ
+pS
+gK
+pS
+pS
 AN
-rD
-rD
-rD
-rD
+AN
+AN
+jz
+LB
+aA
+MH
+AN
+pS
+pS
+gK
+pS
+KZ
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (8,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-AN
-Pa
-do
-rD
-ip
-tJ
-uA
-LB
-mX
-ip
-aA
+pS
+pS
+pS
+pS
+pS
+KZ
+gK
+gK
+pS
+Xm
+So
+AV
+SJ
+Xm
 Gv
-ip
-rD
-rD
-VF
-Tn
+kI
+Nb
 AN
-rD
-rD
-rD
-rD
+pS
+pS
+gK
+gK
+KZ
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (9,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-AN
-rD
-ub
-Rs
-HP
+pS
+pS
+pS
+pS
+pS
+KZ
+pS
 gK
-bu
+gK
+Xm
 oH
-ka
-ip
-Cf
-nP
-tJ
-ip
-SJ
-pe
-rD
-AN
-rD
-rD
-rD
-rD
+Gw
+ke
+So
+Xm
+So
+Rb
+So
+Xm
+gK
+gK
+pS
+KZ
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (10,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ta
-rD
-ip
-kI
-ac
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+gK
+pS
+Xm
 IH
 Tk
 aU
 gZ
 ah
 ya
-ip
-rD
-Yh
-rD
-rD
-rD
-rD
-rD
-rD
+uD
+lZ
+Xm
+pS
+gK
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (11,1,1) = {"
-rD
-rD
-rD
-rD
-AN
-rD
-As
-rH
-rD
-ip
-JN
-xu
+pS
+pS
+pS
+pS
+KZ
+pS
+pS
+gK
+pS
+Xm
 kz
 Ax
 Ii
 JH
 fT
 Cs
-ip
-vj
-av
-Gs
-rD
-AN
-rD
-rD
-rD
+cT
+jS
+Xm
+pS
+gK
+pS
+pS
+KZ
+pS
+pS
+pS
+pS
+pS
 "}
 (12,1,1) = {"
-rD
-rD
-rD
-rD
-AN
-pF
-rH
-ip
-ip
-ip
-rw
+pS
+pS
+pS
+pS
+KZ
+gK
+gK
+vx
+vx
 Xm
 bs
 kT
 mz
-JH
+sa
 RC
 Qy
-ip
+JN
 ME
-ip
-ge
-Tn
-AN
-rD
-rD
-rD
+Xm
+pS
+Fh
+gK
+gK
+KZ
+pS
+pS
+pS
+pS
+pS
 "}
 (13,1,1) = {"
-rD
-rD
-rD
-rD
-AN
-rD
-ip
-tJ
+pS
+pS
+pS
+pS
+KZ
+pS
 vx
-ip
-ip
-hS
+tJ
+RV
+Xm
 So
 tC
 cp
-Da
+So
 Qk
 um
-ip
+zM
 PY
-tJ
+Xm
+ZP
+bt
 ip
-rD
-AN
-rD
-rD
-rD
+pS
+KZ
+pS
+pS
+pS
+pS
+pS
 "}
 (14,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-nU
-dG
+pS
+pS
+pS
+pS
+pS
+pS
+vx
+TN
 bB
-ip
-ip
 UJ
 UJ
 UJ
-ip
-RC
+UJ
+Xm
+if
 qH
-ip
+dR
 vr
-kg
+Xm
+vo
+LE
 ip
-rD
-rD
-rD
-rD
-rD
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 "}
 (15,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ip
-ip
-dR
+pS
+pS
+pS
+pS
+vx
+vx
+vx
+vx
 Zm
-ip
+UJ
 br
-gs
+TV
 Pm
-ip
+So
 PT
-sA
-ip
+PT
+Xm
 RL
+Xm
+Io
+dC
 ip
 ip
-rD
-rD
-rD
-rD
-rD
+ip
+pS
+pS
+pS
+pS
+pS
 "}
 (16,1,1) = {"
-rD
-rD
-rD
-xF
-ip
-ip
+pS
+vx
+vx
+vx
 tJ
 yj
 zv
 nH
 Uh
-ip
+UJ
 Zx
 bm
 Xg
-ip
+UJ
 Lb
-sa
+eD
 gB
 oC
-ip
-ip
-ip
+So
+jJ
+Be
 Gt
-rD
-rD
-rD
+ip
+ip
+Nw
+Id
+ip
+pS
+pS
 "}
 (17,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+vx
 UB
 Ns
 Nu
@@ -5221,73 +5699,79 @@ FM
 sL
 KU
 zs
-Rm
+bg
+Ky
 ip
-rD
-rD
-rD
+eQ
+UD
+dz
+ip
+pS
+pS
 "}
 (18,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+vx
 RX
 ST
 hp
 Nz
-SM
+nd
 HM
 lc
-ip
+UJ
 Ut
 fA
 zw
-ip
-lR
+UJ
+Xm
 rq
-af
-qt
-UT
-oz
-Iu
+Xm
+So
+So
 ip
-rD
-rD
-rD
+xL
+sA
+ip
+bf
+Hd
+OU
+ip
+pS
+pS
 "}
 (19,1,1) = {"
-rD
-rD
 cw
 tJ
 yY
 aB
 jd
+rZ
 mG
-YK
 yv
 dj
-ip
+UJ
 Zt
-aX
+fq
 oK
-ip
-ip
+UJ
+As
 hw
-sF
+MT
+Xm
+WY
+EF
+rw
+uA
 ip
-YY
-oz
-Iu
+hx
+fe
+FC
 ip
-ip
-rD
-rD
+pS
+pS
 "}
 (20,1,1) = {"
-rD
-rD
 JS
 Vm
 Fa
@@ -5297,687 +5781,737 @@ bd
 Ju
 fd
 cW
-ip
+UJ
 wT
-bR
+fq
 nF
-ip
+UJ
 pl
 Vi
 dd
+Xm
+aP
+In
+xI
+Zd
+sA
+CC
 ip
-tZ
-EZ
-GX
-WG
-fw
-rD
-rD
+ip
+ip
+pS
+pS
 "}
 (21,1,1) = {"
-rD
-rD
 pi
 Sv
 kp
 zu
 qz
-tJ
-ip
-ip
-ip
-ip
+kN
+ja
+ja
+ja
+UJ
 EX
 fq
 VM
-ip
+UJ
 SA
 nb
 Im
-ip
+Xm
 JQ
 Fm
 hX
-vS
-fw
-rD
-rD
+dm
+xu
+lP
+wV
+ip
+pS
+pS
+pS
 "}
 (22,1,1) = {"
-rD
-rD
 ol
 bw
 xO
 Du
 CU
-tJ
+kN
 AR
 Vo
 NH
-ip
+UJ
 zk
-SZ
+fq
 hM
-ip
+UJ
 Xj
 ma
 Ho
-ip
-sz
-Qa
+So
+So
+OX
 rO
-sy
-fw
-rD
-rD
+uW
+Kh
+pR
+cg
+MZ
+pS
+pS
+pS
 "}
 (23,1,1) = {"
-rD
-rD
-ip
+vx
 tJ
 hU
 FO
-tJ
-tJ
+kN
+kN
 LL
 Sy
 sU
-ip
+UJ
 zR
 sf
 AK
-ip
+UJ
 sd
 Pq
 DC
-ip
-BQ
-OX
-Jn
-ip
-ip
+av
+So
+Cm
 rD
 rD
+tV
+hs
+qe
+ip
+pS
+pS
+pS
 "}
 (24,1,1) = {"
-rD
-rD
-ip
-ip
+pS
+vx
 XG
 mN
 ez
 FX
 vR
 bA
-tJ
-ip
+kN
+UJ
 Xv
 cP
 ga
-tJ
-ip
-ip
-ip
-ip
-tJ
+Pc
+Xm
+Xm
+Xm
+Xm
+So
 DN
 QM
+Jn
+tV
+rD
+nW
 ip
 ip
-rD
-rD
+pS
+pS
 "}
 (25,1,1) = {"
-rD
-rD
-ip
-ip
-ip
+XA
+XA
+XA
 GP
-ip
+XA
 Au
 EC
 nj
-ip
+ja
 Pf
 ml
-fP
+ml
 ml
 wP
-ip
-Xy
-Ux
-ZN
+pS
+pS
+pS
+rD
 Hp
-Za
-mc
-AA
+oz
+mZ
+ju
+bH
+rD
+zi
+yD
 ip
-rD
-rD
+pS
+pS
 "}
 (26,1,1) = {"
-rD
-rD
-ip
-Je
+XA
+fl
 HA
 Ep
-ip
+XA
 qg
 ie
-ip
-bP
+ja
+ja
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 rD
-rD
-rD
-rD
-rD
-iL
-ip
-aP
-mf
-Hz
+mP
 UQ
 JJ
 ju
+nP
+rD
+kg
+QA
 ip
-rD
-rD
+pS
+pS
 "}
 (27,1,1) = {"
-rD
-rD
-ip
+XA
 id
 gs
 Gk
-ip
-ip
+XA
+ja
 yA
-ip
+ja
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-gi
-tV
 vO
 yE
 Qm
-Xn
+Vy
 Dn
 rD
-rD
+Sg
+hS
+ip
+pS
+pS
 "}
 (28,1,1) = {"
-rD
-rD
-ip
-Je
+XA
+fl
 AM
 CM
-ip
+XA
 Me
 Nm
-ip
+ja
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ZC
-La
-ke
-BO
+hr
+EZ
 Oq
 wW
 kl
 rD
-rD
+fz
+Cd
+ip
+pS
+pS
 "}
 (29,1,1) = {"
-rD
-rD
-ip
-tJ
+XA
+CK
 ne
 Ue
-ip
+XA
 SH
 dA
-ip
+ja
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
 rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-CK
-Zr
-jh
+xM
 Ka
-CF
-ip
-ip
+KN
 rD
 rD
+rD
+iA
+YC
+ip
+pS
+pS
 "}
 (30,1,1) = {"
-rD
-rD
-rD
-tJ
+pS
+CK
 Fg
 Ue
-tJ
-ip
-ip
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ip
-ip
-ip
-fj
-ip
-ip
-rD
-rD
-rD
+CK
+XA
+ja
+ja
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+MC
+MC
+hA
+MC
+MC
+pS
 "}
 (31,1,1) = {"
-rD
-rD
-ip
-tJ
+XA
+CK
 Pk
 jb
 zm
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-rZ
-wi
-Bg
-ip
-ip
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+Jh
+yQ
+sq
+DW
+MC
+pS
 "}
 (32,1,1) = {"
-rD
-rD
-ip
+XA
 ti
 Lk
 BE
 rJ
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-XW
-wi
-hH
-MY
-Rb
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+SL
+wU
+uK
+bx
+MC
+pS
 "}
 (33,1,1) = {"
-rD
-rD
-ip
+XA
 rS
 aN
 TH
 WX
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-YC
-Kh
-Ot
-Sn
-Rb
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+Mx
+un
+Ds
+Rw
+MC
+pS
 "}
 (34,1,1) = {"
-rD
-rD
-ip
+XA
 Ks
 wK
 Jd
 Wo
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-Kc
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
 Er
-Gi
-xN
-Rb
-rD
-rD
+xt
+JI
+Er
+MC
+pS
 "}
 (35,1,1) = {"
-rD
-rD
-ip
+XA
 Tr
 Zh
 AQ
 GT
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-bS
-du
-td
-kN
-ip
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+Ez
+Md
+MC
+pS
+pS
 "}
 (36,1,1) = {"
-rD
-rD
-ip
-tJ
+XA
+CK
 Ob
 aG
-tJ
-bP
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-iL
-ip
-WI
-Mo
-ip
-ip
-rD
-rD
+CK
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+MC
+Er
+ty
+Xa
+Er
+MC
+MC
 "}
 (37,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+XA
 sx
-ip
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-Hn
-Xa
-ip
-rD
-rD
-rD
+XA
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+uC
+ZC
+II
+Bs
+gi
+pC
+da
+uC
 "}
 (38,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+XA
 Vg
 Ag
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-xL
-pD
-ip
-rD
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+gk
+eV
+kw
+BZ
+Kc
+Kv
+KG
+AZ
 "}
 (39,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+XA
 sE
 Az
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-dC
-du
-ip
-rD
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+Xi
+Ah
+FG
+Cf
+sz
+ac
+tQ
+Xi
 "}
 (40,1,1) = {"
-rD
-rD
-rD
-ip
+pS
+XA
 CE
 Ef
-ip
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-ip
-ip
-ip
-ip
-rD
-rD
-rD
+XA
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+MC
+Er
+Hb
+aa
+tl
+Lc
+Er
+MC
 "}
 (41,1,1) = {"
-rD
-rD
-rD
-rD
-rD
+pS
+pS
+pS
 Fl
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+uC
+OZ
+fN
+XE
+Qi
+uC
+pS
 "}
 (42,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+yu
+ZE
+nU
+Iv
+rK
+be
+pS
 "}
 (43,1,1) = {"
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
-rD
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+pS
+yu
+Oo
+Yr
+be
+pS
+pS
 "}

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -144,26 +144,11 @@
 /area/ship/crew/canteen/kitchen)
 "bP" = (
 /obj/structure/table/wood,
-/obj/item/stamp/solfed/captain{
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/item/pen/solfed{
-	pixel_y = -1;
-	pixel_x = -8
-	},
-/obj/item/desk_flag/solgov{
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/obj/item/paper_bin{
-	pixel_y = 2;
-	pixel_x = 7
-	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/fax/solgov,
 /turf/open/floor/wood,
 /area/ship/bridge)
 "bQ" = (
@@ -1644,6 +1629,10 @@
 	pixel_x = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/item/desk_flag/solgov{
+	pixel_y = 15;
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "vo" = (
@@ -2518,6 +2507,10 @@
 	pixel_x = -8;
 	layer = 2.8
 	},
+/obj/item/desk_flag/solgov{
+	pixel_y = 12;
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "EH" = (
@@ -2611,6 +2604,19 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/item/stamp/solfed/captain{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/pen/solfed{
+	pixel_y = -1;
+	pixel_x = -8
+	},
 /turf/open/floor/wood,
 /area/ship/bridge)
 "FK" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -401,7 +401,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "fg" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -8
@@ -726,7 +726,7 @@
 	},
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "kF" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
@@ -907,6 +907,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "mZ" = (
@@ -1035,7 +1038,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "nE" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/maintenance/fore)
@@ -1227,14 +1230,8 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -20
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -1243,7 +1240,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "pT" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 9
@@ -1268,7 +1265,6 @@
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qc" = (
-/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
 	dir = 8
 	},
@@ -1378,7 +1374,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
-/area/ship/cargo)
+/area/ship/storage)
 "qL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1401,7 +1397,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "rf" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
 	dir = 8
@@ -1637,7 +1633,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "to" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1847,10 +1843,6 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/closet/crate/large,
@@ -2265,7 +2257,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
-/area/ship/cargo)
+/area/ship/storage)
 "zN" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -2436,7 +2428,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "BG" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
@@ -2617,7 +2609,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "Dt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -2627,7 +2619,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "DV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2996,8 +2988,9 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "HD" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
@@ -3238,7 +3231,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "Lf" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1;
@@ -3362,6 +3355,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "LX" = (
@@ -3711,7 +3705,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/hull,
-/area/ship/cargo)
+/area/ship/storage)
 "Qy" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-27";
@@ -3861,7 +3855,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/area/ship/storage)
 "Sk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -3942,6 +3936,7 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "To" = (
@@ -4240,6 +4235,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_y = 3
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -11
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
@@ -4662,6 +4668,7 @@
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
 /obj/effect/turf_decal/corner/opaque/solgovblue/half,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "Zy" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -3440,7 +3440,14 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 10
 	},
-/obj/item/radio/intercom/wideband/directional/south,
+/obj/item/radio/intercom/wideband/directional/south{
+	pixel_x = -4
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -15
+	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "PX" = (
@@ -4031,7 +4038,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "VP" = (
-/obj/item/radio/intercom/directional/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -1,33 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"ah" = (
-/obj/structure/fluff/hedge/opaque{
-	pixel_y = -1
-<<<<<<< Updated upstream
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-=======
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/obj/structure/railing/wood{
-	dir = 8
-	},
-/obj/structure/railing/wood{
-	dir = 1;
-	layer = 2
-	},
-/obj/structure/railing/wood{
-	dir = 4
->>>>>>> Stashed changes
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/wood,
-/area/ship/hallway/central)
 "ap" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -159,7 +130,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "bP" = (
 /obj/structure/table/wood,
@@ -181,11 +152,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew)
 "cg" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/traffic,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
@@ -247,21 +213,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 4
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/corner_techfloor_grid,
-/obj/effect/turf_decal/techfloor/corner,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "db" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -320,8 +279,8 @@
 /obj/effect/turf_decal/corner_techfloor_gray/full,
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/jetpack/oxygen/security,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "dK" = (
@@ -362,24 +321,6 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
-<<<<<<< Updated upstream
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblue,
-/area/ship/hallway/central)
-"ej" = (
-/obj/machinery/door/firedoor/border_only{
-=======
->>>>>>> Stashed changes
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -397,16 +338,9 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/machinery/newscaster/directional/west,
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "em" = (
 /obj/structure/toilet{
 	pixel_y = 1;
@@ -416,10 +350,6 @@
 /obj/item/newspaper{
 	pixel_x = -9
 	},
-<<<<<<< Updated upstream
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
 /obj/item/newspaper{
 	pixel_x = -9;
 	pixel_y = -5
@@ -432,7 +362,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "eo" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -606,7 +535,7 @@
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "hH" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "hR" = (
 /obj/effect/turf_decal/siding/wood{
@@ -630,31 +559,20 @@
 /turf/open/floor/wood,
 /area/ship/bridge)
 "ia" = (
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 1
 	},
+/obj/effect/turf_decal/industrial/outline/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "iD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -662,10 +580,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/outline/red,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "iH" = (
@@ -690,11 +605,7 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
-<<<<<<< Updated upstream
-/area/ship/cargo)
-=======
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "je" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
@@ -716,7 +627,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "jy" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -734,17 +645,12 @@
 /obj/machinery/light/colored{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "jP" = (
 /obj/structure/fluff/hedge/opaque{
 	pixel_y = -1
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-	},
-=======
 /obj/structure/railing/wood{
 	dir = 8
 	},
@@ -756,7 +662,6 @@
 	dir = 4
 	},
 /obj/structure/railing/wood,
->>>>>>> Stashed changes
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "ko" = (
@@ -772,28 +677,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"kp" = (
-/turf/open/floor/wood/ebony,
-=======
 /obj/structure/chair/comfy/blue/old/directional/north{
 	dir = 4;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
+/obj/effect/turf_decal/industrial/outline/yellow,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "kp" = (
@@ -808,7 +702,6 @@
 	color = "#D5A66E"
 	},
 /turf/open/floor/carpet/purple,
->>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "kr" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
@@ -822,11 +715,7 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
-<<<<<<< Updated upstream
-/area/ship/cargo)
-=======
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "kz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -835,10 +724,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-<<<<<<< Updated upstream
-=======
 /obj/effect/turf_decal/techfloor,
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kF" = (
@@ -855,27 +741,15 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "la" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 6
-	},
 /obj/structure/filingcabinet/wide{
 	dir = 8
 	},
-<<<<<<< Updated upstream
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -5
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
+	dir = 6
 	},
-/obj/item/storage/bag/trash{
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
-/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "li" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -933,6 +807,8 @@
 /obj/structure/sign/poster/bay/bay_41{
 	pixel_y = 32
 	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/jetpack/suit,
 /turf/open/floor/wood,
 /area/ship/bridge)
 "lG" = (
@@ -988,13 +864,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-/turf/open/floor/wood/ebony,
-/area/ship/crew/crewtwo)
-"mt" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/cargo)
-=======
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
 	dir = 8
@@ -1012,39 +881,32 @@
 /turf/open/floor/carpet/purple,
 /area/ship/crew/crewtwo)
 "mt" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin{
-	pixel_y = 5
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/item/stamp/solgov{
-	pixel_y = 5
-	},
-/obj/item/pen/solfed{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/machinery/light/colored{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/structure/sign/flag/solfed/directional/south,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 1
 	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "mL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/traffic,
 /obj/effect/turf_decal/industrial/stand_clear/white{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "mZ" = (
@@ -1081,8 +943,6 @@
 	color = "#543c30"
 	},
 /obj/machinery/firealarm/directional/south,
-<<<<<<< Updated upstream
-=======
 /obj/item/candle/infinite{
 	pixel_y = 2;
 	light_on = 1;
@@ -1095,20 +955,11 @@
 	light_on = 1;
 	layer = 3.1
 	},
->>>>>>> Stashed changes
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "nm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#543C30"
-<<<<<<< Updated upstream
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood/ebony,
-=======
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1127,18 +978,11 @@
 	color = "#D5A66E"
 	},
 /turf/open/floor/carpet/purple,
->>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "no" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
 	color = "#543C30"
-<<<<<<< Updated upstream
-	},
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood/ebony,
-=======
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1154,7 +998,6 @@
 	color = "#D5A66E"
 	},
 /turf/open/floor/carpet/purple,
->>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1231,14 +1074,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "nQ" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "oe" = (
 /obj/machinery/vending/cigarette,
@@ -1326,6 +1169,14 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"oW" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/desk_flag/solfed{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
 "oY" = (
 /obj/effect/turf_decal/techfloor,
 /obj/effect/decal/cleanable/dirt,
@@ -1388,6 +1239,9 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "pT" = (
@@ -1409,8 +1263,8 @@
 	},
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/jetpack/oxygen/security,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qc" = (
@@ -1424,11 +1278,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
-<<<<<<< Updated upstream
-/obj/structure/closet/crate/bin,
-=======
 /obj/structure/reagent_dispensers/fueltank,
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "qd" = (
@@ -1451,49 +1301,6 @@
 	icon_state = "sec";
 	name = "marine locker";
 	req_access_txt = "2"
-<<<<<<< Updated upstream
-	},
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/ammo_box/magazine/pistol556mm,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/glasses/sunglasses/ballistic,
-/obj/item/storage/belt/military/solfed,
-/obj/item/clothing/suit/armor/vest/marine,
-/obj/item/gun/ballistic/automatic/pistol/solgov,
-/obj/item/radio/headset/solgov/alt,
-/obj/item/clothing/under/solfed,
-/obj/item/clothing/mask/balaclava/combat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/item/encryptionkey/solgov{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/item/clothing/gloves/combat/solfed,
-/obj/item/clothing/head/solfed/beret,
-/obj/item/clothing/under/solfed/camo,
-/obj/item/melee/energy/sword/saber/knife,
-/obj/item/clothing/head/helmet/solfed/m11,
-/obj/effect/turf_decal/corner_techfloor_gray/full{
-	dir = 8
-	},
-/obj/structure/sign/flag/solfed/directional/west,
-/obj/machinery/light/colored/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/darkredfull,
-/area/ship/security/prison)
-"qq" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/closet/emcloset/wall/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-"qB" = (
-/obj/machinery/autolathe,
-=======
 	},
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
@@ -1526,6 +1333,7 @@
 	},
 /obj/item/restraints/handcuffs/tape,
 /obj/item/melee/baton/loaded,
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qq" = (
@@ -1550,7 +1358,6 @@
 /obj/machinery/autolathe,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qI" = (
@@ -1563,6 +1370,12 @@
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 1;
 	id = "tomahawk_cargo_halo"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
@@ -1584,12 +1397,9 @@
 /obj/machinery/light/colored{
 	dir = 8
 	},
-<<<<<<< Updated upstream
-=======
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "rf" = (
@@ -1606,7 +1416,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "rk" = (
 /obj/item/kirbyplants/photosynthetic{
@@ -1630,7 +1440,7 @@
 	pixel_y = -16;
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "rm" = (
 /obj/structure/closet/secure_closet{
@@ -1666,11 +1476,9 @@
 /obj/machinery/light/colored/red{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-=======
 /obj/item/restraints/handcuffs/tape,
 /obj/item/melee/baton/loaded,
->>>>>>> Stashed changes
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "rw" = (
@@ -1688,17 +1496,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew)
 "rK" = (
-<<<<<<< Updated upstream
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/machinery/light/colored{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/item/storage/belt/military/solfed,
 /obj/item/gun/ballistic/automatic/pistol/solgov,
 /obj/item/ammo_box/magazine/pistol556mm,
@@ -1713,24 +1510,20 @@
 /obj/item/melee/energy/sword/saber/knife,
 /obj/item/clothing/gloves/combat/solfed,
 /obj/structure/closet/wall/blue/directional/west,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/item/tank/jetpack/suit,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 8
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "rZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-<<<<<<< Updated upstream
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -1749,9 +1542,9 @@
 	color = "#D5A66E";
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "sb" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
@@ -1803,36 +1596,10 @@
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
-<<<<<<< Updated upstream
-"ti" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/crew/janitor)
-=======
-"tg" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/light/colored{
-	dir = 1
-	},
-/obj/structure/sign/flag/solfed/directional/south,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/law_office)
 "ti" = (
 /obj/structure/sign/solfed,
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "tl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1840,20 +1607,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-<<<<<<< Updated upstream
-/obj/structure/table/wood,
-=======
->>>>>>> Stashed changes
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/light/colored{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-=======
 /obj/structure/sign/flag/solfed/directional/south,
->>>>>>> Stashed changes
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "tn" = (
@@ -1872,6 +1632,9 @@
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -1928,7 +1691,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "uf" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -2013,27 +1776,28 @@
 /turf/open/floor/plating,
 /area/ship/crew)
 "vs" = (
-<<<<<<< Updated upstream
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/structure/table/wood/fancy/purple,
-/obj/item/desk_flag/solfed{
-	pixel_x = -7;
-	pixel_y = 4
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/stamp/solgov{
+	pixel_y = 5
+	},
+/obj/item/pen/solfed{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
+	dir = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "vE" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c"
 	},
-<<<<<<< Updated upstream
-/obj/structure/curtain/cloth,
-/obj/effect/spawner/bunk_bed,
-=======
 /obj/item/kirbyplants{
 	icon_state = "plant-27";
 	pixel_y = -2;
@@ -2045,7 +1809,6 @@
 	pixel_y = -10;
 	pixel_x = 11
 	},
->>>>>>> Stashed changes
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "vG" = (
@@ -2089,11 +1852,8 @@
 	pixel_y = 23;
 	pixel_x = 11
 	},
-<<<<<<< Updated upstream
-=======
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/closet/crate/large,
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "vL" = (
@@ -2128,11 +1888,9 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/north,
-<<<<<<< Updated upstream
-=======
 /obj/item/restraints/handcuffs/fake,
 /obj/item/melee/baton/loaded,
->>>>>>> Stashed changes
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "wf" = (
@@ -2184,24 +1942,14 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "wD" = (
-<<<<<<< Updated upstream
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/effect/turf_decal/industrial/outline/red,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "wM" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 9
@@ -2285,41 +2033,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "xp" = (
-<<<<<<< Updated upstream
-/obj/machinery/door/poddoor{
-	dir = 4;
-	id = "space_cops_starboard_launcher";
-	name = "Cargo Bay Blast Door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/ship/crew/janitor)
-"xs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	id = "bridgetohallway";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
-"xu" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E";
-	dir = 5
-=======
-/obj/structure/chair/wood{
-	dir = 8
->>>>>>> Stashed changes
-	},
-/obj/machinery/light/colored,
-/obj/structure/sign/flag/solfed/directional/north,
-/obj/effect/turf_decal/corner/transparent/solgovgold/half,
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/law_office)
 "xs" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
@@ -2349,31 +2063,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
 	color = "#543C30"
-<<<<<<< Updated upstream
-	},
-/obj/machinery/light/colored{
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"xD" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/engineering)
-"xF" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/spawner/random/maintenance/five,
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/closet/crate/trashcart,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 	},
 /obj/machinery/light/colored{
 	dir = 8
@@ -2394,7 +2083,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "xO" = (
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border{
 	dir = 4
@@ -2422,7 +2110,7 @@
 	pixel_y = 23;
 	id = "tomahawk_kitchen"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "xV" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
@@ -2500,7 +2188,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "zD" = (
 /obj/structure/cable{
@@ -2553,11 +2241,9 @@
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 5
 	},
-<<<<<<< Updated upstream
-=======
 /obj/item/restraints/handcuffs/tape,
 /obj/item/melee/baton/loaded,
->>>>>>> Stashed changes
+/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "zL" = (
@@ -2571,6 +2257,12 @@
 	dir = 4;
 	id = "tomahawk_cargo";
 	name = "Cargo Bay Blast Door"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
@@ -2625,8 +2317,26 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
+"Aj" = (
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4;
+	layer = 3
+	},
+/obj/structure/railing/wood,
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/railing/wood{
+	dir = 1;
+	layer = 2
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "Al" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 10
@@ -2793,7 +2503,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "CC" = (
 /obj/structure/cable{
@@ -2903,6 +2613,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Dt" = (
@@ -2910,12 +2623,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/techfloor{
-<<<<<<< Updated upstream
-	dir = 4
-=======
 	dir = 6
->>>>>>> Stashed changes
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "DV" = (
@@ -2995,27 +2705,15 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "ER" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 10
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-/obj/machinery/light/directional/south,
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-"EY" = (
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "EY" = (
@@ -3035,7 +2733,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Fm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1{
 	dir = 1
@@ -3276,7 +2973,6 @@
 "Hp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-<<<<<<< Updated upstream
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
@@ -3295,46 +2991,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
-"HD" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"HK" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/trashcart,
+"Hs" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/techfloor{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E";
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#D5A66E";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/carpet/royalblue,
-/area/ship/hallway/central)
+/area/ship/cargo)
 "HD" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
@@ -3350,15 +3013,14 @@
 /area/ship/hallway/central)
 "HK" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 1
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+/obj/effect/turf_decal/corner/opaque/solgovblue/half{
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Ih" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning,
@@ -3475,12 +3137,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "Jk" = (
-<<<<<<< Updated upstream
-/obj/item/kirbyplants/photosynthetic{
-	icon_state = "plant-06"
-	},
-=======
->>>>>>> Stashed changes
 /obj/effect/turf_decal/siding/wood{
 	dir = 6;
 	color = "#543C30"
@@ -3488,10 +3144,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-<<<<<<< Updated upstream
-/obj/machinery/light/colored,
-=======
->>>>>>> Stashed changes
 /obj/machinery/power/apc/auto_name/directional/east{
 	pixel_y = 9
 	},
@@ -3510,19 +3162,15 @@
 /obj/structure/sign/poster/solgov/sonnensoldner{
 	pixel_y = 32
 	},
-<<<<<<< Updated upstream
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 5
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Jv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/hallway/central)
@@ -3536,13 +3184,6 @@
 /obj/machinery/navbeacon/wayfinding/cargo{
 	name = "navigation beacon"
 	},
-<<<<<<< Updated upstream
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
@@ -3552,9 +3193,9 @@
 	color = "#D5A66E";
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "JQ" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew)
@@ -3575,7 +3216,7 @@
 /area/ship/crew)
 "Kk" = (
 /obj/effect/decal/cleanable/confetti,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "Kw" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
@@ -3613,31 +3254,19 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Li" = (
-<<<<<<< Updated upstream
-/obj/machinery/airalarm/directional/west,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/machinery/suit_storage_unit/inherit{
 	layer = 2.4
 	},
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/clothing/mask/gas/sechailer,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 9
 	},
-/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Lp" = (
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 8
@@ -3719,12 +3348,16 @@
 /turf/open/floor/wood,
 /area/ship/security/prison)
 "LN" = (
-/turf/closed/wall/mineral/plastitanium,
-<<<<<<< Updated upstream
-/area/ship/crew/janitor)
-=======
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/colored,
+/obj/structure/sign/flag/solfed/directional/north,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/obj/effect/turf_decal/industrial/outline/red,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "LO" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -3811,7 +3444,6 @@
 	},
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "MJ" = (
@@ -3855,7 +3487,7 @@
 /obj/machinery/firealarm/directional/north{
 	pixel_x = -7
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "Nk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4007,10 +3639,6 @@
 	color = "#D5A66E";
 	dir = 4
 	},
-<<<<<<< Updated upstream
-/obj/effect/decal/cleanable/dirt,
-=======
->>>>>>> Stashed changes
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -4076,6 +3704,12 @@
 	dir = 2;
 	id = "tomahawk_cargo_halo"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
 "Qy" = (
@@ -4095,7 +3729,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "Qz" = (
 /obj/structure/fans/tiny,
@@ -4107,17 +3741,10 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "QB" = (
-<<<<<<< Updated upstream
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/techfloor,
-=======
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
->>>>>>> Stashed changes
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
 "QM" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/light/small/directional/north,
@@ -4133,15 +3760,10 @@
 /obj/structure/sign/poster/contraband/cybersun_borg{
 	pixel_y = 32
 	},
-<<<<<<< Updated upstream
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/crew/janitor)
-=======
 /obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Rf" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4168,38 +3790,25 @@
 /area/ship/engineering)
 "Rx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "Rz" = (
-<<<<<<< Updated upstream
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/item/radio/intercom/directional/north{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
 /obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "RA" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 9
 	},
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/clothing/mask/gas/sechailer,
 /obj/machinery/light/colored/red{
 	dir = 8
 	},
+/obj/item/tank/jetpack/oxygen/security,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "RI" = (
@@ -4242,31 +3851,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-<<<<<<< Updated upstream
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/solgovgold/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
+"Sa" = (
+/obj/machinery/light/colored{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "Sk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -4286,22 +3881,12 @@
 	codes_txt = "patrol;next_patrol=dorms";
 	location = "cargo"
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/industrial/outline{
-	color = "#2d2a4e"
-	},
+/obj/effect/turf_decal/industrial/outline/red,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Sz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4366,8 +3951,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-<<<<<<< Updated upstream
-=======
 /obj/structure/table/wood/fancy/purple,
 /obj/machinery/computer/secure_data/laptop{
 	dir = 8;
@@ -4376,16 +3959,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
-"Tp" = (
-/obj/machinery/light/colored{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
->>>>>>> Stashed changes
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
 "Tr" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -4480,7 +4053,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "Ul" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
@@ -4489,12 +4062,9 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-=======
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "UD" = (
@@ -4518,7 +4088,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "UF" = (
 /obj/structure/cable{
@@ -4560,16 +4130,6 @@
 /area/ship/hallway/central)
 "UJ" = (
 /obj/structure/chair/comfy/beige/directional/west,
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/siding/wood{
-	dir = 6;
-	color = "#543C30"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood/ebony,
-=======
 /obj/effect/turf_decal/siding/wood{
 	dir = 6;
 	color = "#543C30"
@@ -4589,7 +4149,6 @@
 	color = "#D5A66E"
 	},
 /turf/open/floor/carpet/purple,
->>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "UO" = (
 /obj/effect/turf_decal/corner_techfloor_gray/full,
@@ -4614,7 +4173,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "UU" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4678,30 +4237,16 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "Vp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/traffic,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-<<<<<<< Updated upstream
-=======
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "VA" = (
 /obj/machinery/navbeacon/wayfinding{
 	location = "Storage Bay"
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/techfloor,
-/obj/structure/closet/firecloset/wall/directional/south,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
 /obj/structure/window/reinforced/fulltile/shuttle{
 	color = "#2d2a4e"
 	},
@@ -4711,7 +4256,6 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "VD" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 10;
@@ -4767,17 +4311,6 @@
 /area/ship/medical)
 "Wi" = (
 /obj/structure/fluff/hedge/opaque{
-<<<<<<< Updated upstream
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1;
-	color = "#543C30"
-	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-	},
-=======
 	pixel_y = 4;
 	layer = 3
 	},
@@ -4796,7 +4329,6 @@
 	dir = 1;
 	layer = 2
 	},
->>>>>>> Stashed changes
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Wl" = (
@@ -4813,16 +4345,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
-<<<<<<< Updated upstream
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /obj/machinery/door/airlock/solgov/glass{
 	name = "Feldwebel Brieff Room"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Wm" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
@@ -4855,18 +4382,13 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "Wu" = (
-<<<<<<< Updated upstream
-/obj/structure/closet/crate/large,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
-/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
+/obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "WE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4930,26 +4452,8 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
-<<<<<<< Updated upstream
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue/corner{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/machinery/light/colored{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/cargo)
-=======
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "XO" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -4958,32 +4462,6 @@
 	color = "#4d362c";
 	dir = 10
 	},
-<<<<<<< Updated upstream
-/obj/machinery/washing_machine,
-/turf/open/floor/wood/walnut,
-/area/ship/crew)
-"XT" = (
-/obj/machinery/door/window/eastright,
-/obj/machinery/button/massdriver{
-	id = "space_cops_starboard_launcher";
-	name = "starboard mass driver button";
-	pixel_x = 7;
-	pixel_y = 25
-	},
-/obj/effect/turf_decal/industrial/loading{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue/full,
-/turf/open/floor/plasteel/white,
-/area/ship/crew/janitor)
-"XY" = (
-/obj/effect/turf_decal/corner_techfloor_gray{
-	dir = 10
-	},
-/obj/structure/sign/poster/clip/enlist{
-	pixel_y = -32
-	},
-=======
 /obj/effect/spawner/bunk_bed,
 /obj/structure/curtain/cloth,
 /turf/open/floor/wood/walnut,
@@ -5003,7 +4481,6 @@
 /obj/structure/sign/poster/clip/enlist{
 	pixel_y = -32
 	},
->>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "XZ" = (
@@ -5182,23 +4659,11 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Zs" = (
-<<<<<<< Updated upstream
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
+/obj/effect/turf_decal/corner/opaque/solgovblue/half,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/janitor)
-=======
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
-/obj/effect/turf_decal/corner/transparent/solgovgold/half,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "Zy" = (
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -5265,11 +4730,6 @@
 "ZL" = (
 /obj/structure/fluff/hedge/opaque{
 	pixel_y = 4
-<<<<<<< Updated upstream
-	},
-/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
-	layer = 5
-=======
 	},
 /obj/structure/railing/wood{
 	dir = 8
@@ -5281,7 +4741,6 @@
 /obj/structure/railing/wood{
 	dir = 1;
 	layer = 2
->>>>>>> Stashed changes
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -5318,11 +4777,7 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
-<<<<<<< Updated upstream
-/area/ship/cargo)
-=======
 /area/ship/crew/law_office)
->>>>>>> Stashed changes
 "ZS" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 8
@@ -5804,7 +5259,7 @@ UD
 so
 Wi
 eg
-ah
+Aj
 En
 En
 TT
@@ -5917,22 +5372,13 @@ WY
 Ul
 Vp
 qX
-<<<<<<< Updated upstream
-vs
-qX
+Hs
+Sa
 ej
 vs
 To
-vs
-=======
->>>>>>> Stashed changes
+oW
 QB
-Tp
-ej
-mt
-To
-vs
-Zs
 iM
 "}
 (32,1,1) = {"
@@ -5971,7 +5417,7 @@ ia
 Sl
 wD
 xF
-LN
+xp
 "}
 (34,1,1) = {"
 PX
@@ -5985,17 +5431,11 @@ nE
 tn
 De
 pC
-LN
-<<<<<<< Updated upstream
-LN
-iD
-LN
-=======
-tg
-iD
 xp
->>>>>>> Stashed changes
+mt
+iD
 LN
+xp
 aZ
 "}
 (35,1,1) = {"
@@ -6010,11 +5450,11 @@ nE
 Qp
 zL
 qI
-LN
+xp
 HK
 RT
 Zs
-LN
+xp
 PX
 "}
 (36,1,1) = {"
@@ -6029,11 +5469,11 @@ nE
 PX
 WT
 PX
-LN
+xp
 Jp
 cY
 la
-LN
+xp
 PX
 "}
 (37,1,1) = {"
@@ -6048,11 +5488,11 @@ nE
 PX
 PX
 PX
-LN
+xp
 qq
 VA
-LN
-LN
+xp
+xp
 PX
 "}
 (38,1,1) = {"
@@ -6067,10 +5507,10 @@ nE
 PX
 PX
 PX
-LN
+xp
 Rz
 em
-LN
+xp
 PX
 PX
 "}
@@ -6086,9 +5526,9 @@ nE
 PX
 PX
 PX
-LN
+xp
 XT
-LN
+xp
 ti
 PX
 PX
@@ -6105,9 +5545,9 @@ nE
 PX
 PX
 PX
-LN
+xp
 QS
-LN
+xp
 PX
 PX
 PX
@@ -6124,12 +5564,8 @@ nE
 PX
 PX
 PX
-LN
-<<<<<<< Updated upstream
 xp
-=======
-LN
->>>>>>> Stashed changes
+xp
 aZ
 PX
 PX

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -1,22 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
-/obj/machinery/camera/autoname{
-	dir = 8
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = -1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
-	dir = 6
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
-"an" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium,
-/area/ship/hallway/port)
 "ap" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -35,54 +29,63 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"ar" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 4
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
 "az" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/obj/machinery/door/poddoor/shutters{
+	id = "bridge";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "aO" = (
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
+/obj/structure/closet/secure_closet{
+	icon_door = "med_secure";
+	icon_state = "med_secure";
+	name = "field medic's locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/radio/headset/solgov,
+/obj/item/clothing/glasses/hud/health/sunglasses,
+/obj/item/storage/firstaid/medical,
+/obj/item/storage/belt/military/solfed/medical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/under/solfed/medical,
+/obj/item/clothing/head/solfed/surgical,
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 9
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/box/bodybags,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "aP" = (
+/obj/machinery/door/airlock/solgov{
+	name = "Cryogenics";
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	name = "Hallway";
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/port)
-"aU" = (
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 1
 	},
-/obj/item/paper_bin{
-	pixel_x = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/folder/blue{
-	pixel_x = -9
-	},
-/obj/item/pen/fountain{
-	pixel_x = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/turf/open/floor/wood,
+/area/ship/crew)
+"aU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -91,65 +94,9 @@
 	dir = 6;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "bn" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/computer/secure_data/laptop,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"bx" = (
-/obj/item/pen/solgov{
-	pixel_x = 2
-	},
-/obj/item/paper_bin/carbon{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light/small/directional/north{
-	pixel_x = 10
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/item/folder/solfed{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/stamp/solfed/captain{
-	pixel_x = -7;
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
-"bC" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/hallway/port)
-"bD" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/janitor)
-"bI" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
-/obj/machinery/computer/crew/solgov{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
-"bJ" = (
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -157,43 +104,104 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -16
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"bx" = (
+/obj/machinery/newscaster/directional/north,
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/crew)
+"bC" = (
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 9
+	},
+/obj/machinery/door/airlock/multi_tile/medical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bJ" = (
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "bP" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/prison)
+/obj/structure/table/wood,
+/obj/item/stamp/solfed/captain{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/pen/solfed{
+	pixel_y = -1;
+	pixel_x = -8
+	},
+/obj/item/desk_flag/solgov{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/obj/item/paper_bin{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/wood,
+/area/ship/bridge)
 "bQ" = (
-/turf/open/floor/engine/hull,
-/area/ship/external)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
 "ca" = (
 /obj/structure/sign/number/one{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew)
 "cg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/industrial/traffic,
-/obj/effect/turf_decal/arrows,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "ck" = (
 /obj/machinery/power/terminal{
@@ -214,6 +222,9 @@
 /obj/item/paper/crumpled{
 	default_raw_text = "Для подачи воздуха из атмосферы достаточно включить первый скрабер"
 	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "ct" = (
@@ -221,12 +232,24 @@
 /turf/open/floor/engine/hull,
 /area/ship/external)
 "cQ" = (
-/obj/machinery/porta_turret/ship/solfed{
-	dir = 9;
-	id = "tomahawk_turrets"
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 10
 	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/obj/item/ammo_box/magazine/gar,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
 "cY" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -239,7 +262,7 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_grid,
 /obj/effect/turf_decal/techfloor/corner,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "db" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -253,83 +276,65 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "df" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
-"dh" = (
-/obj/docking_port/stationary{
-	width = 27;
-	height = 15;
-	dwidth = 10
+"dg" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
 	},
-/turf/template_noop,
-/area/template_noop)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/wood,
+/area/ship/crew)
 "dl" = (
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
+	id = "bridge";
 	name = "Blast Shutters"
 	},
-/turf/open/floor/plating,
-/area/ship/medical)
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "dm" = (
 /obj/structure/sign/number/one{
 	color = "#c48d26";
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "ds" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	req_access = null;
-	req_one_access = list(1,10)
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner_techfloor_gray/full,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "dK" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board{
-	pixel_x = -8
+/obj/structure/sign/poster/solgov/solgov_logo{
+	pixel_y = 32
 	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 18;
-	pixel_x = 7
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_x = -20
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 12;
-	pixel_x = -9
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = 9
+/obj/structure/sign/poster/solgov/solgov_logo{
+	pixel_y = 32
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
+	color = "#D5A66E";
 	dir = 1
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "dS" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -347,22 +352,26 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "eg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "ej" = (
 /obj/machinery/door/firedoor/border_only{
@@ -371,14 +380,9 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "em" = (
 /obj/machinery/firealarm/directional/east,
@@ -388,7 +392,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "eo" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -408,110 +412,77 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "eR" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
 	},
-/obj/effect/turf_decal/industrial/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono,
-/area/ship/cargo)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "eU" = (
 /obj/machinery/porta_turret/ship/solfed/heavy{
 	dir = 5;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "fc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/solgov/all/center_right,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+"fg" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -8
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/prison)
 "fj" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 9;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "fM" = (
-/obj/machinery/firealarm/directional/north,
-/obj/structure/rack,
-/obj/item/roller{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/roller{
-	pixel_y = 5
-	},
-/obj/item/roller{
-	pixel_x = 5
-	},
-/obj/item/storage/box/bodybags{
-	pixel_x = 7;
-	pixel_y = 13
-	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"fO" = (
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/turf_decal/box/corners,
-/obj/effect/spawner/random/maintenance/five,
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plasteel/mono,
-/area/ship/cargo)
-"fV" = (
-/obj/structure/sign/poster/official/obey{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink{
-	pixel_y = 13
-	},
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"fY" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"ge" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 8
 	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"fO" = (
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"ge" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
 "gA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"gR" = (
+/obj/structure/chair/comfy/red,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/freezer,
-/area/ship/crew)
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "gT" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -541,112 +512,91 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "hj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 5
-	},
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/item/storage/box/ammo/ferrolance,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "hD" = (
-/obj/effect/turf_decal/solgov/all,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ship/cargo)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "hE" = (
-/obj/structure/bed,
-/obj/machinery/light/small/directional/east,
-/obj/item/bedsheet/solfed,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/crewtwo)
-"hH" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/firstaid/advanced{
+	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/ship/hallway/port)
-"hR" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	name = "Hallway";
-	dir = 4
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/port)
-"hT" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Morgue"
-	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -16
+/obj/item/storage/firstaid/regular{
+	pixel_x = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"hG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"hH" = (
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"hR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"hT" = (
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
 "ia" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 8
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "iD" = (
 /obj/structure/cable{
@@ -677,73 +627,76 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/janitor)
 "iH" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium,
-/area/ship/engineering)
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "iM" = (
 /obj/structure/sign/number/eight{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
 "je" = (
-/obj/machinery/cryopod,
-/obj/machinery/computer/cryopod/directional/north{
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
 	dir = 9
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/prison)
 "jl" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "jw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "jy" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering)
 "jK" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
+/obj/structure/sign/poster/solgov/terra{
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"jP" = (
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/hallway/central)
 "ko" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -756,34 +709,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Blast Shutters";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood,
 /area/ship/security/prison)
 "kr" = (
-/obj/effect/turf_decal/number/one,
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 5
+	},
+/obj/structure/sign/flag/solfed/directional/south,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "ky" = (
 /obj/structure/sign/number/nine{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
 "kz" = (
 /obj/structure/cable{
@@ -793,38 +749,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/solgov/all/bottom_center,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kF" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 32
-	},
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
-/obj/item/storage/case/surgery{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "kM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/hallway/central)
 "kY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -835,8 +774,8 @@
 	id = "space_cops_windows";
 	name = "Blast Shutters"
 	},
-/turf/open/floor/plating,
-/area/ship/medical)
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "la" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -856,7 +795,7 @@
 /obj/item/storage/bag/trash{
 	pixel_x = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "li" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -868,45 +807,62 @@
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner{
 	dir = 4
 	},
+/obj/structure/closet/emcloset/wall/directional/west,
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/structure/closet/emcloset/wall/directional/west,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "ly" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/item/clothing/suit/armor/vest/solgov/captain,
+/obj/item/clothing/under/solgov/formal/captain,
+/obj/item/clothing/gloves/combat,
+/obj/item/door_remote/captain,
+/obj/item/storage/belt/sabre/solgov,
+/obj/item/clothing/under/solgov,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/under/solgov/formal,
+/obj/item/folder/documents/solgov,
+/obj/structure/closet/secure_closet{
+	icon_state = "cap";
+	name = "\proper captain's locker";
+	req_access_txt = "20";
+	req_ship_access = 1
+	},
+/obj/item/pen/fountain/solgov,
+/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/ammo_box/magazine/modelh,
+/obj/item/clothing/neck/cloak/solgovcap,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/storage/box/ammo/ferroslug,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/clothing/head/beret/solgov,
+/obj/item/radio/headset/solgov/alt/captain,
+/obj/item/storage/belt/military/assault,
+/obj/item/clothing/suit/armor/solgov_trenchcoat{
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	},
+/obj/item/clothing/shoes/combat,
+/obj/item/sharpener,
+/obj/structure/sign/poster/bay/bay_41{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/ship/bridge)
+"lG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet{
-	icon_door = "med_secure";
-	icon_state = "med_secure";
-	name = "field medic's locker";
-	req_access_txt = "5"
-	},
-/obj/item/storage/backpack/medic,
-/obj/item/clothing/accessory/armband/medblue,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/item/radio/headset/headset_medsec/alt,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
-	dir = 5
-	},
-/obj/item/clothing/under/solfed/medical,
-/obj/item/clothing/head/solfed/surgical,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "lH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -917,24 +873,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "lK" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
-/area/ship/crew/office)
+/area/ship/crew)
 "lM" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/computer/operating{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "lQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -942,31 +898,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
 "mi" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -28
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/condiment/ketchup{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/condiment/mayonnaise{
-	pixel_x = 3
+/obj/structure/chair/comfy/beige/old/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543c30"
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 10
+	dir = 8;
+	color = "#543C30"
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "mt" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
 "mL" = (
 /obj/structure/cable{
@@ -982,8 +928,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "mZ" = (
 /obj/machinery/power/terminal{
@@ -998,58 +943,44 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue,
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "nf" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/crewtwo)
-"nh" = (
-/obj/item/storage/box/cups{
-	pixel_x = 16;
+/obj/machinery/vending/wallmed{
 	pixel_y = 5
 	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/medical)
+"nh" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e"
+/obj/item/toy/cards/deck{
+	layer = 2.8;
+	pixel_y = 6
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/obj/effect/turf_decal/siding/wood{
+	color = "#543c30"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "nm" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/structure/chair/wood,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 11
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 4
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
-"no" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"no" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	dir = 8;
+	color = "#543C30"
 	},
-/turf/open/floor/wood,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1058,44 +989,38 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "nA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+	icon_state = "4-8"
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "nD" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/solgov/all/top_right,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "nE" = (
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/maintenance/fore)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1108,68 +1033,75 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/sign/poster/solgov/paperwork{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "nO" = (
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/structure/mirror{
 	pixel_x = 25
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
 "nP" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "space_cops_bridge"
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
+/obj/structure/sign/poster/bay/bay_47{
+	pixel_y = -32
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	name = "Hall"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "nQ" = (
-/obj/machinery/firealarm/directional/north,
-/obj/structure/fluff/hedge/opaque,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"oe" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 6
 	},
 /turf/open/floor/wood,
-/area/ship/hallway/port)
-"oe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/area/ship/hallway/central)
+"oj" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
+"oo" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed,
+/obj/item/toy/plush/blahaj,
+/obj/item/storage/backpack/satchel/solfed,
+/obj/item/storage/backpack/satchel/solfed,
+/obj/item/storage/backpack/solfed,
+/obj/item/storage/backpack/solfed,
+/obj/item/storage/backpack/duffelbag/solfed,
+/obj/item/clothing/head/solfed/cap,
+/obj/item/clothing/head/solfed/cap,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/camo,
 /obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ship/hallway/central)
-"ov" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -12
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
+/area/ship/crew)
 "ox" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/cable{
@@ -1189,68 +1121,51 @@
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/hardhat/solgov,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
 /obj/item/clothing/under/solgov/formal,
 /obj/item/clothing/under/solgov/dress,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/accessory/armband/cargo,
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/gloves/combat,
 /obj/item/storage/backpack,
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/item/clothing/glasses/meson/prescription,
-/obj/item/melee/knife/letter_opener,
 /obj/item/clothing/glasses/meson,
 /obj/item/storage/bag/ore,
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "oD" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
-"oH" = (
-/obj/structure/fluff/hedge/opaque,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 10
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "oY" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/techfloor,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "pi" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 6
+/obj/effect/turf_decal/corner/opaque/cybersunteal/bordercorner{
+	dir = 1
 	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "pm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -1263,8 +1178,7 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "pv" = (
 /obj/machinery/door/firedoor/window,
@@ -1273,12 +1187,12 @@
 	id = "space_cops_windows";
 	name = "Blast Shutters"
 	},
-/turf/open/floor/plating,
-/area/ship/hallway/port)
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/canteen/kitchen)
 "pA" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/canteen/kitchen)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/hallway/central)
 "pC" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -1292,11 +1206,12 @@
 	pixel_x = 11;
 	pixel_y = -20
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "pT" = (
-/obj/machinery/pipedispenser,
 /obj/effect/turf_decal/techfloor{
 	dir = 9
 	},
@@ -1306,20 +1221,18 @@
 	pixel_x = 8;
 	pixel_y = 19
 	},
+/obj/machinery/power/ship_gravity,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "pZ" = (
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -25
+/obj/effect/turf_decal/corner_techfloor_gray/full{
+	dir = 8
 	},
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qc" = (
 /obj/machinery/firealarm/directional/east,
@@ -1333,69 +1246,71 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "qd" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "qh" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
-/obj/structure/fluff/hedge/opaque,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 5;
+	color = "#543C30"
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "qj" = (
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "marine locker";
+	req_access_txt = "2"
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel/white,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/mask/balaclava/combat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/effect/turf_decal/corner_techfloor_gray/full{
+	dir = 8
+	},
+/obj/structure/sign/flag/solfed/directional/west,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qq" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/structure/closet/emcloset/wall/directional/north,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "qB" = (
-/obj/machinery/camera/autoname,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/guncloset{
-	desc = "A locker that holds weapons.";
-	name = "weapon locker"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/item/gun/ballistic/automatic/powered/gauss/gar,
-/obj/item/gun/ballistic/automatic/powered/gauss/gar,
-/obj/item/gun/ballistic/automatic/powered/gauss/gar,
-/obj/item/gun/ballistic/automatic/powered/gauss/gar,
-/turf/open/floor/plasteel/white,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qI" = (
 /obj/structure/cable,
@@ -1411,106 +1326,115 @@
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
 "qL" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 5
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/airlock/solgov{
-	dir = 1;
-	name = "Overseer's Quarters";
-	req_access = list(57)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"rf" = (
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/crewtwo)
-"rc" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew)
-"re" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"rf" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "rk" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "space_cops_bridge"
+/obj/item/kirbyplants/photosynthetic{
+	icon_state = "plant-10"
 	},
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"rm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
-/area/ship/security/prison)
-"rw" = (
-/obj/structure/sign/poster/official/cleanliness,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
-"rz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
+/obj/machinery/power/apc/auto_name/directional/south{
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = -16;
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"rm" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "marine locker";
+	req_access_txt = "2"
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/mask/balaclava/combat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/effect/turf_decal/corner_techfloor_gray/full{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"rw" = (
+/obj/structure/sign/poster/official/cleanliness,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"rz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "rE" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew)
 "rK" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "rZ" = (
 /obj/structure/cable{
@@ -1518,43 +1442,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/mecha/working/ripley/cargo,
-/obj/structure/closet/crate/large,
-/obj/item/mecha_parts/mecha_equipment/drill,
-/obj/item/circuitboard/machine/mech_recharger,
-/obj/item/circuitboard/computer/mech_bay_power_console,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "sb" = (
-/obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
 	dir = 6
 	},
 /obj/structure/curtain/cloth,
-/obj/item/bedsheet/solfed,
+/obj/effect/spawner/bunk_bed,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "so" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 1
-	},
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/canteen/kitchen)
 "su" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/sign/poster/solgov/solgov_logo{
+	pixel_y = 32
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	color = "#D5A66E";
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -1562,23 +1471,45 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = -9;
+	id = "bridge"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = 8;
+	id = "bridgetohallway"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -34;
+	id = "armory"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "ti" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/janitor)
 "tl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "tn" = (
@@ -1595,7 +1526,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "to" = (
 /obj/structure/cable{
@@ -1620,6 +1554,9 @@
 	dir = 8;
 	name = "Crew Quarters"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew)
 "tr" = (
@@ -1628,66 +1565,63 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
+"tC" = (
+/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "bridge";
+	name = "Blast Shutters"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = -9;
+	id = bridge
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "tO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/chair/bench/orange/directional/east,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"uf" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D5A66E"
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"ut" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/bridge)
+"uM" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
-/area/ship/hallway/port)
-"uf" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"ut" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/computer/operating/solgov,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"uM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/item/megaphone/command,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom/table{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "uW" = (
 /obj/structure/cable/yellow{
@@ -1703,8 +1637,26 @@
 "vm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-28";
+	pixel_y = 9;
+	layer = 4.3;
+	pixel_x = -9
+	},
+/obj/structure/table/glass/light_glass,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/lighter/zippo/sol{
+	pixel_y = 3;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "vo" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/machinery/door/firedoor/window,
@@ -1716,30 +1668,47 @@
 /turf/open/floor/plating,
 /area/ship/crew)
 "vs" = (
-/obj/effect/turf_decal/solgov/all/center_left,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "vE" = (
-/obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c"
 	},
 /obj/structure/curtain/cloth,
-/obj/item/bedsheet/solfed,
+/obj/effect/spawner/bunk_bed,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
+"vG" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "vJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/techfloor{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4";
+	tag = null
 	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "vK" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
@@ -1751,31 +1720,45 @@
 	pixel_y = 23;
 	pixel_x = 11
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "vL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "marine locker";
+	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/mask/balaclava/combat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 5
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/atmos{
-	dir = 4;
-	name = "Engine Room";
-	req_one_access = list(10)
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/engineering)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
 "wf" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/sign/poster/official/safety_internals{
@@ -1787,7 +1770,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "wh" = (
 /obj/structure/cable{
@@ -1798,35 +1781,35 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "wv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/turretid/ship{
+	pixel_y = -25;
+	id = "tomahawk_turrets"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "wD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 8
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "wM" = (
 /obj/effect/turf_decal/techfloor/orange{
@@ -1840,33 +1823,27 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "wN" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/power/ship_gravity,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/engineering)
-"wY" = (
-/obj/structure/closet/crate{
-	name = "space suits crate"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
 	},
-/obj/item/clothing/suit/space/solgov,
-/obj/item/clothing/suit/space/solgov,
-/obj/item/clothing/suit/space/solgov,
-/obj/item/clothing/head/helmet/space/solgov,
-/obj/item/clothing/head/helmet/space/solgov,
-/obj/item/clothing/head/helmet/space/solgov,
-/obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/turf/open/floor/plasteel/mono/white,
-/area/ship/storage)
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
 "xb" = (
 /obj/machinery/door/window/eastleft,
 /obj/machinery/button/massdriver{
@@ -1880,21 +1857,23 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue/full,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "xi" = (
-/obj/structure/chair/office{
-	dir = 1
+/obj/effect/turf_decal/corner_techfloor_gray/full{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/obj/structure/rack,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/obj/item/storage/box/ammo/ferrolance,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
 "xk" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1905,6 +1884,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "xp" = (
@@ -1917,126 +1897,87 @@
 /turf/open/floor/plating,
 /area/ship/crew/janitor)
 "xs" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "bridgetohallway";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "xu" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
+/obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	color = "#D5A66E";
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "xy" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/wall/directional/west{
-	icon_state = "sec_wall";
-	name = "Ammo Locker";
-	dir = 4;
-	pixel_x = 30
-	},
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/ammo_box/magazine/gar,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/obj/item/stock_parts/cell/gun/solgov,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"xD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/button/door{
-	id = "solc_airblast";
-	name = "Cargo Bay Doors";
-	pixel_y = 8;
-	pixel_x = -24;
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/hallway/central)
+"xD" = (
+/obj/structure/sign/solfed,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
 "xF" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue/corner{
-	dir = 1
+/obj/effect/spawner/random/maintenance/five,
+/obj/effect/spawner/random/maintenance/three,
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/techfloor{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "xO" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"xQ" = (
-/obj/structure/fluff/hedge/opaque,
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
-"xV" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
-	},
-/obj/machinery/navbeacon/wayfinding{
-	codes_txt = "patrol;next_patrol=podbay";
-	location = "med"
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 11
+/obj/structure/sign/poster/bay/bay_43{
+	pixel_x = 28
 	},
-/mob/living/simple_animal/bot/medbot{
-	name = "\improper Lt. Kelley"
+/obj/machinery/computer/crew{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"xQ" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/solgov/sonnensoldner{
+	pixel_y = 31
+	},
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"xV" = (
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "xX" = (
 /obj/structure/ore_box,
-/obj/effect/turf_decal/corner/opaque/orange/mono,
-/turf/open/floor/plasteel/mono/white,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "yg" = (
 /obj/structure/cable{
@@ -2049,70 +1990,52 @@
 	color = "#4d362c";
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
-"yG" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 11
-	},
-/obj/effect/decal/cleanable/dirt,
+"yA" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 10
+	dir = 4;
+	color = "#543C30"
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "yO" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e"
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 6
 	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"yY" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/kirbyplants/photosynthetic{
+	icon_state = "plant-01";
+	pixel_y = 9
 	},
-/turf/open/floor/plating,
-/area/ship/crew/canteen/kitchen)
+/obj/item/reagent_containers/pill/stimulant,
+/obj/item/reagent_containers/pill/stimulant,
+/obj/item/reagent_containers/pill/stimulant,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "zd" = (
-/obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 5
+/obj/machinery/door/airlock/multi_tile/solgov,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"zy" = (
-/obj/structure/closet/wall/directional/east,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood{
-	color = "#4d362c";
-	dir = 5
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 10
 	},
-/obj/item/clothing/neck/stripedsolgovscarf,
-/obj/item/clothing/neck/stripedsolgovscarf,
-/obj/item/clothing/neck/stripedsolgovscarf,
-/obj/item/clothing/neck/stripedsolgovscarf,
-/obj/item/clothing/under/solfed/assistant,
-/obj/item/clothing/under/solfed/assistant,
-/obj/item/clothing/under/solfed/assistant,
-/obj/item/storage/backpack/satchel/solfed,
-/obj/item/storage/backpack/satchel/solfed,
-/obj/item/storage/backpack/satchel/solfed,
-/obj/item/storage/backpack/solfed,
-/obj/item/storage/backpack/solfed,
-/obj/item/storage/backpack/solfed,
-/obj/item/storage/backpack/duffelbag/solfed,
-/obj/item/storage/backpack/duffelbag/solfed,
-/turf/open/floor/wood/walnut,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "zD" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2130,38 +2053,44 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/closet/crate/secure/gear{
-	populate = 0;
-	name = "emergency sauerkraut supplies";
-	desc = "For emergency use only";
-	req_access = list(19)
-	},
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
-/obj/item/food/grown/cabbage,
 /obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "zG" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "marine locker";
+	req_access_txt = "2"
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/mask/balaclava/combat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/turf_decal/corner/opaque/solgovblue{
+	dir = 10
 	},
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "zL" = (
 /obj/structure/cable{
@@ -2178,56 +2107,30 @@
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
 "zN" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/double/solgov,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
-"zR" = (
-/obj/structure/closet/secure_closet/security{
-	populate = 0;
-	name = "marine's locker";
-	anchored = 1
+/obj/machinery/cryopod{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/techfloor{
-	dir = 6
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
-/obj/item/melee/energy/sword/saber/knife,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/radio/headset/solgov/alt,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solfed,
-/obj/item/clothing/under/solfed/camo,
-/obj/item/clothing/head/helmet/solfed/m11,
-/obj/item/clothing/suit/armor/vest/marine,
-/obj/item/storage/belt/military/solfed,
-/obj/item/clothing/gloves/combat/solfed,
-/obj/item/clothing/glasses/sunglasses/ballistic,
-/obj/item/clothing/head/solfed/beret,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"zS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "Helm"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/ship/bridge)
+/area/ship/crew)
+"zS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D5A66E"
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "Ac" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D5A66E"
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -2248,54 +2151,65 @@
 /area/ship/maintenance/fore)
 "Ah" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/vending/boozeomat/all_access{
+	all_items_free = 1
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
-"Al" = (
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "space_cops_bridge"
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"Aw" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding/sec{
-	location = "Brig"
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"AK" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 9
 	},
-/turf/open/floor/wood/mahogany,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
-"AS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#543C30"
+"Al" = (
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 10
 	},
-/obj/effect/turf_decal/spline/fancy/wood,
-/obj/structure/filingcabinet,
-/obj/item/documents/solfed,
+/obj/structure/rack,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/item/stock_parts/cell/gun/solgov,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"Aw" = (
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"AK" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/prison)
+"AS" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed,
+/obj/item/toy/plush/blahaj,
+/obj/item/storage/backpack/satchel/solfed,
+/obj/item/storage/backpack/satchel/solfed,
+/obj/item/storage/backpack/solfed,
+/obj/item/storage/backpack/solfed,
+/obj/item/storage/backpack/duffelbag/solfed,
+/obj/item/clothing/head/solfed/cap,
+/obj/item/clothing/head/solfed/cap,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/assistant,
+/obj/item/clothing/under/solfed/camo,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
-/area/ship/crew/office)
+/area/ship/crew)
 "AY" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -2313,41 +2227,27 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering)
-"Ba" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
 "Bh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 4;
+	color = "#543C30"
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "BC" = (
-/obj/item/folder/solgov,
-/obj/item/folder/solgov,
-/obj/item/folder/solgov,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/paper_bin/bundlenatural,
-/obj/item/paper_bin/bundlenatural,
-/obj/item/paper_bin/bundlenatural,
-/obj/structure/closet/crate/wooden,
 /obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "BF" = (
 /obj/structure/cable{
@@ -2357,36 +2257,24 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/solgov/all/top,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "BG" = (
-/obj/structure/closet/secure_closet/captains{
-	populate = 0;
-	anchored = 1
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
 	},
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/gloves/combat,
-/obj/item/door_remote/captain,
-/obj/item/storage/belt/sabre/solgov,
-/obj/item/clothing/suit/armor/vest/solgov/captain,
-/obj/item/gun/ballistic/automatic/powered/gauss/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/ammo_box/magazine/modelh,
-/obj/item/binoculars,
-/obj/item/hatchet/wooden{
-	name = "Tomahawk";
-	force = 20;
-	throwforce = 25
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/storage/backpack/solfed,
-/obj/item/clothing/under/solfed/formal,
-/obj/item/clothing/suit/armor/solfed/formal,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/office)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -2396,50 +2284,46 @@
 	},
 /obj/machinery/holopad/emergency/command,
 /turf/open/floor/wood,
-/area/ship/bridge)
+/area/ship/hallway/central)
 "BM" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/storage)
-"Ci" = (
 /obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"Cp" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/stand_clear{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/mono,
-/area/ship/cargo)
-"Cr" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
-"Cs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
+"Cp" = (
 /obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/hallway/central)
+"Cs" = (
+/obj/structure/table,
+/obj/machinery/jukebox/boombox{
+	pixel_y = -3
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-33";
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "CC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2462,13 +2346,12 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Treatment Center";
+/obj/machinery/door/airlock/solgov{
 	dir = 4;
-	req_one_access = list(5,45)
+	name = "Bridge"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ship/medical)
+/area/ship/bridge)
 "CE" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2490,23 +2373,14 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "CN" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "space_cops_bridge"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Da" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -2520,16 +2394,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 4
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 4
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "Db" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -2563,137 +2433,124 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Dt" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/solgov/all/bottom_right,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "DV" = (
-/obj/structure/closet/secure_closet/security{
-	populate = 0;
-	name = "marine's locker";
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4";
+	tag = null
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/item/melee/energy/sword/saber/knife,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/radio/headset/solgov/alt,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solfed,
-/obj/item/clothing/under/solfed/camo,
-/obj/item/clothing/head/helmet/solfed/m11,
-/obj/item/clothing/suit/armor/vest/marine,
-/obj/item/storage/belt/military/solfed,
-/obj/item/clothing/gloves/combat/solfed,
-/obj/item/clothing/glasses/sunglasses/ballistic,
-/obj/item/clothing/head/solfed/beret,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "Ef" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
+	dir = 1
+	},
+/obj/structure/sign/poster/solgov/solgov_logo{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"Ej" = (
+/obj/structure/chair/comfy/red{
+	dir = 1
+	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	color = "#D5A66E";
+	dir = 6
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
-"Eh" = (
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
 "En" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/crewtwo)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/medical)
 "Eu" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "Ez" = (
-/obj/structure/table/optable,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 9
+	},
+/obj/structure/table/glass/light_glass,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -8;
+	layer = 2.8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"EH" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"EH" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/ship/hallway/central)
-"EI" = (
-/obj/structure/chair/wood,
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 8
-	},
-/turf/open/floor/wood/mahogany,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "ER" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
-	dir = 4
-	},
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "EY" = (
-/obj/effect/turf_decal/solgov/all/bottom_left,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Fm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer4{
+	dir = 1;
+	filter_types = list("n2","o2");
+	name = "Environment to Air"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
+/turf/open/floor/engine/hull,
+/area/ship/external)
 "Fr" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Fu" = (
@@ -2719,68 +2576,49 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "FB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/sign/poster/bay/bay_50{
+	pixel_x = 29
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov/glass{
-	dir = 4;
-	name = "Cafeteria"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/central)
-"FE" = (
-/obj/effect/decal/cleanable/oil,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering)
-"FK" = (
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security{
-	dir = 4;
-	name = "Sonnensoldner Locker Room";
-	req_one_access = list(1,10)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"FE" = (
+/obj/structure/flora/bigplant{
+	pixel_y = 1;
+	pixel_x = -20
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood,
+/area/ship/bridge)
+"FK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "FL" = (
 /obj/item/radio/headset/headset_eng,
@@ -2798,9 +2636,6 @@
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/meson/engine,
@@ -2822,9 +2657,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/corner/opaque/solgovgold/half,
 /obj/effect/turf_decal/corner/opaque/solgovgold/half{
 	dir = 4
@@ -2839,15 +2671,18 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "FQ" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/machinery/navbeacon/wayfinding/med{
-	name = "navigation beacon"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "FU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -2863,154 +2698,173 @@
 "Go" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Gu" = (
-/obj/structure/closet/secure_closet/security{
-	populate = 0;
-	name = "marine's locker";
-	anchored = 1
-	},
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/techfloor,
-/obj/item/melee/energy/sword/saber/knife,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/radio/headset/solgov/alt,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solfed,
-/obj/item/clothing/under/solfed/camo,
-/obj/item/clothing/head/helmet/solfed/m11,
-/obj/item/clothing/suit/armor/vest/marine,
-/obj/item/storage/belt/military/solfed,
-/obj/item/clothing/gloves/combat/solfed,
-/obj/item/clothing/glasses/sunglasses/ballistic,
-/obj/item/clothing/head/solfed/beret,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"Gw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer4{
-	dir = 1;
-	filter_types = list("n2","o2");
-	name = "Environment to Air"
-	},
-/turf/open/floor/engine/hull,
-/area/ship/engineering)
-"GC" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/maintenance/fore)
-"GJ" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/office)
-"Hh" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium,
-/area/ship/maintenance/fore)
-"Hm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/machinery/computer/cargo/solgov,
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/wood,
-/area/ship/bridge)
-"Hp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	id = "armory";
+	name = "Blast Shutters";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/security/prison)
+"Gw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"GJ" = (
+/obj/machinery/door/airlock/multi_tile/solgov,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"Hh" = (
+/obj/structure/sign/solfed,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/maintenance/fore)
+"Hp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 4
+	color = "#D5A66E";
+	dir = 1
 	},
-/turf/open/floor/wood/ebony,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "HD" = (
-/obj/machinery/porta_turret/ship/solfed{
-	dir = 10;
-	id = "tomahawk_turrets"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "HK" = (
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/trashcart,
 /obj/effect/turf_decal/techfloor{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
-"Ig" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
 "Ih" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/computer/cargo,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Ii" = (
-/obj/machinery/navbeacon/wayfinding{
-	codes_txt = "patrol;next_patrol=med";
-	location = "dorms"
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/stasis{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/ship/hallway/central)
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Ip" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/solgov,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/east,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/item/clothing/neck/cloak/gezena{
+	desc = "dark cape of a marine scout of the Solar Federation";
+	name = "\improper dark cape"
+	},
+/obj/structure/closet/wall{
+	dir = 4;
+	pixel_y = -1;
+	pixel_x = 32
+	},
+/obj/structure/chair/bench/orange/directional/east{
+	dir = 2;
+	pixel_y = 24;
+	pixel_x = 1
+	},
+/obj/item/toy/plush/celadon/tora{
+	pixel_y = 39
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
-/area/ship/crew/office)
+/area/ship/crew)
 "Is" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/cryopod,
-/obj/effect/turf_decal/siding/wood{
-	color = "#4d362c";
+/obj/machinery/door/airlock/multi_tile/solgov{
+	name = "Hallway"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/wood/walnut,
-/area/ship/crew)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "Iw" = (
 /obj/structure/toilet{
 	pixel_y = 9
@@ -3032,64 +2886,39 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "IO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 6
+	},
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "Jf" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 6;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "Jk" = (
-/obj/structure/table/reinforced,
-/obj/item/gps{
-	gpstag = null;
-	pixel_x = -9;
-	pixel_y = 7
+/obj/item/kirbyplants/photosynthetic{
+	icon_state = "plant-06"
 	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
-/obj/item/binoculars{
-	pixel_x = -9;
-	pixel_y = -2
-	},
-/obj/item/radio/intercom/wideband/table{
-	dir = 4;
-	pixel_x = 7
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
-"Jm" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/office)
-"Jo" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#543C30"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/machinery/door/airlock/solgov{
-	req_one_access = list(20);
-	name = "Captain's Quarters";
-	id_tag = "sgi_captainbolt";
-	dir = 1
+/obj/machinery/power/apc/auto_name/directional/west{
+	dir = 4;
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"Jo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/tech,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
 "Jp" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3099,11 +2928,11 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "Jv" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/hallway/central)
 "JF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3115,27 +2944,21 @@
 /obj/machinery/navbeacon/wayfinding/cargo{
 	name = "navigation beacon"
 	},
-/obj/effect/turf_decal/industrial/stand_clear{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/closet/crate/large,
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "JQ" = (
-/obj/effect/turf_decal/box/corners,
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew)
 "JT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/wood,
-/area/ship/hallway/port)
+/area/ship/crew/canteen/kitchen)
 "Ki" = (
 /obj/machinery/shower{
 	pixel_y = 13
@@ -3145,33 +2968,18 @@
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
 "Kk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/ship/hallway/port)
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "Kw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 8
 	},
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "KX" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering)
 "KZ" = (
 /obj/structure/cable{
@@ -3182,43 +2990,31 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/solgov/all/center,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"Lb" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+"Lf" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/crewtwo)
-"Lf" = (
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = -11
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+	icon_state = "1-2"
 	},
 /turf/open/floor/wood,
-/area/ship/bridge)
+/area/ship/hallway/central)
 "Li" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Lp" = (
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
@@ -3230,7 +3026,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Lv" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
@@ -3252,6 +3048,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "LB" = (
@@ -3260,28 +3057,42 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
-"LG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/ship/security/prison)
-"LK" = (
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
-"LN" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/janitor)
-"LO" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
-	dir = 1
+"LE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"LG" = (
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"LK" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/ship/security/prison)
+"LN" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/janitor)
+"LO" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "LX" = (
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
@@ -3296,13 +3107,14 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "LZ" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/modular_computer/console/preset/id,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28
 	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Ma" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3326,14 +3138,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "Mp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3344,33 +3153,28 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
-	},
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "MG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
-	dir = 1
+/obj/structure/sign/poster/solgov/luna{
+	pixel_x = -29
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/carpet/royalblue/airless,
+/area/ship/bridge)
 "MJ" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/crew/janitor)
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "MN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3388,37 +3192,36 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "MT" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 5
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/port)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "Nk" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "Nl" = (
 /obj/structure/sign/number/eight{
 	color = "#c48d26";
 	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "Nv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/table,
-/obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/royalblue/airless,
+/area/ship/bridge)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3426,33 +3229,52 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
-"NL" = (
-/obj/structure/chair/wood{
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
-"NS" = (
-/obj/structure/closet/secure_closet/head_of_personnel{
-	anchored = 1;
-	name = "\proper overseer's locker";
-	populate = 0
+"NL" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
 	},
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/under/solgov/formal,
-/obj/item/clothing/head/solgov,
-/obj/item/storage/belt/sabre/solgov,
-/obj/item/storage/backpack,
-/obj/item/clothing/under/solgov/dress,
-/obj/machinery/light/directional/south,
-/obj/item/binoculars,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/carpet/royalblue,
-/area/ship/crew/crewtwo)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north{
+	pixel_x = -5;
+	pixel_y = 27
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"NS" = (
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/firstaid/brute{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Oq" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -3513,89 +3335,57 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "OF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
 "OM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Py" = (
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border,
+/obj/structure/table/glass,
+/obj/item/storage/case/surgery,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Py" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/structure/fluff/hedge/opaque,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
-"PK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
 "PS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/closet/secure_closet/wall{
-	icon_door = "med_wall";
-	name = "medicine locker";
-	pixel_y = -28;
-	req_access_txt = "5"
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/brute{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = -5
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 10
+	},
+/obj/item/radio/intercom/wideband/directional/south,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
 "PX" = (
 /turf/template_noop,
 /area/template_noop)
@@ -3617,7 +3407,23 @@
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
 "Qy" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/item/kirbyplants{
+	icon_state = "plant-27";
+	pixel_y = -2;
+	layer = 4.3;
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 10
+	},
+/obj/structure/sign/poster/contraband/starkist{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "Qz" = (
 /obj/structure/fans/tiny,
@@ -3629,36 +3435,10 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "QB" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
-"QJ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = 11
-	},
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 9
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
 "QM" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/light/small/directional/north,
@@ -3667,7 +3447,7 @@
 	dir = 9
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "QS" = (
 /obj/machinery/mass_driver{
@@ -3679,19 +3459,9 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/janitor)
-"Re" = (
-/obj/machinery/porta_turret/ship/solfed{
-	dir = 5;
-	id = "tomahawk_turrets"
-	},
-/turf/closed/wall/mineral/titanium,
-/area/ship/bridge)
 "Rf" = (
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
 	},
 /obj/effect/turf_decal/techfloor/orange/corner{
 	dir = 1
@@ -3708,22 +3478,15 @@
 	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Rx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/ship/hallway/port)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "Rz" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -3733,21 +3496,18 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "RA" = (
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/telecomms/relay{
-	network = "SolNet";
-	autolinkers = list("SolHub")
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood{
-	color = "4d362c";
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ship/bridge)
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
 "RI" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -3769,7 +3529,7 @@
 /obj/item/pickaxe/mini,
 /obj/item/pickaxe/mini,
 /obj/item/pickaxe/mini,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "RM" = (
 /obj/effect/turf_decal/techfloor/orange{
@@ -3784,36 +3544,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"RO" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/structure/window/reinforced,
-/obj/item/melee/energy/sword/saber/knife,
-/obj/item/clothing/shoes/combat,
-/obj/item/clothing/glasses/hud/security/sunglasses,
-/obj/structure/closet/secure_closet/security{
-	populate = 0;
-	name = "marine's locker";
-	anchored = 1
-	},
-/obj/item/radio/headset/solgov/alt,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
-/obj/item/clothing/under/solfed,
-/obj/item/clothing/under/solfed/camo,
-/obj/item/clothing/head/helmet/solfed/m11,
-/obj/item/clothing/suit/armor/vest/marine,
-/obj/item/storage/belt/military/solfed,
-/obj/item/clothing/gloves/combat/solfed,
-/obj/item/clothing/glasses/sunglasses/ballistic,
-/obj/item/clothing/head/solfed/beret,
-/turf/open/floor/plasteel/white,
-/area/ship/security/prison)
 "RT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3836,18 +3566,8 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
-"Sj" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/door/airlock/security/glass{
-	req_one_access = list(1,10)
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/security/prison)
 "Sk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -3857,7 +3577,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "Sl" = (
 /obj/structure/cable{
@@ -3873,13 +3593,10 @@
 	codes_txt = "patrol;next_patrol=dorms";
 	location = "cargo"
 	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 8
+/obj/effect/turf_decal/techfloor{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 8
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Sz" = (
 /obj/structure/cable{
@@ -3908,125 +3625,47 @@
 	name = "Cafeteria"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/canteen/kitchen)
+/area/ship/hallway/central)
 "SD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/ship/hallway/port)
-"SH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"SH" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/wood,
-/area/ship/hallway/port)
-"SO" = (
-/obj/machinery/button/door{
-	id = "space_cops_windows";
-	name = "Exterior Windows";
-	pixel_x = -6;
-	pixel_y = 22
-	},
-/obj/machinery/button/door{
-	id = "space_cops_bridge";
-	name = "Bridge Lockdown";
-	pixel_x = 6;
-	pixel_y = 22
-	},
-/obj/machinery/button/door{
-	id = "sol_cops_bay";
-	name = "Cargo Bay Doors";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 9
-	},
-/obj/machinery/computer/helm/solgov{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/bridge)
+/area/ship/crew/canteen/kitchen)
 "SP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/poster/solgov/solgov_logo{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
 /turf/open/floor/wood,
-/area/ship/crew/office)
-"SU" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	dir = 3;
-	name = "Cargo Bay Blast Door";
-	id = "solc_airblast"
-	},
-/obj/docking_port/mobile{
-	dir = 2;
-	launch_status = 0;
-	port_direction = 8;
-	preferred_direction = 4
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/port)
-"SZ" = (
-/obj/machinery/door/window/eastleft,
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/pen/fountain,
-/obj/item/folder/red{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/westright{
-	req_one_access_txt = list(1,10)
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "To" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plasteel/mono,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Tr" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -4066,6 +3705,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "TA" = (
@@ -4089,71 +3729,40 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/capacitor/adv,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "TG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/effect/turf_decal/corner/opaque/cybersunteal/bordercorner{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "TH" = (
 /obj/structure/sign/number/four{
 	dir = 1;
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "TT" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = -11
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/medical)
 "TX" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner,
+/obj/effect/decal/cleanable/confetti,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"Ui" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	dir = 3;
-	name = "Cargo Bay Blast Door";
-	id = "solc_airblast"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/port)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "Ul" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 1
@@ -4161,9 +3770,49 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "UD" = (
+/obj/structure/closet/secure_closet/freezer{
+	name = "fridge";
+	anchored = 1
+	},
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/reagent_containers/condiment/enzyme,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
+"UF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"UH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -4174,76 +3823,55 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"UF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	color = "#D5A66E";
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "UJ" = (
-/obj/item/kitchen/fork{
-	pixel_x = 8
-	},
-/obj/structure/table/wood,
-/obj/item/kitchen/fork{
-	pixel_x = 6
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 4
-	},
-/obj/item/kitchen/fork{
-	pixel_x = 4
-	},
+/obj/structure/chair/comfy/beige/directional/west,
 /obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 6
+	dir = 6;
+	color = "#543C30"
 	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
 "UO" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "space_cops_bridge"
+/obj/effect/turf_decal/corner_techfloor_gray/full,
+/obj/structure/guncloset{
+	anchored = 1
 	},
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"US" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
+	dir = 6
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
-"US" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/ship/hallway/central)
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "UU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "UX" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4277,37 +3905,28 @@
 	},
 /obj/item/pickaxe/drill/jackhammer,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/hardhat/solgov,
-/obj/item/radio{
-	icon_state = "sec_radio"
-	},
 /obj/item/clothing/under/solgov/formal,
 /obj/item/clothing/under/solgov/dress,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/suit/hazardvest/solgov,
-/obj/item/clothing/accessory/armband/cargo,
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/gloves/combat,
 /obj/item/storage/backpack,
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/item/clothing/glasses/meson/prescription,
-/obj/item/melee/knife/letter_opener,
 /obj/item/clothing/glasses/meson,
 /obj/item/storage/bag/ore,
 /obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "Vp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/industrial/traffic,
-/obj/effect/turf_decal/arrows,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4318,14 +3937,14 @@
 	},
 /obj/effect/turf_decal/techfloor,
 /obj/structure/closet/firecloset/wall/directional/south,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
 "VD" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 10;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "VF" = (
 /obj/machinery/light/directional/north,
@@ -4334,39 +3953,59 @@
 	},
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "VP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Wc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov{
+	req_one_access = list(20);
+	name = "Captain's Quarters";
+	id_tag = "sgi_captainbolt";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/bridge)
+"Wa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Wi" = (
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
 	},
-/turf/open/floor/wood/ebony,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/turf/open/floor/wood,
 /area/ship/hallway/central)
 "Wl" = (
 /obj/structure/cable{
@@ -4381,13 +4020,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning,
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Wm" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "Wq" = (
 /obj/structure/cable{
@@ -4399,12 +4036,12 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/closet/firecloset/wall/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Wt" = (
@@ -4417,13 +4054,10 @@
 /turf/open/floor/plating,
 /area/ship/crew)
 "Wu" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/structure/closet/crate/large,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "WE" = (
 /obj/structure/cable/yellow{
@@ -4449,6 +4083,19 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"WP" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
 "WY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4459,16 +4106,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/closet/cardboard{
-	desc = "Contains a lifetime supply of Solarian Marine Society Shark plushies!";
-	name = "plushie transport box"
-	},
-/obj/item/toy/plush/blahaj,
-/obj/item/toy/plush/blahaj,
-/obj/item/toy/plush/blahaj,
-/obj/item/toy/plush/blahaj,
 /obj/effect/turf_decal/corner/opaque/solgovblue/mono,
-/turf/open/floor/plasteel/mono/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Xb" = (
 /obj/machinery/door/firedoor/border_only{
@@ -4478,23 +4117,19 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
 /obj/effect/turf_decal/spline/fancy/transparent/solgovblue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/corner{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "XO" = (
-/obj/structure/bed,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
@@ -4502,8 +4137,7 @@
 	color = "#4d362c";
 	dir = 10
 	},
-/obj/structure/curtain/cloth,
-/obj/item/bedsheet/solfed,
+/obj/machinery/washing_machine,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "XT" = (
@@ -4521,51 +4155,34 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/janitor)
 "XY" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 10
 	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
+/obj/structure/sign/poster/clip/enlist{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "XZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/airlock/solgov{
-	dir = 4;
-	name = "Bridge";
-	req_one_access = list(20,41)
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/mono/dark,
-/area/ship/bridge)
-"Yl" = (
-/obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/corner_techfloor_grid{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/storage)
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
 "Yq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4577,15 +4194,15 @@
 	location = "Crew Quarters";
 	name = "navigation beacon"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -4603,90 +4220,48 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"YA" = (
-/obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 10
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"YD" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/rice,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/soymilk,
-/obj/item/reagent_containers/condiment/soymilk,
-/obj/machinery/airalarm/directional/north,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/storage/box/ingredients/fruity,
-/obj/effect/turf_decal/siding/wood{
-	color = "#5d241e";
-	dir = 5
-	},
-/turf/open/floor/wood/mahogany,
-/area/ship/crew/canteen/kitchen)
 "YL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/window/brigdoor/southright{
-	req_one_access = list(1,10)
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 6
 	},
-/obj/effect/turf_decal/corner/opaque/solgovgold/half,
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/warning,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "YN" = (
 /obj/structure/sign/number/nine{
 	dir = 1;
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "YV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "Operations"
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/turretid/ship{
-	pixel_y = -27;
-	id = "tomahawk_turrets"
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
 	},
 /turf/open/floor/wood,
-/area/ship/bridge)
+/area/ship/hallway/central)
 "YZ" = (
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/item/bedsheet/double/solgov{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/structure/bed/double{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/belt/medical/paramedic,
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/structure/curtain/cloth/purpl,
+/turf/open/floor/carpet/royalblue/airless,
+/area/ship/bridge)
 "Za" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 4
@@ -4695,34 +4270,33 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Zf" = (
-/obj/structure/table/wood/fancy/purple,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 9
+/obj/effect/turf_decal/corner/opaque/cybersunteal/border{
+	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/light/small/directional/west,
-/obj/item/desk_flag/solfed{
-	pixel_x = -9;
-	pixel_y = 11
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/item/folder/solfed{
-	pixel_x = 11;
-	pixel_y = -1
+/obj/machinery/power/apc/auto_name/directional/north{
+	pixel_x = -5;
+	pixel_y = 27
 	},
-/obj/item/pen/solfed,
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/machinery/light_switch{
+	pixel_x = 10;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Zg" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Zk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4736,28 +4310,17 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Zn" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 20;
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/spline/fancy/wood{
+/obj/structure/chair/office/purple{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ship/crew/crewtwo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Zq" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -4781,90 +4344,94 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
-"Zu" = (
-/obj/machinery/fax/solgov,
-/obj/structure/table/wood/fancy/purple,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ship/crew/office)
 "Zy" = (
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Zz" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/lighter/zippo/engraved{
+	pixel_y = 8;
+	pixel_x = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
+/obj/item/storage/fancy/cigarettes/cigpack_carp{
+	pixel_y = 7;
+	pixel_x = -4
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_x = -25
+/obj/item/storage/ashtray/glass{
+	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/ridged,
-/area/ship/hallway/port)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"ZJ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D5A66E"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/ship/crew)
 "ZK" = (
-/obj/structure/bed,
-/obj/item/bedsheet/grey,
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/turf/open/floor/plasteel/white,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/security/prison)
 "ZL" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/fluff/hedge/opaque{
+	pixel_y = 4
 	},
-/obj/structure/chair/wood{
+/obj/effect/turf_decal/spline/fancy/wood/three_quarters{
+	layer = 5
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"ZM" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
+"ZN" = (
+/obj/structure/sign/poster/official/no_erp{
+	pixel_y = 30
+	},
+/obj/structure/sign/flag/solfed/directional/west,
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
-	color = "#2e211e";
-	dir = 8
-	},
-/turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
-"ZM" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
+	color = "#D5A66E";
 	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/ship/storage)
-"ZN" = (
-/obj/structure/fluff/hedge/opaque,
-/obj/effect/turf_decal/spline/fancy/wood{
-	dir = 5
 	},
 /turf/open/floor/wood,
-/area/ship/crew/office)
+/area/ship/crew)
 "ZO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
-/obj/structure/chair/office/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/sign/poster/official/moth/epi{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/turf/open/floor/carpet/royalblue/airless,
+/area/ship/bridge)
 "ZP" = (
 /obj/structure/sign/number/four{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
 "ZS" = (
 /obj/effect/turf_decal/techfloor/orange{
@@ -4941,8 +4508,8 @@ PX
 PX
 PX
 PX
-PX
-jy
+ct
+Jo
 mZ
 ap
 Ou
@@ -4952,15 +4519,15 @@ WE
 Yy
 hf
 ck
-jy
-PX
+gA
+Fm
 PX
 "}
 (5,1,1) = {"
 PX
 PX
 PX
-iH
+xD
 jy
 Rf
 Wq
@@ -4972,7 +4539,7 @@ TA
 Tv
 FN
 jy
-iH
+xD
 PX
 "}
 (6,1,1) = {"
@@ -4981,7 +4548,7 @@ PX
 PX
 jy
 jy
-vL
+jy
 jy
 pT
 Oq
@@ -4997,12 +4564,12 @@ PX
 (7,1,1) = {"
 PX
 PX
-bQ
-az
+PX
+ut
 YZ
 MG
 jy
-wN
+jy
 FL
 Db
 FU
@@ -5010,13 +4577,13 @@ jy
 Ki
 ge
 LB
-rc
-bQ
+JQ
+PX
 "}
 (8,1,1) = {"
 PX
 PX
-ct
+PX
 kY
 Nv
 ZO
@@ -5027,63 +4594,63 @@ jy
 jy
 jy
 Iw
-gA
+ge
 nO
 vo
-Gw
+PX
 "}
 (9,1,1) = {"
 PX
 PX
-cQ
-az
+fj
+ut
 ly
 hT
 bP
 ZK
 pZ
-bP
+RA
 ds
-bP
-rc
+AK
+JQ
 to
-rc
-rc
-HD
+JQ
+JQ
+VD
 "}
 (10,1,1) = {"
 PX
 PX
-az
+ut
 ut
 lQ
 VP
-bP
-fV
+AK
+AK
 kr
-Sj
+Aw
 XY
-bP
+AK
 je
 yg
 Fr
 XO
-rc
+JQ
 "}
 (11,1,1) = {"
 PX
 PX
-dl
+tC
 Ez
 vm
 PS
-bP
+AK
 rm
 LG
-LG
+qB
 Kw
-bP
-Is
+UO
+AK
 tl
 Zy
 vE
@@ -5096,17 +4663,17 @@ az
 kF
 FQ
 nF
-bP
-qB
-hj
-RO
-Aw
-bP
-zy
+AK
+zG
+bQ
+Gw
+rz
+cQ
+AK
 Yq
 Zq
 sb
-rc
+JQ
 "}
 (13,1,1) = {"
 PX
@@ -5115,70 +4682,70 @@ dl
 Eu
 OM
 sL
-bP
-zG
-Fm
+AK
+vL
+Aw
 DV
 jl
-bP
-Qy
+Al
+AK
 Sz
-Qy
-Qy
-yY
+Jv
+Jv
+Jv
 "}
 (14,1,1) = {"
 PX
 PX
-az
+ut
 fM
 xV
 wv
-bP
+AK
 qj
 IO
 YL
-rz
-bP
+IO
+xi
 AK
 ny
-EI
+no
 mi
-Qy
+Jv
 "}
 (15,1,1) = {"
 PX
-an
-az
+PX
+ut
 xs
-az
+xs
 CC
-bP
-Eh
+AK
+AK
 LK
 Gu
 kp
-bP
-dK
+AK
+fg
 NI
-Cr
+fO
 nh
-Qy
+Jv
 "}
 (16,1,1) = {"
-dh
-SU
-Zz
-Ui
-xD
-Ba
-bP
-Ci
-xy
-zR
-re
-bP
-YD
+PX
+PX
+Jv
+iH
+eR
+lG
+GJ
+LE
+fO
+hG
+fO
+eR
+GJ
 Da
 nm
 UJ
@@ -5186,77 +4753,77 @@ pA
 "}
 (17,1,1) = {"
 PX
-Re
-bC
-bC
+PX
+Jv
+Jv
 qh
 SD
-rf
-rf
-SZ
-rf
+df
+yA
+hD
+hj
 FK
-rf
-rf
+vG
+Bh
 FB
-rf
-rf
+Jk
+Jv
 Jf
 "}
 (18,1,1) = {"
 PX
 PX
 PX
-pv
+so
 JT
 SH
-CN
+so
 xu
 Ac
 nA
 uf
 oe
-CN
-no
-yG
-EH
+En
+En
+En
+En
 PX
 "}
 (19,1,1) = {"
 PX
 PX
 PX
-pv
+so
 Ah
 tO
-UO
-Bh
+so
+so
 su
-UD
+Hp
 Ef
-TX
-UO
+En
+En
 Ii
 lM
-EH
+En
 PX
 "}
 (20,1,1) = {"
 PX
 PX
 PX
-bC
+pv
 nQ
 bJ
-rf
-QJ
+Qy
+so
 ZL
-PK
-YA
+UH
+jP
 En
-En
-En
-En
+aO
+pi
+LZ
 En
 PX
 "}
@@ -5264,17 +4831,17 @@ PX
 PX
 PX
 PX
-pv
+so
 jK
 Kk
 rk
 so
 NL
-Wc
-yO
+wN
+hR
 En
 Zf
-xO
+Zg
 Py
 nf
 PX
@@ -5285,31 +4852,31 @@ PX
 PX
 pv
 Cs
-kM
+hH
 rf
 zd
-ar
-Hp
-pi
-En
+xy
 bn
-Zg
+Go
+bC
+Wa
+CN
 NS
-nf
+En
 PX
 "}
 (23,1,1) = {"
 PX
 PX
 PX
-bC
+so
 xQ
 hH
-rf
+TX
 US
 aU
 uM
-Go
+aU
 qL
 TG
 Zn
@@ -5322,94 +4889,94 @@ PX
 PX
 PX
 pv
-JT
+EH
 Rx
 nP
-Ig
+so
 UU
 UF
-df
-Lb
+YV
 En
+oD
+xO
+yO
 En
-En
-nf
 PX
 "}
 (25,1,1) = {"
 PX
 PX
 PX
-pv
+so
 MT
 jw
-rf
-ov
-fY
+UD
+so
+Wi
 eg
 ah
-Jo
-SP
+En
+En
 TT
-oH
-GJ
+En
+En
 PX
 "}
 (26,1,1) = {"
 PX
 PX
-cQ
-bC
-aP
-hR
-Jv
-Jv
-Jv
+fj
+so
+so
+so
+so
+so
+dK
 XZ
-Jv
-Jv
+SP
+JQ
 bx
-xi
+oo
 AS
-Jm
-HD
+JQ
+VD
 "}
 (27,1,1) = {"
 PX
 PX
 Wm
-xX
-Ul
+oj
+LO
 vJ
-Jv
-Hm
+Is
+Cp
 Lf
 OF
-RA
-Jv
-Zu
+HD
+aP
+BG
 lK
-aO
+ZJ
 zN
-Jm
+JQ
 "}
 (28,1,1) = {"
 PX
 PX
 Nk
 xX
-LO
+ZM
 oY
-Jv
-LZ
+kM
+MJ
 zS
 BJ
 YV
-Jv
+JQ
 ZN
 Ip
-BG
-oD
+dg
+WP
 rE
 "}
 (29,1,1) = {"
@@ -5421,13 +4988,13 @@ ZM
 lH
 Jv
 Jv
-SO
-Jk
-bI
-Jv
-Jm
-Jm
-Jm
+gR
+Zz
+Ej
+JQ
+JQ
+JQ
+JQ
 JQ
 ca
 "}
@@ -5440,9 +5007,9 @@ Za
 Mp
 li
 Jv
-Al
-Al
-Al
+Jv
+Jv
+Jv
 Jv
 Li
 ko
@@ -5457,15 +5024,15 @@ YN
 Ih
 BC
 WY
-Yl
+Ul
 Vp
-hD
+EY
 vs
 EY
 ej
-Cp
+vs
 To
-eR
+vs
 QB
 iM
 "}
@@ -5474,7 +5041,7 @@ PX
 PX
 dm
 vK
-wY
+BC
 zD
 pm
 mL
@@ -5484,7 +5051,7 @@ kz
 Wl
 rZ
 JF
-fO
+EY
 Wu
 ZP
 "}
@@ -5511,57 +5078,57 @@ mt
 PX
 PX
 eU
-GC
-GC
+nE
+nE
 Os
 Ae
-GC
+nE
 tn
 De
 pC
-bD
-bD
+LN
+LN
 iD
-MJ
-bD
+LN
+LN
 aZ
 "}
 (35,1,1) = {"
 PX
 PX
 PX
-GC
+nE
 QM
 Ma
 oC
-GC
+nE
 Qp
 zL
 qI
-bD
+LN
 HK
 RT
 Zs
-bD
+LN
 PX
 "}
 (36,1,1) = {"
 PX
 PX
 PX
-GC
+nE
 RI
 dS
 UY
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 Jp
 cY
 la
-bD
+LN
 PX
 "}
 (37,1,1) = {"
@@ -5569,17 +5136,17 @@ PX
 PX
 PX
 nE
-GC
+nE
 Sk
 UY
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 qq
 VA
-bD
+LN
 LN
 PX
 "}
@@ -5588,17 +5155,17 @@ PX
 PX
 PX
 PX
-GC
+nE
 wf
 qd
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 Rz
 em
-bD
+LN
 PX
 PX
 "}
@@ -5608,15 +5175,15 @@ PX
 PX
 PX
 Hh
-GC
+nE
 xb
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 XT
-bD
+LN
 ti
 PX
 PX
@@ -5627,15 +5194,15 @@ PX
 PX
 PX
 PX
-GC
+nE
 gT
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 QS
-bD
+LN
 PX
 PX
 PX
@@ -5648,11 +5215,11 @@ PX
 PX
 eU
 Qz
-GC
+nE
 PX
 PX
 PX
-bD
+LN
 xp
 aZ
 PX

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -29,15 +29,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"az" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/poddoor/shutters{
-	id = "bridge";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "aO" = (
 /obj/structure/closet/secure_closet{
 	icon_door = "med_secure";
@@ -97,12 +88,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "bn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -135,6 +120,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
 /area/ship/crew)
 "bC" = (
@@ -192,7 +178,6 @@
 /area/ship/crew)
 "cg" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/industrial/traffic,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -201,6 +186,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/colored{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "ck" = (
@@ -222,7 +210,7 @@
 /obj/item/paper/crumpled{
 	default_raw_text = "Для подачи воздуха из атмосферы достаточно включить первый скрабер"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
 	dir = 6
 	},
 /turf/open/floor/plasteel/tech,
@@ -248,6 +236,7 @@
 /obj/item/ammo_box/magazine/gar,
 /obj/item/ammo_box/magazine/gar,
 /obj/item/ammo_box/magazine/gar,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "cY" = (
@@ -296,11 +285,15 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 12
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "dl" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "bridge";
 	name = "Blast Shutters"
@@ -413,8 +406,8 @@
 /area/ship/engineering)
 "eR" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#543C30"
+	color = "#4d362c";
+	dir = 9
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
@@ -472,7 +465,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew)
 "gA" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering)
 "gR" = (
@@ -518,9 +511,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -577,6 +567,7 @@
 	color = "#D5A66E"
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/light/colored,
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "hT" = (
@@ -596,6 +587,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "iD" = (
@@ -685,6 +677,9 @@
 /obj/structure/sign/poster/solgov/terra{
 	pixel_y = 31
 	},
+/obj/machinery/light/colored{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "jP" = (
@@ -715,19 +710,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kp" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/ship/security/prison)
+/turf/open/floor/wood/ebony,
+/area/ship/crew/crewtwo)
 "kr" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 5
@@ -764,18 +748,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
-"kY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
 "la" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -813,6 +785,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
+"ln" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/light/colored,
+/turf/open/floor/wood,
+/area/ship/hallway/central)
 "ly" = (
 /obj/item/clothing/suit/armor/vest/solgov/captain,
 /obj/item/clothing/under/solgov/formal/captain,
@@ -836,7 +815,7 @@
 /obj/item/clothing/neck/cloak/solgovcap,
 /obj/item/storage/backpack/satchel/leather,
 /obj/item/storage/box/ammo/ferroslug,
-/obj/item/clothing/glasses/hud/health/night,
+/obj/item/clothing/glasses/hud/health/sunglasses,
 /obj/item/clothing/head/beret/solgov,
 /obj/item/radio/headset/solgov/alt/captain,
 /obj/item/storage/belt/military/assault,
@@ -844,7 +823,6 @@
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	},
 /obj/item/clothing/shoes/combat,
-/obj/item/sharpener,
 /obj/structure/sign/poster/bay/bay_41{
 	pixel_y = 32
 	},
@@ -867,13 +845,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/techfloor,
+/obj/machinery/light/colored,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "lK" = (
@@ -892,14 +867,8 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "lQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/bridge)
+/area/ship/crew/crewtwo)
 "mi" = (
 /obj/structure/chair/comfy/beige/old/directional/east,
 /obj/effect/turf_decal/siding/wood{
@@ -909,8 +878,11 @@
 	dir = 8;
 	color = "#543C30"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "mt" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
@@ -963,8 +935,9 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#543c30"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "nm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#543C30"
@@ -972,16 +945,18 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "no" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
 	color = "#543C30"
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -989,15 +964,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1;
 	color = "#543C30"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "nA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1036,6 +1011,7 @@
 /obj/structure/sign/poster/solgov/paperwork{
 	pixel_y = -32
 	},
+/obj/machinery/light/colored/blue,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "nO" = (
@@ -1100,6 +1076,9 @@
 	color = "#D5A66E";
 	dir = 8
 	},
+/obj/machinery/light/colored{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "ox" = (
@@ -1144,6 +1123,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "oY" = (
@@ -1181,10 +1161,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "pv" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
+	id = "tomahawk_kitchen";
 	name = "Blast Shutters"
 	},
 /turf/open/floor/plasteel/dark,
@@ -1192,7 +1171,7 @@
 "pA" = (
 /obj/structure/sign/solfed,
 /turf/closed/wall/mineral/plastitanium,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "pC" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -1256,12 +1235,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "qh" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5;
 	color = "#543C30"
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "qj" = (
@@ -1282,9 +1260,6 @@
 /obj/item/clothing/mask/balaclava/combat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/item/encryptionkey/solgov{
 	pixel_x = -5;
@@ -1299,6 +1274,9 @@
 	dir = 8
 	},
 /obj/structure/sign/flag/solfed/directional/west,
+/obj/machinery/light/colored/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qq" = (
@@ -1316,12 +1294,12 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sol_cops_bay";
+	id = "tomahawk_cargo";
 	name = "Cargo Bay Blast Door"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 1;
-	id = "sgc_holocargo"
+	id = "tomahawk_cargo_halo"
 	},
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
@@ -1339,6 +1317,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"qX" = (
+/obj/machinery/light/colored{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/cargo)
 "rf" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner{
 	dir = 8
@@ -1397,9 +1381,6 @@
 /obj/item/clothing/mask/balaclava/combat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/item/encryptionkey/solgov{
 	pixel_x = -5;
@@ -1412,6 +1393,9 @@
 /obj/item/clothing/head/helmet/solfed/m11,
 /obj/effect/turf_decal/corner_techfloor_gray/full{
 	dir = 8
+	},
+/obj/machinery/light/colored/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
@@ -1432,6 +1416,9 @@
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/light/colored{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
@@ -1491,7 +1478,7 @@
 /obj/machinery/button/door{
 	dir = 1;
 	pixel_y = -34;
-	id = "armory"
+	id = "tomahawk_armory"
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -1510,18 +1497,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/light/colored{
+	dir = 1
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "tn" = (
 /obj/machinery/button/door{
-	id = "sol_cops_bay";
+	id = "tomahawk_cargo";
 	name = "Cargo Bay Doors";
 	pixel_y = 25
 	},
 /obj/machinery/button/shieldwallgen{
 	pixel_y = 23;
 	pixel_x = 9;
-	id = "sgc_holocargo"
+	id = "tomahawk_cargo_halo"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -1566,8 +1556,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "tC" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "bridge";
 	name = "Blast Shutters"
@@ -1636,7 +1625,6 @@
 /area/ship/engineering)
 "vm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 8
 	},
@@ -1655,14 +1643,13 @@
 	pixel_y = 3;
 	pixel_x = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "vo" = (
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
+	id = "tomahawk_sleeper";
 	name = "Blast Shutters"
 	},
 /turf/open/floor/plating,
@@ -1740,9 +1727,6 @@
 /obj/item/clothing/mask/balaclava/combat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/item/encryptionkey/solgov{
 	pixel_x = -5;
@@ -1770,6 +1754,9 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
+/obj/machinery/light/colored{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "wh" = (
@@ -1777,11 +1764,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "wv" = (
@@ -1872,6 +1859,7 @@
 /obj/item/storage/box/ammo/ferrolance,
 /obj/item/storage/box/ammo/ferrolance,
 /obj/item/storage/box/ammo/ferrolance,
+/obj/machinery/light/colored/red,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "xk" = (
@@ -1897,8 +1885,7 @@
 /turf/open/floor/plating,
 /area/ship/crew/janitor)
 "xs" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
 	id = "bridgetohallway";
 	name = "Blast Shutters";
@@ -1920,6 +1907,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
+/area/ship/hallway/central)
+"xz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/machinery/light/colored{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "xD" = (
 /obj/structure/sign/solfed,
@@ -1957,10 +1954,14 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/solgov/sonnensoldner{
-	pixel_y = 31
-	},
 /obj/effect/decal/cleanable/confetti,
+/obj/machinery/light/colored{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	pixel_y = 23;
+	id = "tomahawk_kitchen"
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "xV" = (
@@ -1973,18 +1974,14 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "xX" = (
-/obj/structure/ore_box,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/open/floor/plasteel/tech,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "yg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
@@ -1992,6 +1989,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/button{
+	pixel_y = 23;
+	id = "tomahawk_sleeper"
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -2074,9 +2078,6 @@
 /obj/item/clothing/mask/balaclava/combat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
-/obj/effect/turf_decal/corner/opaque/solgovblue{
-	dir = 10
-	},
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/item/encryptionkey/solgov{
 	pixel_x = -5;
@@ -2101,7 +2102,7 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sol_cops_bay";
+	id = "tomahawk_cargo";
 	name = "Cargo Bay Blast Door"
 	},
 /turf/open/floor/engine/hull,
@@ -2244,7 +2245,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "BC" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue/mono,
 /turf/open/floor/plasteel/tech,
@@ -2293,6 +2294,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Cp" = (
@@ -2382,9 +2386,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Da" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -2398,8 +2399,11 @@
 	color = "#543C30";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "Db" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -2538,10 +2542,8 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Fm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/layer4{
-	dir = 1;
-	filter_types = list("n2","o2");
-	name = "Environment to Air"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer1{
+	dir = 1
 	},
 /turf/open/floor/engine/hull,
 /area/ship/external)
@@ -2551,6 +2553,9 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Fu" = (
@@ -2596,7 +2601,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "FE" = (
 /obj/structure/flora/bigplant{
 	pixel_y = 1;
@@ -2671,11 +2676,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
@@ -2701,11 +2706,6 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Gu" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Blast Shutters";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -2719,6 +2719,19 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Blast Shutters";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -2740,6 +2753,14 @@
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
+"GZ" = (
+/obj/docking_port/stationary{
+	dwidth = 15;
+	height = 15;
+	width = 30
+	},
+/turf/template_noop,
+/area/ship/external)
 "Hh" = (
 /obj/structure/sign/solfed,
 /turf/closed/wall/mineral/plastitanium,
@@ -2793,6 +2814,9 @@
 	dir = 1
 	},
 /obj/machinery/computer/cargo,
+/obj/machinery/light/colored{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Ii" = (
@@ -2909,12 +2933,17 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	dir = 4;
-	pixel_x = 28
+/obj/machinery/light/colored,
+/obj/machinery/power/apc/auto_name/directional/east{
+	pixel_y = 9
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -5
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/closed/wall/mineral/plastitanium,
@@ -3048,7 +3077,7 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "LB" = (
@@ -3063,6 +3092,9 @@
 	color = "#543C30"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/colored{
+	dir = 8
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/hallway/central)
 "LG" = (
@@ -3072,18 +3104,26 @@
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "LK" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "armory";
-	name = "Blast Shutters";
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/space/basic,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "tomahawk_armory";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/ship/security/prison)
 "LN" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -3156,8 +3196,8 @@
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
@@ -3166,13 +3206,23 @@
 /obj/structure/sign/poster/solgov/luna{
 	pixel_x = -29
 	},
-/turf/open/floor/carpet/royalblue/airless,
+/obj/machinery/light/colored/blue{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/inherit{
+	layer = 2.4
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/suit/space/hardsuit/solgov,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "MJ" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "MN" = (
@@ -3185,14 +3235,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
-	dir = 6
-	},
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "MT" = (
@@ -3205,11 +3255,15 @@
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "Nk" = (
-/obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Nl" = (
 /obj/structure/sign/number/eight{
@@ -3220,7 +3274,7 @@
 /area/ship/storage)
 "Nv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet/royalblue/airless,
+/turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "NI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3237,7 +3291,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "NL" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
@@ -3256,6 +3310,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 10;
 	pixel_y = 23
+	},
+/obj/machinery/light/colored{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -3285,10 +3342,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Os" = (
@@ -3389,6 +3446,11 @@
 "PX" = (
 /turf/template_noop,
 /area/template_noop)
+"Qe" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
 "Qp" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3397,12 +3459,12 @@
 	},
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "sol_cops_bay";
+	id = "tomahawk_cargo";
 	name = "Cargo Bay Blast Door"
 	},
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 2;
-	id = "sgc_holocargo"
+	id = "tomahawk_cargo_halo"
 	},
 /turf/open/floor/engine/hull,
 /area/ship/cargo)
@@ -3506,6 +3568,9 @@
 /obj/item/clothing/suit/space/hardsuit/solgov,
 /obj/item/tank/internals/emergency_oxygen/double,
 /obj/item/clothing/mask/gas/sechailer,
+/obj/machinery/light/colored/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "RI" = (
@@ -3625,7 +3690,7 @@
 	name = "Cafeteria"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "SD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4;
@@ -3695,7 +3760,6 @@
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 20;
@@ -3706,6 +3770,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "TA" = (
@@ -3726,10 +3791,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/green/hidden/layer4,
 /obj/item/stock_parts/micro_laser/high,
 /obj/item/stock_parts/capacitor/adv,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "TG" = (
@@ -3796,9 +3861,6 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "UF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3809,7 +3871,12 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet/royalblue,
 /area/ship/hallway/central)
 "UH" = (
@@ -3837,8 +3904,11 @@
 	dir = 6;
 	color = "#543C30"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood/ebony,
-/area/ship/hallway/central)
+/area/ship/crew/crewtwo)
 "UO" = (
 /obj/effect/turf_decal/corner_techfloor_gray/full,
 /obj/structure/guncloset{
@@ -3848,6 +3918,7 @@
 /obj/item/gun/ballistic/automatic/powered/gauss/gar,
 /obj/item/gun/ballistic/automatic/powered/gauss/gar,
 /obj/item/gun/ballistic/automatic/powered/gauss/gar,
+/obj/machinery/light/colored/red,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "US" = (
@@ -3864,9 +3935,11 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "UU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
+	dir = 1
+	},
+/obj/machinery/light/colored{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -3894,6 +3967,9 @@
 	dir = 4;
 	name = "Engine Room";
 	req_one_access = list(10)
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
@@ -3947,13 +4023,12 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "VF" = (
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
-/turf/open/floor/plasteel/tech,
+/turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
 "VP" = (
 /obj/item/radio/intercom/directional/south,
@@ -4045,14 +4120,13 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Wt" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor/shutters{
-	id = "space_cops_windows";
-	name = "Blast Shutters"
+/obj/machinery/door/airlock/multi_tile/solgov,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/ship/crew)
+/turf/open/floor/wood/ebony,
+/area/ship/crew/crewtwo)
 "Wu" = (
 /obj/structure/closet/crate/large,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4096,6 +4170,15 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew)
+"WT" = (
+/obj/docking_port/mobile{
+	dir = 4;
+	launch_status = 0;
+	preferred_direction = 4;
+	port_direction = 2
+	},
+/turf/template_noop,
+/area/ship/external)
 "WY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4125,6 +4208,9 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/colored{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
@@ -4201,8 +4287,9 @@
 	color = "#4d362c";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -4252,7 +4339,6 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "YZ" = (
-/obj/machinery/light/small/directional/west,
 /obj/item/bedsheet/double/solgov{
 	dir = 4
 	},
@@ -4260,7 +4346,7 @@
 	dir = 4
 	},
 /obj/structure/curtain/cloth/purpl,
-/turf/open/floor/carpet/royalblue/airless,
+/turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "Za" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
@@ -4333,6 +4419,9 @@
 	color = "#4d362c";
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Zs" = (
@@ -4374,8 +4463,27 @@
 	icon_state = "0-8"
 	},
 /obj/structure/table/wood,
+/obj/machinery/light/colored{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
+"ZF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_x = 25;
+	req_access = null
+	},
+/obj/machinery/light/small/directional/east{
+	pixel_x = 32;
+	pixel_y = 10
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/storage)
 "ZJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8;
@@ -4425,7 +4533,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/carpet/royalblue/airless,
+/turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "ZP" = (
 /obj/structure/sign/number/four{
@@ -4584,7 +4692,7 @@ PX
 PX
 PX
 PX
-kY
+dl
 Nv
 ZO
 FE
@@ -4596,7 +4704,7 @@ jy
 Iw
 ge
 nO
-vo
+JQ
 PX
 "}
 (9,1,1) = {"
@@ -4623,7 +4731,7 @@ PX
 PX
 ut
 ut
-lQ
+ut
 VP
 AK
 AK
@@ -4654,12 +4762,12 @@ AK
 tl
 Zy
 vE
-Wt
+vo
 "}
 (12,1,1) = {"
 PX
 PX
-az
+dl
 kF
 FQ
 nF
@@ -4690,9 +4798,9 @@ jl
 Al
 AK
 Sz
-Jv
-Jv
-Jv
+lQ
+lQ
+lQ
 "}
 (14,1,1) = {"
 PX
@@ -4711,7 +4819,7 @@ AK
 ny
 no
 mi
-Jv
+lQ
 "}
 (15,1,1) = {"
 PX
@@ -4724,13 +4832,13 @@ AK
 AK
 LK
 Gu
-kp
+LK
 AK
 fg
 NI
-fO
+kp
 nh
-Jv
+lQ
 "}
 (16,1,1) = {"
 PX
@@ -4744,8 +4852,8 @@ LE
 fO
 hG
 fO
-eR
-GJ
+xz
+Wt
 Da
 nm
 UJ
@@ -4767,7 +4875,7 @@ vG
 Bh
 FB
 Jk
-Jv
+lQ
 Jf
 "}
 (18,1,1) = {"
@@ -4895,7 +5003,7 @@ nP
 so
 UU
 UF
-YV
+ln
 En
 oD
 xO
@@ -4962,8 +5070,8 @@ JQ
 "}
 (28,1,1) = {"
 PX
-PX
-Nk
+Wm
+Wm
 xX
 ZM
 oY
@@ -4980,11 +5088,11 @@ WP
 rE
 "}
 (29,1,1) = {"
-PX
-PX
-TH
+GZ
+Qe
+ZF
 BM
-ZM
+Nk
 lH
 Jv
 Jv
@@ -5000,8 +5108,8 @@ ca
 "}
 (30,1,1) = {"
 PX
-PX
-Nl
+Wm
+TH
 VF
 Za
 Mp
@@ -5020,15 +5128,15 @@ ky
 (31,1,1) = {"
 PX
 PX
-YN
+Nl
 Ih
 BC
 WY
 Ul
 Vp
-EY
+qX
 vs
-EY
+qX
 ej
 vs
 To
@@ -5039,7 +5147,7 @@ iM
 (32,1,1) = {"
 PX
 PX
-dm
+YN
 vK
 BC
 zD
@@ -5058,7 +5166,7 @@ ZP
 (33,1,1) = {"
 PX
 PX
-Wm
+dm
 qc
 Lp
 Fu
@@ -5122,7 +5230,7 @@ dS
 UY
 nE
 PX
-PX
+WT
 PX
 LN
 Jp

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -73,7 +73,7 @@
 	dir = 6;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "bn" = (
 /obj/structure/cable{
@@ -149,7 +149,7 @@
 /obj/structure/sign/number/one{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew)
 "cg" = (
 /obj/effect/turf_decal/techfloor{
@@ -273,7 +273,7 @@
 	color = "#c48d26";
 	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "ds" = (
 /obj/effect/turf_decal/corner_techfloor_gray/full,
@@ -339,7 +339,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "em" = (
 /obj/structure/toilet{
@@ -391,7 +391,7 @@
 	dir = 5;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "fc" = (
 /obj/structure/cable{
@@ -406,14 +406,14 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -8
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/prison)
 "fj" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 9;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "fM" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
@@ -441,7 +441,7 @@
 /area/ship/crew)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden/layer1,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "gR" = (
 /obj/structure/chair/comfy/red,
@@ -604,14 +604,14 @@
 /obj/structure/sign/number/eight{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "je" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
 	dir = 9
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/prison)
 "jl" = (
 /obj/structure/cable{
@@ -630,7 +630,7 @@
 /turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen/kitchen)
 "jy" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "jK" = (
 /obj/structure/chair/plastic{
@@ -714,7 +714,7 @@
 /obj/structure/sign/number/nine{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "kz" = (
 /obj/structure/cable{
@@ -847,10 +847,11 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
+/obj/machinery/light/colored/white,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "lQ" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/crewtwo)
 "mi" = (
 /obj/structure/chair/comfy/beige/old/directional/east,
@@ -934,7 +935,7 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = 5
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/medical)
 "nh" = (
 /obj/structure/table/wood,
@@ -1040,7 +1041,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "nE" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/fore)
 "nF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1224,7 +1225,7 @@
 /area/ship/crew/canteen/kitchen)
 "pA" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/crewtwo)
 "pC" = (
 /obj/machinery/camera/autoname{
@@ -1479,7 +1480,7 @@
 /area/ship/security/prison)
 "rw" = (
 /obj/structure/sign/poster/official/cleanliness,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "rz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -1489,7 +1490,7 @@
 /area/ship/security/prison)
 "rE" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew)
 "rK" = (
 /obj/item/storage/belt/military/solfed,
@@ -1505,8 +1506,9 @@
 /obj/item/sign/flag/solfed,
 /obj/item/melee/energy/sword/saber/knife,
 /obj/item/clothing/gloves/combat/solfed,
-/obj/structure/closet/wall/blue/directional/west,
-/obj/item/tank/jetpack/suit,
+/obj/structure/closet/wall/blue/directional/west{
+	req_access = list(57)
+	},
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold{
 	dir = 8
 	},
@@ -1551,7 +1553,7 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "so" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/canteen/kitchen)
 "su" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -1594,7 +1596,7 @@
 /area/ship/bridge)
 "ti" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "tl" = (
 /obj/structure/cable{
@@ -1697,7 +1699,7 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "ut" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "uM" = (
 /obj/structure/cable{
@@ -2025,7 +2027,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "xp" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "xs" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
@@ -2063,7 +2065,7 @@
 /area/ship/hallway/central)
 "xD" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "xF" = (
 /obj/structure/flora/ausbushes/brflowers{
@@ -2073,7 +2075,9 @@
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/ship/crew/law_office)
 "xO" = (
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border{
@@ -2117,7 +2121,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "yg" = (
 /obj/structure/cable{
@@ -2163,6 +2167,7 @@
 /obj/item/reagent_containers/pill/stimulant,
 /obj/item/reagent_containers/pill/stimulant,
 /obj/item/reagent_containers/pill/stimulant,
+/obj/machinery/light/colored/white,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "zd" = (
@@ -2352,7 +2357,7 @@
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "AK" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/prison)
 "AS" = (
 /obj/structure/closet/cabinet,
@@ -2657,7 +2662,7 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "En" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/medical)
 "Eu" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/line{
@@ -2705,6 +2710,9 @@
 	},
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 1
+	},
+/obj/structure/sign/poster/solgov/mars{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
@@ -2960,7 +2968,7 @@
 /area/ship/external)
 "Hh" = (
 /obj/structure/sign/solfed,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/maintenance/fore)
 "Hp" = (
 /obj/structure/cable{
@@ -3033,7 +3041,6 @@
 /obj/machinery/stasis{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Ip" = (
@@ -3127,7 +3134,7 @@
 	dir = 6;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "Jk" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3149,7 +3156,7 @@
 /area/ship/crew/crewtwo)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "Jp" = (
 /obj/structure/sign/poster/solgov/sonnensoldner{
@@ -3165,7 +3172,7 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "Jv" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hallway/central)
 "JF" = (
 /obj/structure/cable{
@@ -3190,7 +3197,7 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew/law_office)
 "JQ" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew)
 "JT" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3219,7 +3226,7 @@
 /area/ship/security/prison)
 "KX" = (
 /obj/structure/sign/poster/contraband/hacking_guide,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/engineering)
 "KZ" = (
 /obj/structure/cable{
@@ -3258,6 +3265,7 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue/three_quarters{
 	dir = 4
 	},
+/obj/item/clothing/suit/space/hardsuit/solgov,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/law_office)
 "Lp" = (
@@ -3493,7 +3501,7 @@
 	color = "#c48d26";
 	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "Nv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -4033,11 +4041,11 @@
 	dir = 1;
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "TT" = (
 /obj/structure/cable,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/medical)
 "TX" = (
 /obj/effect/turf_decal/trimline/opaque/solgovblue/filled/corner,
@@ -4267,7 +4275,7 @@
 	dir = 10;
 	id = "tomahawk_turrets"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/bridge)
 "VF" = (
 /obj/effect/turf_decal/techfloor{
@@ -4275,7 +4283,7 @@
 	},
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/corner,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "VP" = (
 /obj/structure/cable{
@@ -4357,7 +4365,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/law_office)
 "Wm" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "Wq" = (
 /obj/structure/cable{
@@ -4458,7 +4466,7 @@
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "XO" = (
 /obj/structure/sign/poster/contraband/random{
@@ -4484,9 +4492,7 @@
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 10
 	},
-/obj/structure/sign/poster/clip/enlist{
-	pixel_y = -32
-	},
+/obj/structure/sign/flag/solfed/directional/north,
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "XZ" = (
@@ -4567,7 +4573,7 @@
 	dir = 1;
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/storage)
 "YV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4732,7 +4738,7 @@
 /area/ship/crew)
 "ZK" = (
 /obj/machinery/light/small/directional/west,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/security/prison)
 "ZL" = (
 /obj/structure/fluff/hedge/opaque{
@@ -4783,7 +4789,7 @@
 /obj/structure/sign/number/four{
 	color = "#c48d26"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/crew/law_office)
 "ZS" = (
 /obj/effect/turf_decal/techfloor/orange{

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -1860,6 +1860,11 @@
 /obj/item/storage/box/ammo/ferrolance,
 /obj/item/storage/box/ammo/ferrolance,
 /obj/machinery/light/colored/red,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "xk" = (
@@ -2421,11 +2426,6 @@
 	},
 /obj/effect/turf_decal/techfloor{
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = -12
 	},
 /obj/machinery/space_heater,
 /obj/structure/cable{

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -2,13 +2,30 @@
 "ah" = (
 /obj/structure/fluff/hedge/opaque{
 	pixel_y = -1
+<<<<<<< Updated upstream
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
 	},
 /obj/effect/turf_decal/spline/fancy/wood/three_quarters{
 	layer = 5
+=======
 	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/railing/wood{
+	dir = 1;
+	layer = 2
+	},
+/obj/structure/railing/wood{
+	dir = 4
+>>>>>>> Stashed changes
+	},
+/obj/structure/railing/wood,
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "ap" = (
@@ -228,18 +245,23 @@
 /area/ship/security/prison)
 "cY" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
 	dir = 4
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/corner_techfloor_grid,
 /obj/effect/turf_decal/techfloor/corner,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "db" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -340,6 +362,7 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
+<<<<<<< Updated upstream
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -355,25 +378,61 @@
 /area/ship/hallway/central)
 "ej" = (
 /obj/machinery/door/firedoor/border_only{
+=======
+>>>>>>> Stashed changes
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"ej" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
+<<<<<<< Updated upstream
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/machinery/newscaster/directional/west,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "em" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/structure/toilet{
+	pixel_y = 1;
+	dir = 8;
+	pixel_x = 4
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 6
+/obj/item/newspaper{
+	pixel_x = -9
 	},
+<<<<<<< Updated upstream
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/item/newspaper{
+	pixel_x = -9;
+	pixel_y = -5
+	},
+/obj/item/newspaper{
+	pixel_y = -10;
+	pixel_x = -9
+	},
+/obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "eo" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -571,40 +630,44 @@
 /turf/open/floor/wood,
 /area/ship/bridge)
 "ia" = (
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "iD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/airlock/solgov{
-	dir = 8;
-	name = "Janitor room"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
-/area/ship/crew/janitor)
+/area/ship/crew/law_office)
 "iH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5;
@@ -627,7 +690,11 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
+<<<<<<< Updated upstream
 /area/ship/cargo)
+=======
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "je" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
@@ -673,9 +740,23 @@
 /obj/structure/fluff/hedge/opaque{
 	pixel_y = -1
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/spline/fancy/wood/three_quarters{
 	layer = 5
 	},
+=======
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/railing/wood{
+	dir = 1;
+	layer = 2
+	},
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/railing/wood,
+>>>>>>> Stashed changes
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "ko" = (
@@ -691,6 +772,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/techfloor{
 	dir = 8
 	},
@@ -698,6 +780,35 @@
 /area/ship/cargo)
 "kp" = (
 /turf/open/floor/wood/ebony,
+=======
+/obj/structure/chair/comfy/blue/old/directional/north{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"kp" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/turf/open/floor/carpet/purple,
+>>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "kr" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
@@ -711,7 +822,11 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
+<<<<<<< Updated upstream
 /area/ship/cargo)
+=======
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "kz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -720,6 +835,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+<<<<<<< Updated upstream
+=======
+/obj/effect/turf_decal/techfloor,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "kF" = (
@@ -736,17 +855,13 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "la" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/turf_decal/techfloor{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
 	dir = 6
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = -16
+/obj/structure/filingcabinet/wide{
+	dir = 8
 	},
+<<<<<<< Updated upstream
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -5
@@ -756,6 +871,11 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "li" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -868,11 +988,49 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+<<<<<<< Updated upstream
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "mt" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/cargo)
+=======
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/structure/sign/poster/contraband/shamblers_juice{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/purple,
+/area/ship/crew/crewtwo)
+"mt" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/stamp/solgov{
+	pixel_y = 5
+	},
+/obj/item/pen/solfed{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "mL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -923,26 +1081,80 @@
 	color = "#543c30"
 	},
 /obj/machinery/firealarm/directional/south,
+<<<<<<< Updated upstream
+=======
+/obj/item/candle/infinite{
+	pixel_y = 2;
+	light_on = 1;
+	pixel_x = -8;
+	layer = 3.1
+	},
+/obj/item/candle/infinite{
+	pixel_y = 2;
+	pixel_x = 10;
+	light_on = 1;
+	layer = 3.1
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "nm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	color = "#543C30"
+<<<<<<< Updated upstream
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood/ebony,
+=======
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D5A66E"
+	},
+/turf/open/floor/carpet/purple,
+>>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "no" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
 	color = "#543C30"
+<<<<<<< Updated upstream
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood/ebony,
+=======
+	},
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D5A66E"
+	},
+/turf/open/floor/carpet/purple,
+>>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "ny" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1212,7 +1424,11 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 5
 	},
+<<<<<<< Updated upstream
 /obj/structure/closet/crate/bin,
+=======
+/obj/structure/reagent_dispensers/fueltank,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "qd" = (
@@ -1235,6 +1451,7 @@
 	icon_state = "sec";
 	name = "marine locker";
 	req_access_txt = "2"
+<<<<<<< Updated upstream
 	},
 /obj/item/ammo_box/magazine/pistol556mm,
 /obj/item/ammo_box/magazine/pistol556mm,
@@ -1276,6 +1493,64 @@
 /area/ship/crew/janitor)
 "qB" = (
 /obj/machinery/autolathe,
+=======
+	},
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/belt/military/solfed,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/radio/headset/solgov/alt,
+/obj/item/clothing/under/solfed,
+/obj/item/clothing/mask/balaclava/combat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/gloves/combat/solfed,
+/obj/item/clothing/head/solfed/beret,
+/obj/item/clothing/under/solfed/camo,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/head/helmet/solfed/m11,
+/obj/effect/turf_decal/corner_techfloor_gray/full{
+	dir = 8
+	},
+/obj/structure/sign/flag/solfed/directional/west,
+/obj/machinery/light/colored/red{
+	dir = 1
+	},
+/obj/item/restraints/handcuffs/tape,
+/obj/item/melee/baton/loaded,
+/turf/open/floor/plasteel/darkredfull,
+/area/ship/security/prison)
+"qq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/airlock/solgov/glass{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"qB" = (
+/obj/machinery/autolathe,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "qI" = (
@@ -1309,6 +1584,12 @@
 /obj/machinery/light/colored{
 	dir = 8
 	},
+<<<<<<< Updated upstream
+=======
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "rf" = (
@@ -1385,6 +1666,11 @@
 /obj/machinery/light/colored/red{
 	dir = 1
 	},
+<<<<<<< Updated upstream
+=======
+/obj/item/restraints/handcuffs/tape,
+/obj/item/melee/baton/loaded,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "rw" = (
@@ -1402,6 +1688,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew)
 "rK" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -1411,14 +1698,60 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/item/storage/belt/military/solfed,
+/obj/item/gun/ballistic/automatic/pistol/solgov,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/ammo_box/magazine/pistol556mm,
+/obj/item/radio/headset/solgov/alt/captain,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/glasses/sunglasses/ballistic,
+/obj/item/storage/backpack/satchel/leather,
+/obj/item/sign/flag/solfed,
+/obj/item/melee/energy/sword/saber/knife,
+/obj/item/clothing/gloves/combat/solfed,
+/obj/structure/closet/wall/blue/directional/west,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "rZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+<<<<<<< Updated upstream
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "sb" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c";
@@ -1470,10 +1803,36 @@
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
+<<<<<<< Updated upstream
 "ti" = (
 /obj/structure/sign/solfed,
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/janitor)
+=======
+"tg" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light/colored{
+	dir = 1
+	},
+/obj/structure/sign/flag/solfed/directional/south,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"ti" = (
+/obj/structure/sign/solfed,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "tl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1481,13 +1840,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+<<<<<<< Updated upstream
 /obj/structure/table/wood,
+=======
+>>>>>>> Stashed changes
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/light/colored{
 	dir = 1
 	},
+<<<<<<< Updated upstream
+=======
+/obj/structure/sign/flag/solfed/directional/south,
+>>>>>>> Stashed changes
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "tn" = (
@@ -1647,15 +2013,39 @@
 /turf/open/floor/plating,
 /area/ship/crew)
 "vs" = (
+<<<<<<< Updated upstream
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/structure/table/wood/fancy/purple,
+/obj/item/desk_flag/solfed{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "vE" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#4d362c"
 	},
+<<<<<<< Updated upstream
 /obj/structure/curtain/cloth,
 /obj/effect/spawner/bunk_bed,
+=======
+/obj/item/kirbyplants{
+	icon_state = "plant-27";
+	pixel_y = -2;
+	layer = 4.3;
+	pixel_x = -8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-33";
+	pixel_y = -10;
+	pixel_x = 11
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "vG" = (
@@ -1699,6 +2089,11 @@
 	pixel_y = 23;
 	pixel_x = 11
 	},
+<<<<<<< Updated upstream
+=======
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/closet/crate/large,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "vL" = (
@@ -1733,6 +2128,11 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/north,
+<<<<<<< Updated upstream
+=======
+/obj/item/restraints/handcuffs/fake,
+/obj/item/melee/baton/loaded,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "wf" = (
@@ -1784,12 +2184,24 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "wD" = (
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "wM" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 9
@@ -1873,6 +2285,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "xp" = (
+<<<<<<< Updated upstream
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "space_cops_starboard_launcher";
@@ -1881,6 +2294,33 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/ship/crew/janitor)
+"xs" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "bridgetohallway";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"xu" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 5
+=======
+/obj/structure/chair/wood{
+	dir = 8
+>>>>>>> Stashed changes
+	},
+/obj/machinery/light/colored,
+/obj/structure/sign/flag/solfed/directional/north,
+/obj/effect/turf_decal/corner/transparent/solgovgold/half,
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
 "xs" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -1909,6 +2349,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8;
 	color = "#543C30"
+<<<<<<< Updated upstream
 	},
 /obj/machinery/light/colored{
 	dir = 8
@@ -1932,6 +2373,28 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+	},
+/obj/machinery/light/colored{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/ship/hallway/central)
+"xD" = (
+/obj/structure/sign/solfed,
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/engineering)
+"xF" = (
+/obj/structure/flora/ausbushes/brflowers{
+	layer = 4
+	},
+/obj/structure/railing/wood{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "xO" = (
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border{
 	dir = 4
@@ -2090,6 +2553,11 @@
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 5
 	},
+<<<<<<< Updated upstream
+=======
+/obj/item/restraints/handcuffs/tape,
+/obj/item/melee/baton/loaded,
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "zL" = (
@@ -2442,7 +2910,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/techfloor{
+<<<<<<< Updated upstream
 	dir = 4
+=======
+	dir = 6
+>>>>>>> Stashed changes
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
@@ -2526,9 +2998,13 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "ER" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
 	dir = 1
 	},
+<<<<<<< Updated upstream
 /obj/machinery/light/directional/south,
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/techfloor{
@@ -2539,6 +3015,27 @@
 "EY" = (
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"EY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Fm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer1{
 	dir = 1
@@ -2779,6 +3276,7 @@
 "Hp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+<<<<<<< Updated upstream
 	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E";
@@ -2818,6 +3316,49 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/carpet/royalblue,
+/area/ship/hallway/central)
+"HD" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/hallway/central)
+"HK" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Ih" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold,
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning,
@@ -2934,9 +3475,12 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/bridge)
 "Jk" = (
+<<<<<<< Updated upstream
 /obj/item/kirbyplants/photosynthetic{
 	icon_state = "plant-06"
 	},
+=======
+>>>>>>> Stashed changes
 /obj/effect/turf_decal/siding/wood{
 	dir = 6;
 	color = "#543C30"
@@ -2944,7 +3488,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+<<<<<<< Updated upstream
 /obj/machinery/light/colored,
+=======
+>>>>>>> Stashed changes
 /obj/machinery/power/apc/auto_name/directional/east{
 	pixel_y = 9
 	},
@@ -2960,16 +3507,22 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/engineering)
 "Jp" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/item/caution,
-/obj/item/caution,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/structure/sign/poster/solgov/sonnensoldner{
+	pixel_y = 32
 	},
+<<<<<<< Updated upstream
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Jv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/hallway/central)
@@ -2980,15 +3533,28 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/navbeacon/wayfinding/cargo{
 	name = "navigation beacon"
 	},
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "JQ" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew)
@@ -3047,6 +3613,7 @@
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Li" = (
+<<<<<<< Updated upstream
 /obj/machinery/airalarm/directional/west,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -3056,6 +3623,21 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/machinery/suit_storage_unit/inherit{
+	layer = 2.4
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Lp" = (
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 8
@@ -3138,7 +3720,11 @@
 /area/ship/security/prison)
 "LN" = (
 /turf/closed/wall/mineral/plastitanium,
+<<<<<<< Updated upstream
 /area/ship/crew/janitor)
+=======
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "LO" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -3301,6 +3887,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light/colored{
+	dir = 1
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "NL" = (
@@ -3418,7 +4007,10 @@
 	color = "#D5A66E";
 	dir = 4
 	},
+<<<<<<< Updated upstream
 /obj/effect/decal/cleanable/dirt,
+=======
+>>>>>>> Stashed changes
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -3515,8 +4107,15 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/fore)
 "QB" = (
+<<<<<<< Updated upstream
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/techfloor,
+=======
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "QM" = (
@@ -3530,15 +4129,19 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/fore)
 "QS" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "space_cops_starboard_launcher"
-	},
-/obj/structure/sign/warning/vacuum/external{
+/obj/structure/bed/double/maint,
+/obj/structure/sign/poster/contraband/cybersun_borg{
 	pixel_y = 32
 	},
+<<<<<<< Updated upstream
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Rf" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -3568,6 +4171,7 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "Rz" = (
+<<<<<<< Updated upstream
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/item/radio/intercom/directional/north{
@@ -3578,6 +4182,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "RA" = (
 /obj/effect/turf_decal/corner_techfloor_gray{
 	dir = 9
@@ -3631,6 +4242,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+<<<<<<< Updated upstream
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -3651,6 +4263,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Sk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -3666,21 +4282,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/navbeacon/wayfinding{
 	codes_txt = "patrol;next_patrol=dorms";
 	location = "cargo"
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/outline{
+	color = "#2d2a4e"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Sz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3745,6 +4366,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+<<<<<<< Updated upstream
+=======
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"Tp" = (
+/obj/machinery/light/colored{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "Tr" = (
@@ -3850,6 +4489,12 @@
 /obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
 	dir = 1
 	},
+<<<<<<< Updated upstream
+=======
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "UD" = (
@@ -3915,6 +4560,7 @@
 /area/ship/hallway/central)
 "UJ" = (
 /obj/structure/chair/comfy/beige/directional/west,
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/siding/wood{
 	dir = 6;
 	color = "#543C30"
@@ -3923,6 +4569,27 @@
 	dir = 1
 	},
 /turf/open/floor/wood/ebony,
+=======
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D5A66E"
+	},
+/turf/open/floor/carpet/purple,
+>>>>>>> Stashed changes
 /area/ship/crew/crewtwo)
 "UO" = (
 /obj/effect/turf_decal/corner_techfloor_gray/full,
@@ -4017,19 +4684,34 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+<<<<<<< Updated upstream
+=======
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "VA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/navbeacon/wayfinding{
 	location = "Storage Bay"
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/techfloor,
 /obj/structure/closet/firecloset/wall/directional/south,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/structure/window/reinforced/fulltile/shuttle{
+	color = "#2d2a4e"
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "VD" = (
 /obj/machinery/porta_turret/ship/solfed{
 	dir = 10;
@@ -4085,6 +4767,7 @@
 /area/ship/medical)
 "Wi" = (
 /obj/structure/fluff/hedge/opaque{
+<<<<<<< Updated upstream
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -4094,6 +4777,26 @@
 /obj/effect/turf_decal/spline/fancy/wood/three_quarters{
 	layer = 5
 	},
+=======
+	pixel_y = 4;
+	layer = 3
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/railing/wood,
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/railing/wood{
+	dir = 1;
+	layer = 2
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Wl" = (
@@ -4110,8 +4813,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
+<<<<<<< Updated upstream
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/machinery/door/airlock/solgov/glass{
+	name = "Feldwebel Brieff Room"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Wm" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/storage)
@@ -4144,11 +4855,18 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/crewtwo)
 "Wu" = (
+<<<<<<< Updated upstream
 /obj/structure/closet/crate/large,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
+/obj/effect/turf_decal/corner/transparent/solgovgold/three_quarters,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "WE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4209,13 +4927,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/storage)
 "Xb" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 1
 	},
+<<<<<<< Updated upstream
 /obj/effect/turf_decal/spline/fancy/transparent/solgovblue/corner{
 	dir = 8
 	},
@@ -4231,6 +4946,10 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
+=======
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "XO" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -4239,6 +4958,7 @@
 	color = "#4d362c";
 	dir = 10
 	},
+<<<<<<< Updated upstream
 /obj/machinery/washing_machine,
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -4263,6 +4983,27 @@
 /obj/structure/sign/poster/clip/enlist{
 	pixel_y = -32
 	},
+=======
+/obj/effect/spawner/bunk_bed,
+/obj/structure/curtain/cloth,
+/turf/open/floor/wood/walnut,
+/area/ship/crew)
+"XT" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/diagonal,
+/obj/machinery/light/colored/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+"XY" = (
+/obj/effect/turf_decal/corner_techfloor_gray{
+	dir = 10
+	},
+/obj/structure/sign/poster/clip/enlist{
+	pixel_y = -32
+	},
+>>>>>>> Stashed changes
 /turf/open/floor/plasteel/darkredfull,
 /area/ship/security/prison)
 "XZ" = (
@@ -4441,6 +5182,7 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
 "Zs" = (
+<<<<<<< Updated upstream
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/oil,
@@ -4451,6 +5193,12 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/janitor)
+=======
+/obj/effect/turf_decal/spline/fancy/transparent/solgovblue,
+/obj/effect/turf_decal/corner/transparent/solgovgold/half,
+/turf/open/floor/plasteel/mono/dark,
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "Zy" = (
 /turf/open/floor/wood/walnut,
 /area/ship/crew)
@@ -4517,9 +5265,23 @@
 "ZL" = (
 /obj/structure/fluff/hedge/opaque{
 	pixel_y = 4
+<<<<<<< Updated upstream
 	},
 /obj/effect/turf_decal/spline/fancy/wood/three_quarters{
 	layer = 5
+=======
+	},
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/railing/wood,
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/railing/wood{
+	dir = 1;
+	layer = 2
+>>>>>>> Stashed changes
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -4556,7 +5318,11 @@
 	color = "#c48d26"
 	},
 /turf/closed/wall/mineral/plastitanium,
+<<<<<<< Updated upstream
 /area/ship/cargo)
+=======
+/area/ship/crew/law_office)
+>>>>>>> Stashed changes
 "ZS" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 8
@@ -5151,13 +5917,22 @@ WY
 Ul
 Vp
 qX
+<<<<<<< Updated upstream
 vs
 qX
 ej
 vs
 To
 vs
+=======
+>>>>>>> Stashed changes
 QB
+Tp
+ej
+mt
+To
+vs
+Zs
 iM
 "}
 (32,1,1) = {"
@@ -5196,7 +5971,7 @@ ia
 Sl
 wD
 xF
-mt
+LN
 "}
 (34,1,1) = {"
 PX
@@ -5211,9 +5986,15 @@ tn
 De
 pC
 LN
+<<<<<<< Updated upstream
 LN
 iD
 LN
+=======
+tg
+iD
+xp
+>>>>>>> Stashed changes
 LN
 aZ
 "}
@@ -5344,7 +6125,11 @@ PX
 PX
 PX
 LN
+<<<<<<< Updated upstream
 xp
+=======
+LN
+>>>>>>> Stashed changes
 aZ
 PX
 PX

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -1066,6 +1066,7 @@
 /obj/machinery/light/colored{
 	dir = 8
 	},
+/obj/machinery/computer/cryopod/directional/west,
 /turf/open/floor/wood,
 /area/ship/crew)
 "ox" = (
@@ -3732,9 +3733,6 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "SP" = (
-/obj/structure/sign/poster/solgov/solgov_logo{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#D5A66E"
 	},

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -1565,7 +1565,7 @@
 	dir = 1;
 	pixel_y = -22;
 	pixel_x = -9;
-	id = bridge
+	id = "bridge"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -127,7 +127,9 @@
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border{
 	dir = 9
 	},
-/obj/machinery/door/airlock/multi_tile/medical,
+/obj/machinery/door/airlock/multi_tile/medical{
+	name = "Medbay"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -2020,7 +2022,9 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "zd" = (
-/obj/machinery/door/airlock/multi_tile/solgov,
+/obj/machinery/door/airlock/multi_tile/solgov{
+	name = "Cafeteria"
+	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3700,7 +3704,7 @@
 	},
 /obj/machinery/door/airlock/solgov{
 	dir = 8;
-	name = "Cafeteria"
+	name = "Crew Quarters"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/crewtwo)
@@ -4061,7 +4065,7 @@
 	},
 /obj/machinery/door/airlock/solgov{
 	req_one_access = list(20);
-	name = "Captain's Quarters";
+	name = "Kommandant's Quarters";
 	id_tag = "sgi_captainbolt";
 	dir = 4
 	},
@@ -4132,7 +4136,9 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Wt" = (
-/obj/machinery/door/airlock/multi_tile/solgov,
+/obj/machinery/door/airlock/multi_tile/solgov{
+	name = "Restroom"
+	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1


### PR DESCRIPTION
## Описание / Что этот PR делает
Полный ремапп Томагавка, небольшое дополнение базовых вещей на Даггерфолл.
## Причина создания ПР / Почему это хорошо для игры
Слава Солнечной Федерации!
## Демонстрация изменений / Тестирование
<img width="1312" height="544" alt="image" src="https://github.com/user-attachments/assets/1ce86445-3d81-4cab-9e7a-712f88f18c0a" />

## Список изменений
```yml
🆑
map: Полный ремапп Томагавка, его небольшая смена конфига.
За место раундстартовых 4000 кредитов теперь лежит 2000
Префикс судна изменен с SFSV, на BSFSV
Слегка отредактировано описание
Убран один слот марина.
/🆑
```
