### PR TITLE
FIX: Исправление рецепта святой воды

### DIFF
--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -5,6 +5,7 @@
 
 #include "code/_translate_eng.dm"
 #include "code/ammo.dm"
+#include "code/chemical_reaction.dm"
 #include "code/coil.dm"
 #include "code/cutter.dm"
 //#include "code/fax_name.dm"

--- a/mod_celadon/fixes/code/chemical_reaction.dm
+++ b/mod_celadon/fixes/code/chemical_reaction.dm
@@ -1,0 +1,5 @@
+// Исправляем рецепт приготовления святой воды
+/datum/chemical_reaction/holywater
+	results = list(/datum/reagent/water/holywater = 3)
+	required_reagents = list(/datum/reagent/water = 3)
+	required_catalysts = list(/datum/reagent/water/hollowwater = 1)


### PR DESCRIPTION
## Описание / Что этот PR делает
Офы облажались с рецептом святой воды. В самом рецепте сказано, что ингридиентом должна выступать полая вода, та что кое как добывается из гейзеров. Но также эта полая вода является и катализатором. А по механу нельзя чтобы был один ингридиент и катализатором и ингридиентом. Получается этакой парадокс. Пофикшено

## Список изменений

```yml
🆑
tweak: Изменен рецепт hollowwater
/🆑
```
