### PR TITLE
FIX: Design disks: writing, clearing, and printing work reliably again

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -109,26 +109,23 @@ other types of metals and chemistry for reagents).
 	pixel_y = base_pixel_y + rand(-5, 5)
 	if(design_name)
 		name = jointext(list(disk_name, design_name), " - ")
-	//[CELADON-EDIT] -- CELADON_FIXES -- Превращаем обычный список в ассоциативный. Люммох пидарас. Вагабонд боженька. Чиним диски пупупу
+	// [CELADON-EDIT] - CELADON_FIXES - Инициализируем строго индексный массив слотов 1..max_blueprints без ассоциативных ключей
+	// ORIGINAL (commented):
 	// if(length(starting_blueprints))
-		// for(var/design in starting_blueprints)
-			// blueprints += new design()
-	var/list/new_designs = list()
-	var/list/previous_designs = starting_blueprints
-	var/maxim_shelby = length(previous_designs)
-	for(var/i in 1 to max_blueprints)
-		if(maxim_shelby >= i)
-			var/a = pick(previous_designs)
-			var/datum/design/b = new a()
-			new_designs += b
-			new_designs[b] = i
-			previous_designs -= a
-		else
-			var/c = null
-			new_designs += c
-			new_designs[c] = i
-	blueprints = new_designs
-	//[/CELADON-EDIT]
+	// 	for(var/design in starting_blueprints)
+	// 		blueprints += new design()
+	// CELADON: фиксированная длина + раскладка стартовых чертежей по индексам
+	var/list/fixed_blueprints = list()
+	fixed_blueprints.len = max_blueprints
+	var/idx = 1
+	if(length(starting_blueprints))
+		for(var/path in starting_blueprints)
+			if(idx > max_blueprints)
+				break
+			fixed_blueprints[idx] = new path()
+			idx++
+	blueprints = fixed_blueprints
+	// [/CELADON-EDIT]
 
 /obj/item/disk/design_disk/adv
 	name = "Advanced Component Design Disk"

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -78,6 +78,12 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code/modules/research/rdconsole.dm` - Попытка изменить абьюз, когда игрок мог внести семена сколько угодно раз, пересобирая тупо консоль. Сделано через глобальный список.
 
+- EDIT: `code/modules/research/designs.dm` - [CELADON-EDIT] - CELADON_FIXES - Инициализация `obj/item/disk/design_disk/Initialize()` переписана на фиксированный индексный список слотов `1..max_blueprints` без ассоциативных ключей. `starting_blueprints` раскладываются по индексам, оставшиеся слоты `null`.
+- EDIT: `code/modules/research/rdconsole.dm` - [CELADON-EDIT] - CELADON_FIXES -
+  - `ui_designdisk()` теперь рисует строго по индексам 1..max_blueprints и нормализует длину `blueprints.len = max_blueprints`.
+  - `copy_design` записывает дизайн строго по индексу слота без сжатия списка.
+  - `clear_design` очищает либо все слоты, либо один слот установкой `null` по индексу; не используется `list -= value`.
+
 - ADD: `/obj/machinery/computer/telecomms/server/ui_interact` - Добавляем поддержку UTF-8
 - ADD: `/obj/machinery/computer/telecomms/monitor/ui_interact` - Добавляем поддержку UTF-8
 
@@ -189,6 +195,8 @@ FIXES_SOUND
 
 
 RalseiDreemuurr, Mirag1993 , Корольный крыс, MrCat15352, MysticalFaceLesS, Burbonchik, MrRomainzZ, Molniz, Redwizz, Sjerty, Garomt, Ganza9991, KOCMOHABT
+
+- Автор фикса дисков дизайнов: Турон/Mirag1993
 
 <!--
   Здесь находится твой никнейм


### PR DESCRIPTION
## Описание / Что этот PR делает
Диски дизайнов снова корректно записывают выбранные чертежи через R&D консоль.
Можно очищать отдельный слот или весь диск; меню больше не пропадает.
Чережтежи не «перепрыгивают» между слотами после очистки.
Автолат снова видит чертежи на диске и печатает совместимые предметы.
Продвинутые диски (3/5/10 слотов) работают так же, по индексам слотов.
Старые «сломанные» диски автоматически нормализуются при открытии консоли.
## Причина создания ПР / Почему это хорошо для игры
Багрепорт
## Демонстрация изменений / Тестирование
Вставить диск → Copy to Disk в слот → Clear Slot → Clear Disk.
Вставить диск с предметом в автолат → напечатать предмет
## Список изменений
Починка дисков изменена логика записи технологий
```yml
🆑 Турон/Mirag1993
fix: Починены диски дизайнов — запись чертежей и очистка слотов/диска работают стабильно, меню больше не пропадает.
fix: Автолат снова видит чертежи на диске и печатает совместимые предметы.
tweak: Слоты диска теперь стабильные и индексные; старые «сломанные» диски нормализуются при открытии R&D консоли.
/🆑
```
