### PR TITLE
FIX: Лодаут и выход в крио для гостролей

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -309,6 +309,22 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
 
+	// [CELADON-ADD] - CELADON_GHOST_ROLES
+	// Check if this is a ghost role
+	if(!mob_occupant.mind?.original_ship)
+		// Ghost role - simple deletion without crew processing
+		if(mob_occupant.client)
+			mob_occupant.ghostize(TRUE)
+
+		for(var/obj/item/W in mob_occupant.GetAllContents())
+			qdel(W)
+
+		open_machine()
+		qdel(mob_occupant)
+		occupant = null
+		return
+	// [/CELADON-ADD]
+
 	if(!isnull(mob_occupant.mind.original_ship))
 		var/datum/overmap/ship/controlled/original_ship_instance = mob_occupant.mind.original_ship.resolve()
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -151,6 +151,24 @@
 		special(M, name)
 		MM.name = M.real_name
 		special_post_appearance(M, name)
+		// Issue player loadout for ghost role when they chose to load character slot
+		if(ishuman(M) && load_character && M.client && M.client.prefs?.equipped_gear && length(M.client.prefs.equipped_gear))
+			var/mob/living/carbon/human/H = M
+			var/obj/item/storage/box/loadout_dumper = new()
+
+			for(var/gear_id in M.client.prefs.equipped_gear)
+				var/datum/gear/new_gear = GLOB.gear_datums[gear_id]
+				if(new_gear)
+					// spawn item into the box; spawn_item handles role replacements via job/assigned_role
+					new_gear.spawn_item(loadout_dumper, H)
+
+			// try to place box into back storage, else into hands, else drop on turf
+			var/datum/component/storage/back_storage = H.back?.GetComponent(/datum/component/storage)
+			if(back_storage)
+				back_storage.handle_item_insertion(loadout_dumper, TRUE)
+			else if(!H.put_in_hands(loadout_dumper, TRUE))
+				loadout_dumper.forceMove(get_turf(H))
+				to_chat(H, span_warning("Unable to place your loadout box into hands, dropped at your feet."))
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -151,6 +151,7 @@
 		special(M, name)
 		MM.name = M.real_name
 		special_post_appearance(M, name)
+	// [CELADON-ADD] - CELADON_GHOST_ROLES
 		// Issue player loadout for ghost role when they chose to load character slot
 		if(ishuman(M) && load_character && M.client && M.client.prefs?.equipped_gear && length(M.client.prefs.equipped_gear))
 			var/mob/living/carbon/human/H = M
@@ -169,6 +170,8 @@
 			else if(!H.put_in_hands(loadout_dumper, TRUE))
 				loadout_dumper.forceMove(get_turf(H))
 				to_chat(H, span_warning("Unable to place your loadout box into hands, dropped at your feet."))
+	spawned_mob_ref = WEAKREF(M)
+	// [/CELADON-ADD]
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)

--- a/mod_celadon/ghost_roles/README.md
+++ b/mod_celadon/ghost_roles/README.md
@@ -42,7 +42,8 @@ ID мода: CELADON_GHOST_ROLES
 
 ### Изменения *кор кода*
 
-- Отсутствуют
+- `code/modules/awaymissions/corpse.dm`
+- `code/game/machinery/cryopod.dm`
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Чинит спавн за гост рольку, выдавая игроку вещи из лодаута
Делает так, что по выходу в крио гост ролька теперь через некоторое время удаляется с карты освобождая криокапсулу

## Причина создания ПР / Почему это хорошо для игры
Не будет храпящих карбонов на аванпосту
Наконец-то смогут все заходить с лодаутом, а не клянчить и искать закладки на аванпосту, ради того чтобы купить нужные тебе вещи...

## Список изменений

```yml
🆑
fix: выдача лодаута гост роли
fix: удаление тела после выхода в крио гост роли
/🆑
```
