### PR TITLE
Возвращаем лаву на океанический планетоид

### DIFF
--- a/code/datums/mapgen/planetary/waterGenerator.dm
+++ b/code/datums/mapgen/planetary/waterGenerator.dm
@@ -134,8 +134,5 @@
 	)
 
 /datum/biome/cave/waterplanet/fault
-	// [CELADON-EDIT] - CELADON_FIXES - Убираем лаву с генерации водяной планеты
-	// open_turf_types = list(/turf/open/lava = 5, /turf/open/water/stormy_planet_underground = 1)	// ORIGINAL
-	open_turf_types = list(/turf/open/water/stormy_planet_underground = 1)
-	// [/CELADON-EDIT]
+	open_turf_types = list(/turf/open/lava = 5, /turf/open/water/stormy_planet_underground = 1)
 	mob_spawn_chance = 0

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -122,8 +122,6 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code/modules/mob/living/carbon/human/species_types/kepori.dm` : Делаем так чтобы кепори могли брать мелкие предметы в клюв
 
-- EDIT: `code/datums/mapgen/planetary/waterGenerator.dm` : Убираем спавн лавы на водяной планете
-
 - EDIT, ADD: `code/modules/mob/living/blood.dm` : Вводим нормальный уровень для крови
 - EDIT, ADD: `code/game/machinery/iv_drip.dm` : Проверка крови у пациента
 - ADD: `code/modules/reagents/chemistry/holder.dm` : Вводим ограничения на шприцы, бикеры, капельницы


### PR DESCRIPTION
## Описание / Что этот PR делает
Возвращаем лаву на океанический планетоид, вырезанное в этом ПРе - https://github.com/CeladonSS13/Shiptest/pull/1874
## Причина создания ПР / Почему это хорошо для игры
Лава была вайбовой. Лава не была багом. Одобрено шиптест Хэдом
## Демонстрация изменений / Тестирование

## Список изменений
- Возвращаем лаву в генерацию океанического планетоида
```yml
🆑
map: Изменения аква планетоида
```
