### PR TITLE
MAP: Fix rondo and daggerfall

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
@@ -81,11 +81,9 @@
 	pixel_x = -23;
 	dir = 4
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
@@ -987,10 +985,12 @@
 /turf/open/floor/engine/hull,
 /area/ship/external)
 "nD" = (
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/smes/engineering,
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
 "nG" = (
@@ -1008,9 +1008,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "nI" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/trimline/opaque/orange/corner{
 	dir = 1
 	},
@@ -1114,6 +1111,12 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/dark,
 /area/ship/security/armory)
+"px" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull,
+/area/ship/external)
 "pE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -1545,18 +1548,12 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "ug" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/turf_decal/trimline/opaque/orange/warning,
 /obj/machinery/power/terminal{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/opaque/orange/warning,
-/obj/structure/cable{
-	icon_state = "0-1"
 	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
@@ -1611,9 +1608,6 @@
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering/electrical)
 "uY" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/trimline/opaque/orange/corner{
 	dir = 8
 	},
@@ -1678,14 +1672,15 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "vy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
 	},
 /turf/open/floor/plasteel/heavymetal,
 /area/ship/engineering/electrical)
@@ -2147,8 +2142,9 @@
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/engineering/electrical)
@@ -2713,20 +2709,12 @@
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
 "Hl" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/power/terminal,
 /obj/effect/turf_decal/trimline/opaque/orange/warning{
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering/electrical)
@@ -3332,13 +3320,15 @@
 /turf/closed/wall/mineral/titanium/exterior,
 /area/ship/crew/canteen/kitchen)
 "Ps" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/trimline/opaque/orange/end{
 	dir = 8
 	},
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/port_gen/pacman/super{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Pz" = (
@@ -3417,14 +3407,14 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "Qa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/heavymetal,
 /area/ship/engineering)
@@ -4416,7 +4406,7 @@ nZ
 nZ
 Xh
 aU
-aU
+px
 Lg
 hA
 Rv

--- a/_maps/_mod_celadon/shuttles/pirate/ramzi_rondo.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/ramzi_rondo.dmm
@@ -260,9 +260,6 @@
 /area/ship/hallway/central)
 "di" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -809,6 +806,9 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "kj" = (
@@ -1225,10 +1225,10 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "qv" = (
@@ -2247,6 +2247,9 @@
 /obj/item/storage/belt/utility/syndicate{
 	pixel_y = -7
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "Cv" = (
@@ -2476,7 +2479,7 @@
 	pixel_y = 44;
 	pixel_x = -1
 	},
-/obj/machinery/computer/communications{
+/obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
 /obj/machinery/newscaster/security_unit/directional/west,
@@ -2699,9 +2702,6 @@
 	},
 /area/ship/external)
 "Ia" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -2797,6 +2797,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
@@ -3056,6 +3059,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
@@ -3744,13 +3750,11 @@
 /area/ship/hallway/central)
 "YN" = (
 /obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "YU" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Что-то чинит для рондо и даггерфолла, читать в изменениях
## Причина создания ПР / Почему это хорошо для игры
закрывает https://discord.com/channels/1100198143456465067/1406511736206524436
багфиксит, да-а-а
## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
map: 
рондо: чинит проводку для генератора и смеса, меняет консоль стационную коммуникатион консоль на командную
даггерфолл: чинит проводку для генератора и смеса
/🆑
```
