### PR TITLE
ADD: Фильтр крови лезет в мед разгрузку

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -204,6 +204,7 @@
 		/obj/item/clothing/mask/breath/medical,
 		/obj/item/scalpel,
 		/obj/item/circular_saw,
+		/obj/item/blood_filter,	// [CELADON-ADD] - CELADON_BALANCE
 		/obj/item/surgicaldrill,
 		/obj/item/retractor,
 		/obj/item/cautery,
@@ -252,6 +253,7 @@
 /obj/item/storage/belt/medical/surgery/PopulateContents()
 	new /obj/item/scalpel(src)
 	new /obj/item/circular_saw(src)
+	new /obj/item/blood_filter(src)	// [CELADON-ADD] - CELADON_BALANCE
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/retractor(src)
 	new /obj/item/cautery(src)
@@ -262,6 +264,7 @@
 /obj/item/storage/belt/medical/webbing/surgery/PopulateContents()
 	new /obj/item/scalpel(src)
 	new /obj/item/circular_saw(src)
+	new /obj/item/blood_filter(src)	// [CELADON-ADD] - CELADON_BALANCE
 	new /obj/item/surgicaldrill(src)
 	new /obj/item/retractor(src)
 	new /obj/item/cautery(src)

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -121,6 +121,8 @@ EDIT: `code/modules/mob/living/carbon/human/species_types/kepori.dm` : Подн�
 ADD: `code/modules/mob/living/carbon/human/species_types/lizardpeople.dm` : Даём сарати резист к огню на 15%
 ADD: `code/modules/mob/living/carbon/human/species_types/vox.dm` : Даём воксам резист к холоду на 20%
 
+ADD: `code/game/objects/items/storage/belt.dm` : Добавлен новый филтр крови в возможность грузить в мед разгрузку
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет возможность добавлять в мед разгрузку новый инструмент фильтр крови

## Причина создания ПР / Почему это хорошо для игры
Офы ввели новый инструмент но его нельзя воткнуть в разгрузку. По размеру он как пила. Но пила лезет в разгрузку а фильтр крови нет

## Список изменений

```yml
🆑
add: Добавлена возможность добавить фильтр крови в мед разгрузку
/🆑
```
