### PR TITLE
Бафф брони интеков

### DIFF
--- a/mod_celadon/outfit/code/inteq/armor.dm
+++ b/mod_celadon/outfit/code/inteq/armor.dm
@@ -5,4 +5,4 @@
 	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/items/clothing/suit/overlay/armor_celadon.dmi'
 	icon_state = "armor_inteq"
 	item_state = "armor_inteq"
-	armor = list("melee" = 38, "bullet" = 33, "laser" = 33, "energy" = 43, "bomb" = 28, "bio" = 3, "rad" = 3, "fire" = 53, "acid" = 53)
+	armor = list("melee" = 39, "bullet" = 33, "laser" = 33, "energy" = 43, "bomb" = 28, "bio" = 3, "rad" = 3, "fire" = 53, "acid" = 53)


### PR DESCRIPTION
## Описание / Что этот PR делает
Бафф брони интеков. Мили защита была 38 и стала 39
## Причина создания ПР / Почему это хорошо для игры
Ну чет слабенькие они. QoL фича
## Демонстрация изменений / Тестирование
<img width="916" height="94" alt="image" src="https://github.com/user-attachments/assets/53b08d61-519c-42b5-9563-ec4516bc56fa" />

## Список изменений

```yml
🆑
add: Что-то добавлено
del: Что-то удалено
balance: Что-то изменено в балансе
tweak: Что-то изменено по мелочи
fix: Что-то исправлено
sound: Добавлен/Изменен/Удален звук
image: Добавлен/Изменен/Удален спрайт
map: Изменения на карте
spellcheck: Исправлена опечатка/добавлен перевод
admin: Изменения в кнопках администрации
/🆑
```
