### PR TITLE
ADD: Ограничение входа ксенорасам на корабли сепаратистов

### DIFF
--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -164,6 +164,14 @@
 		if(!S.is_join_option())
 			continue
 
+		// [CELADON-ADD] - YOU_NOT_SEPARATIST
+		// Проверка ограничений по видам для кораблей фракции Elysium
+		if(S.source_template.faction.name == FACTION_ELYSIUM)
+			var/species_id = user.client?.prefs?.pref_species?.id
+			if(species_id != "human" && species_id != "ipc" && species_id != "lanius")
+				continue
+		// [/CELADON-ADD]
+
 		var/list/ship_jobs = list()
 		for(var/datum/job/job as anything in S.job_slots)
 			var/slots = S.job_slots[job]
@@ -197,6 +205,12 @@
 		var/datum/map_template/shuttle/T = SSmapping.ship_purchase_list[template_name]
 		if(!T.enabled)
 			continue
+
+		// Проверка ограничений по видам для шаблонов кораблей фракции Elysium
+		if(T.faction.name == FACTION_ELYSIUM)
+			var/species_id = user.client?.prefs?.pref_species?.id
+			if(species_id != "human" && species_id != "ipc" && species_id != "lanius")
+				continue
 		var/list/ship_data = list(
 			"name" = T.name,
 			"faction" = T.faction.name,

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -19,6 +19,7 @@ ID мода:
 	CELADON_BALANCE_OVERMAP_EVENTS
 	CELADON_BALANCE_SPECIES
 	BALLISTIC_SHIELD
+	YOU_NOT_SEPARATIST
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов. Добавлены
@@ -122,6 +123,9 @@ ADD: `code/modules/mob/living/carbon/human/species_types/lizardpeople.dm` : Да
 ADD: `code/modules/mob/living/carbon/human/species_types/vox.dm` : Даём воксам резист к холоду на 20%
 
 ADD: `code/game/objects/items/storage/belt.dm` : Добавлен новый филтр крови в возможность грузить в мед разгрузку
+
+YOU_NOT_SEPARATIST
+ADD: `code/modules/mob/dead/new_player/ship_select.dm` : Добавляем сокрытие определенных кораблей для определенных видов
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Ограничивает въод ксенорасам на корабли сепаратистов. Кроме:
- Людей
- ИПС
- Ланиусов
У других рас будет сокрыт список и доступных к покупке кораблей и текущих кораблей сепаратистов в игре

## Причина создания ПР / Почему это хорошо для игры
Устраняем нелогичность, рофляные ситуации, лишнюю нервотрепку всем.

## Список изменений

```yml
🆑
add: Паспортный контроль для ксеноэмигрантов
/🆑
```
