### PR TITLE
Update: Rust Version

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=1642
 export RUST_VERSION=1.81.0
 
 #rust_g git tag
-export RUST_G_VERSION=3.6.0
+export RUST_G_VERSION=4.0.0
 
 #node version
 export NODE_VERSION=16


### PR DESCRIPTION
## Описание / Что этот PR делает

Обновляемся с RUST_G_VERSION=**3.6.0 до 4.0.0**
Версия вышла 3 недели назад.

## Причина создания ПР / Почему это хорошо для игры

Предоставит кодерам больше кислороду.

