### PR TITLE
FIX: Вечные щупальца голиафов в космосе

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -68,6 +68,12 @@
 
 /mob/living/simple_animal/hostile/asteroid/goliath/death(gibbed)
 	move_resist = MOVE_RESIST_DEFAULT
+	// [CELADON-ADD] - FIXES_GOLIATH_TENTACLES
+	// Удаляем все тентакли при смерти голиафа
+	for(var/obj/effect/temp_visual/goliath_tentacle/T in world)
+		if(T.spawner == src)
+			qdel(T)
+	// [/CELADON-ADD]
 	..()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/gib()
@@ -266,6 +272,12 @@
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/Life()
 	. = ..()
 	if(!.) // dead
+		// [CELADON-ADD] - FIXES_GOLIATH_TENTACLES
+		// Удаляем все тентакли при смерти древнего голиафа
+		for(var/obj/effect/temp_visual/goliath_tentacle/T in world)
+			if(T.spawner == src)
+				qdel(T)
+		// [/CELADON-ADD]
 		return
 	if(AIStatus != AI_ON)
 		return
@@ -327,10 +339,22 @@
 	// [/CELADON-EDIT]
 
 /obj/effect/temp_visual/goliath_tentacle/proc/tripanim()
+	// [CELADON-ADD] - FIXES_GOLIATH_TENTACLES
+	// Проверяем, жив ли еще создатель
+	if(QDELETED(spawner) || (spawner && spawner.stat == DEAD))
+		qdel(src)
+		return
+	// [/CELADON-ADD]
 	deltimer(timerid)
 	timerid = addtimer(CALLBACK(src, PROC_REF(trip)), 3, TIMER_STOPPABLE)
 
 /obj/effect/temp_visual/goliath_tentacle/proc/trip()
+	// [CELADON-ADD] - FIXES_GOLIATH_TENTACLES
+	// Проверяем, жив ли еще создатель
+	if(QDELETED(spawner) || (spawner && spawner.stat == DEAD))
+		qdel(src)
+		return
+	// [/CELADON-ADD]
 	var/latched = FALSE
 	for(var/mob/living/L in loc)
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -21,6 +21,7 @@ FIXES_ICON
 FIXES_SOUND
 MECH_WEAPON
 FIXES_CHAMELEON
+FIXES_GOLIATH_TENTACLES
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -158,6 +159,8 @@ FIXES_SOUND
 FIXES_CHAMELEON
 - EDIT: `code/datums/mutations/chameleon.dm` - Чиним крит баг с вечной невидимостью
 
+FIXES_GOLIATH_TENTACLES
+- ADD: `code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm` : Добавляем прок и прверки на жизненный цикл тентакли и её создателя
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксит баг когда щупальца оставались в космосе и не исчезали

## Причина создания ПР / Почему это хорошо для игры
Крит баг

## Список изменений

```yml
🆑
add: недостающие проверки и проки для щупалец
/🆑
```
