### PR TITLE
FIX: Попытка зайти на корабль за того же уже существующим персонажем

### DIFF
--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -31,6 +31,15 @@
 				spawnee.new_player_panel()
 				return
 
+			// [CELADON-ADD] - CELADON_FIXES
+			// Проверяем дублирование имен при входе на корабль
+			if(!spawnee.client.prefs.randomise[RANDOM_NAME])
+				var/name = spawnee.client.prefs.real_name
+				if(GLOB.real_names_joined.Find(name))
+					to_chat(spawnee, span_warning("Someone has spawned with this name already."))
+					spawnee.new_player_panel()
+					return
+			// [/CELADON-ADD]
 			var/did_application = FALSE
 			if(target.join_mode == SHIP_JOIN_MODE_APPLY)
 				var/datum/ship_application/current_application = target.get_application(spawnee)
@@ -78,6 +87,13 @@
 				return
 
 			var/datum/map_template/shuttle/template = SSmapping.ship_purchase_list[params["name"]]
+			// [CELADON-ADD] - CELADON_FIXES - фикс спавна пустых шаттлов (вагинобонд)
+			// Проверяем дублирование имен в самом начале
+			var/name = spawnee.client.prefs.real_name
+			if(GLOB.real_names_joined.Find(name))
+				to_chat(spawnee, span_warning("Someone has spawned with this name already."))
+				return
+			// [/CELADON-ADD]
 			if(SSovermap.ship_spawning)
 				to_chat(spawnee, span_danger("A ship is currently spawning. Try again in a little while."))
 				return
@@ -98,12 +114,6 @@
 			if(num_ships_with_template >= template.limit)
 				to_chat(spawnee, span_danger("There are already [num_ships_with_template] ships of this type; you cannot spawn more!"))
 				return
-			//[CELADON-ADD] -- CELADON_FIXES -- фикс спавна пустых шаттлов (вагинобонд)
-			var/name = spawnee.client.prefs.real_name
-			if(GLOB.real_names_joined.Find(name))
-				to_chat(usr, "<span class='warning'>Someone has spawned with this name already.")
-				return
-			//[/CELADON-ADD]
 
 			ui.close()
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксим заход на шип с одинаковым именем. Если заспавнить шаттл без кэпа (иметь имя, которое уже есть в раунде) то на него зайти нельзя. Теперь, будет две проверки:
1. ДО создания шипа проверяется имя на дубликат в раунде для тех случаев когда пытаются купить корабль без капитана
2. Проверяется имя на дубликат для тех случаев когда пытаются зайти на уже имеющийся корабль в раунде

## Причина создания ПР / Почему это хорошо для игры
Древнее зло надо чинить

## Список изменений

```yml
🆑
add: Дополнительная проверка на вход шипов с имеющимся в игре именем
tweak: Подвинута проверка с ПОСЛЕ создания шипа до ДО создания шипа на наличие одинаковых имен, что предотвращает появление закрытых шипов без капитанов и команды
/🆑
```
