### PR TITLE
FIX: Выдаем лицензию на сушку мокрой кожи в сушилке

### DIFF
--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(monkey_recipes, list ( \
 	var/wetness = 30 //Reduced when exposed to high temperautres
 	var/drying_threshold_temperature = 500 //Kelvin to start drying
 
-/obj/item/stack/sheet/leather/wetleather/Initialize(mapload, new_amount, merge)
+/obj/item/stack/sheet/wethide/Initialize(mapload, new_amount, merge)	// [CELADON-EDIT] - FIXES_WETHIDE // /obj/item/stack/sheet/leather/wetleather/Initialize(mapload, new_amount, merge)
 	. = ..()
 	AddElement(/datum/element/dryable, /obj/item/stack/sheet/leather)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -318,7 +318,7 @@
 			rack_dry(item_iterator)
 
 		SStgui.update_uis(src)
-		update_icon()
+		update_appearance()	// [CELADON-EDIT] - FIXES_WETHIDE - Замена устаревшего метода // update_icon()
 
 /obj/machinery/smartfridge/drying_rack/accept_check(obj/item/O)
 	if(HAS_TRAIT(O, TRAIT_DRYABLE)) //set on dryable element

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -22,6 +22,8 @@ FIXES_SOUND
 MECH_WEAPON
 FIXES_CHAMELEON
 FIXES_GOLIATH_TENTACLES
+FIXES_SHIP_LOGIN_DOUBLE_NAME
+FIXES_WETHIDE
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -161,6 +163,12 @@ FIXES_CHAMELEON
 
 FIXES_GOLIATH_TENTACLES
 - ADD: `code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm` : Добавляем прок и прверки на жизненный цикл тентакли и её создателя
+FIXES_SHIP_LOGIN_DOUBLE_NAME
+- ADD: `code/modules/mob/dead/new_player/ship_select.dm` : Поднимаем проверку на одинаковые имена ДО создания корабля, чтобы избежать спавна изолированного корабля
+
+FIXES_WETHIDE
+- EDIT: `code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm` : Заменен устаревший метод `update_icon()` на `update_appearance()`
+- EDIT: `code/game/objects/items/stacks/sheets/leather.dm` : Исправлен неправильный путь класса. Изменено `/obj/item/stack/sheet/leather/wetleather/Initialize` на `/obj/item/stack/sheet/wethide/Initialize`. Это позволяет мокрой коже правильно добавить элемент `dryable` при инициализации
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксится способ сушки мокрой кожи в сушилке. Теперь можно сушить кожу там, а не только в микроволновке...

## Причина создания ПР / Почему это хорошо для игры
Логично что мокрую кожу сушать надо в сушилке
Не логично что кожу сушат в микроволновке

## Список изменений

```yml
🆑
fix: Исправлен класс присвоения сигналов для сушки
add: Добавлены записи
code: Исправлен старый метод обновления иконки
/🆑
```
