### PR TITLE
ADD: Admin Panel Menu

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -29,6 +29,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/revokebunkerbypass,
 	/client/proc/requests,
 	/client/proc/fax_panel, /*send a paper to fax*/
+	/client/proc/show_all_verbs, // [CELADON-ADD] - ADMIN-PANEL - Black Reality
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -796,3 +797,79 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 	var/datum/admins/admin = GLOB.admin_datums[ckey]
 	admin?.associate(src)
+
+// [CELADON-ADD] - ADMIN-PANEL - Black Reality
+/client/proc/show_all_verbs()
+	set category = "Admin"
+	set name = "Admin Panel 📋"
+
+	if(!holder)
+		return
+
+	admin_menu = new(usr)
+	admin_menu.ui_interact(usr)
+
+/datum/admin_menu
+	var/client/holder
+	var/compact_mode = FALSE
+
+/datum/admin_menu/New(user)
+	if (istype(user, /client))
+		var/client/user_client = user
+		holder = user_client
+	else
+		var/mob/user_mob = user
+		holder = user_mob.client
+
+/datum/admin_menu/ui_state(mob/user)
+	return GLOB.admin_state
+
+/datum/admin_menu/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "AdminVerbs")
+		ui.open()
+
+/datum/admin_menu/ui_data(mob/user)
+	var/list/data = list()
+	data["compactMode"] = compact_mode
+	return data
+
+/datum/admin_menu/ui_static_data(mob/user)
+	var/list/temp_data = list()
+	for(var/procpath/cur_verb as anything in holder.verbs)
+		if(!cur_verb.category)
+			continue
+		if(!temp_data[cur_verb.category])
+			temp_data[cur_verb.category] = list()
+		temp_data[cur_verb.category] += list(list("verb" = "[cur_verb]", "name" = cur_verb.name, "desc" = cur_verb.desc))
+
+	var/list/tgui_data = list()
+	for(var/category in temp_data)
+		var/list/cat = list(
+			"name" = category,
+			"items" = temp_data[category])
+		tgui_data["categories"] += list(cat)
+
+	LAZYADDASSOCLIST(tgui_data, "categories", list("name" = "История", "items" = reverseList(holder.last_verbs_used)))
+	return tgui_data
+
+/datum/admin_menu/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("compact_toggle")
+			compact_mode = !compact_mode
+			return TRUE
+
+	if(!check_rights(R_ADMIN) || action != "run")
+		return
+
+	INVOKE_ASYNC(holder, text2path(params["verb"]))
+
+	LAZYADD(holder.last_verbs_used, list(list("verb" = params["verb"], "name" = params["name"], "desc" = params["desc"])))
+
+	SStgui.close_uis(usr)
+// [/CELADON-ADD]

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -195,3 +195,10 @@
 	/// Used by SSserver_maint to detect if a client is newly AFK.
 	var/last_seen_afk = 0
 
+// [CELADON-ADD] - ADMIN-PANEL - Black Reality
+	/// Last Admin Verbs used
+	var/list/last_verbs_used = list()
+
+	/// Literally Admin Verbs Menu
+	var/datum/admin_menu/admin_menu
+// [/CELADON-ADD]

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -16,6 +16,7 @@ ID мода: CELADON_QOL
 
 FIX_LATHE
 AUTOLATE_MAXSTACK
+ADMIN-PANEL
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -137,6 +138,11 @@ AUTOLATE_MAXSTACK, FIX_LATHE
 - EDIT `code/game/machinery/autolathe.dm` - Добавление/изменения макс стопок в автолате
 - EDIT `code/game/machinery/autolathe.dm` - Удаляет абуз с дюпом
 - EDIT `tgui/packages/tgui/interfaces/Autolathe.js` - Интерфейсы под них
+
+ADMIN-PANEL
+- ADD `code/modules/admin/admin_verbs.dm`			- Добавляет Админ панель в игру
+- ADD `code/modules/client/client_defines.dm` 		-
+- ADD `tgui/packages/tgui/interfaces/AdminVerbs.js` -
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/tgui/packages/tgui/interfaces/AdminVerbs.js
+++ b/tgui/packages/tgui/interfaces/AdminVerbs.js
@@ -1,0 +1,138 @@
+import { createSearch } from 'common/string';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Input, Table, Button, Tabs, Flex, Section } from '../components';
+import { Window } from '../layouts';
+import { Fragment } from 'inferno';
+
+const MAX_SEARCH_RESULTS = 25;
+
+export const AdminVerbs = (_, context) => {
+  const { act, data } = useBackend(context);
+  const { compactMode, categories = [] } = data;
+  const [searchText, setSearchText] = useLocalState(context, 'searchText', '');
+  const [selectedCategory, setSelectedCategory] = useLocalState(
+    context,
+    'category',
+    'Admin'
+  );
+  const testSearch = createSearch(searchText, (item) => {
+    return item.name;
+  });
+  const items =
+    (searchText.length > 0 &&
+      categories
+        .filter((category) => category.name !== 'История')
+        .flatMap((category) => category.items || [])
+        .filter(testSearch)
+        .filter((item, i) => i < MAX_SEARCH_RESULTS)) ||
+    categories.find((category) => category.name === selectedCategory)?.items ||
+    [];
+  return (
+    <Window theme="ntos_darkmode" width={500} height={720}>
+      <Window.Content scrollable>
+        <Section
+          title={<Box inline>Admin Panel</Box>}
+          buttons={
+            <Fragment>
+              Поиск
+              <Input
+                autoFocus
+                value={searchText}
+                onInput={(e, value) => setSearchText(value)}
+                onEnter={(event) => {
+                  event.preventDefault();
+                  setSearchText('');
+                  act('run', {
+                    'name': items[0].name,
+                    'desc': items[0].desc,
+                    'verb': items[0].verb,
+                  });
+                }}
+                mx={1}
+              />
+              <Button
+                icon={compactMode ? 'list' : 'info'}
+                content={compactMode ? 'Компактно' : 'Детально'}
+                onClick={() => act('compact_toggle')}
+              />
+            </Fragment>
+          }
+        >
+          <Flex>
+            {searchText.length === 0 && (
+              <Flex.Item>
+                <Tabs vertical mr={1}>
+                  {categories.map((category) => (
+                    <Tabs.Tab
+                      key={category.name}
+                      selected={category.name === selectedCategory}
+                      onClick={() => setSelectedCategory(category.name)}
+                    >
+                      {category.name}
+                    </Tabs.Tab>
+                  ))}
+                </Tabs>
+              </Flex.Item>
+            )}
+            <Flex.Item grow={1} basis={0}>
+              <VerbList
+                compactMode={searchText.length > 0 || compactMode}
+                items={items}
+              />
+            </Flex.Item>
+          </Flex>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const VerbList = (props, context) => {
+  const { items = [], compactMode } = props;
+  const { act } = useBackend(context);
+  if (compactMode) {
+    return (
+      <Table>
+        {items.map((obj) => (
+          <Table.Row key={obj.name} className="candystripe">
+            <Button
+              fluid
+              content={obj.name}
+              selected={obj.selected}
+              onClick={() =>
+                act('run', {
+                  'name': obj.name,
+                  'desc': obj.desc,
+                  'verb': obj.verb,
+                })
+              }
+            />
+          </Table.Row>
+        ))}
+      </Table>
+    );
+  }
+  return items.map((obj) => (
+    <Section
+      fluid
+      key={obj.name}
+      mb={obj.desc ? 0 : -1}
+      pb={obj.desc ? 0 : -1}
+      title={
+        <Button
+          fluid
+          content={obj.name}
+          onClick={() =>
+            act('run', {
+              'name': obj.name,
+              'desc': obj.desc,
+              'verb': obj.verb,
+            })
+          }
+        />
+      }
+    >
+      {!!obj.desc && <Box>{obj.desc}</Box>}
+    </Section>
+  ));
+};


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет новой функциональное меню с поиском по кнопкам для педалей/дебагинга в котором можно искать кнопки через поиск.
Сделанное в виде отдельного меню.

## Причина создания ПР / Почему это хорошо для игры
Я заебался искать нужные мне кнопки в интерфейсе каждый гребаный раз.

## Список изменений

```yml
🆑
admin: Добавляет в кнопки новый верб - Админ панель
/🆑
```
