### PR TITLE
Spellcheck: Стандартизирует названия Обойм в описание товаров карго консоли

### DIFF
--- a/mod_celadon/outpost_console/code/supply_pack/inteq/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/inteq/magazines.dm
@@ -21,7 +21,7 @@
 
 /datum/supply_pack/faction/inteq/magazine/co9mm_mag
 	name = "Commisioner pistol magazine"
-	desc = "A 12-round double-stack 9x18mm magazine for Commander pistols. These rounds do okay damage, but struggle against armor."
+	desc = "Contains a 9x18mm magazine for Commander pistols, with a capacity of 12 rounds. These rounds do okay damage, but struggle against armor."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
@@ -6,20 +6,20 @@ MARK: VI
 */
 
 /datum/supply_pack/faction/nanotrasen/magazine/co9mm_mag
-	name = "9x18mm  Commander Magazine Crate"
-	desc = "Contains a 9x18mm  magazine for the standard-issue Commander pistol, with a capacity of twelve rounds."
+	name = "9x18mm Commander Magazine Crate"
+	desc = "Contains a 9x18mm magazine for the standard-issue Commander pistol, with a capacity of 12 rounds."
 	contains = list(/obj/item/ammo_box/magazine/co9mm/empty)
 	cost = 150
 
 /datum/supply_pack/faction/nanotrasen/magazine/smgm9mm_mag
-	name = "9x18mm  SMG Magazine Crate"
-	desc = "Contains a 9x18mm  magazine for the Vector and Saber SMGs, with a capacity of thirty rounds."
+	name = "9x18mm SMG Magazine Crate"
+	desc = "Contains a 9x18mm magazine for the Vector and Saber SMGs, with a capacity of 30 rounds."
 	contains = list(/obj/item/ammo_box/magazine/smgm9mm/empty)
 	cost = 250
 
 /datum/supply_pack/faction/nanotrasen/magazine/wt550_mag
 	name = "WT-550 Auto Rifle Magazine Crate"
-	desc = "Contains a 9x18mm magazine for the WT-550 Auto Rifle, with a capacity of 30 rounds Each magazine is designed to facilitate rapid tactical reloads."
+	desc = "Contains a 4.6x30mm magazine for the WT-550 Auto Rifle, with a capacity of 20 rounds."
 	cost = 300
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/empty)
 
@@ -57,12 +57,12 @@ MARK: Energy weapons
 
 /datum/supply_pack/faction/nanotrasen/magazine/powercells_large
 	name = "NT Energy wWeapon Extra-Large Power Cell Crate"
-	desc = "The crate contains a extra-large battery for energy weapons."
+	desc = "The crate contains a EXTRA-LARGE battery for energy weapons."
 	contains = list(/obj/item/stock_parts/cell/gun/large/empty)
 	cost = 900
 
 /datum/supply_pack/faction/nanotrasen/magazine/gauss
 	name = "Gauss Magazine Crate"
-	desc = "A 24-round magazine for the prototype gauss rifle. Ferromagnetic pellets do okay damage with significant armor penetration."
+	desc = "Contains a Gauss magazine for the prototype gauss rifle, with a capacity of 24 rounds. Ferromagnetic pellets do okay damage with significant armor penetration."
 	contains = list(/obj/item/ammo_box/magazine/gauss/empty)
 	cost = 550

--- a/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/nanotrasen/magazines.dm
@@ -19,7 +19,7 @@ MARK: VI
 
 /datum/supply_pack/faction/nanotrasen/magazine/wt550_mag
 	name = "WT-550 Auto Rifle Magazine Crate"
-	desc = "Contains a 4.6x30mm magazine for the WT-550 Auto Rifle, with a capacity of 20 rounds."
+	desc = "Contains a 4.6x30mm magazine for the WT-550 Auto Rifle, with a capacity of 30 rounds."
 	cost = 300
 	contains = list(/obj/item/ammo_box/magazine/wt550m9/empty)
 

--- a/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/solfed/magazines.dm
@@ -33,19 +33,19 @@
 
 /datum/supply_pack/faction/solfed/magazine/a858
 	name = "8x58mm Caseless Clip"
-	desc = "A 5-round stripper clip for the SSG-669C rifle. These rounds do good damage with significant armor penetration"
+	desc = "Contains a stripper 8x58mm clip for the SSG-669C rifle, with a capacity of  5 rounds. These rounds do good damage with significant armor penetration"
 	contains = list(/obj/item/ammo_box/a858)
 	cost = 500
 
 /datum/supply_pack/faction/solfed/magazine/gauss
 	name = "Gauss Magazine"
-	desc = "A 24-round magazine for the prototype gauss rifle. Ferromagnetic pellets do okay damage with significant armor penetration."
+	desc = "Contains a Gauss magazine for the prototype gauss rifle, with a capacity of 24 rounds. Ferromagnetic pellets do okay damage with significant armor penetration."
 	contains = list(/obj/item/ammo_box/magazine/gauss/empty)
 	cost = 550
 
 /datum/supply_pack/faction/solfed/magazine/p16
 	name = "Model 82 Magazine (5.56x42mm)"
-	desc = "A simple, 30-round magazine for 5.56x42mm assault rifles. These rounds do moderate damage with good armor penetration."
+	desc = "Contains a 5.56x42mm magazine for the assault rifles, with a capacity of 30 rounds. These rounds do moderate damage with good armor penetration."
 	contains = list(/obj/item/ammo_box/magazine/p16/empty)
 	cost = 550
 

--- a/mod_celadon/outpost_console/code/supply_pack/syndicate/magazines.dm
+++ b/mod_celadon/outpost_console/code/supply_pack/syndicate/magazines.dm
@@ -86,12 +86,12 @@
 
 /datum/supply_pack/faction/syndicate/magazine/bulldog
 	name = "Bulldog Box Magazine Crate"
-	desc = "Contains an 8-round 12ga box magazine for the Bulldog weapons platform."
+	desc = "Contains a 12ga box magazine for the Bulldog weapons platform, with a capacity of 8 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m12g_bulldog/empty)
 	cost = 750
 
 /datum/supply_pack/faction/syndicate/magazine/bulldog_12
 	name = "Bulldog Drum Magazine Crate"
-	desc = "Contains a 12-round 12ga drum magazine for the Bulldog weapons platform."
+	desc = "Contains a 12ga drum magazine for the Bulldog weapons platform, with a capacity of 12 rounds."
 	contains = list(/obj/item/ammo_box/magazine/m12g_bulldog/drum/empty)
 	cost = 1500


### PR DESCRIPTION
## Описание / Что этот PR делает
Правки в описании не более

## Причина создания ПР / Почему это хорошо для игры
Стандартизация описания магазинов:
Калибр - Количество патрон которое он может содержать.

## Список изменений

```yml
🆑
spellcheck: Исправлена опечатка, стандартизированы описания у магазинов под единый стиль
/🆑
```
