### PR TITLE
REMOVE: Ограничение на покраску одежды

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -674,7 +674,7 @@
 
 		return
 
-// [CELADON-EDIT] -
+// [CELADON-EDIT] - UNFUCK_SPRAYCAN
 	//if(isobj(target) && !istype(target, /obj/effect/decal/cleanable/crayon/gang) && !istype(target, /obj/item/clothing))
 	if(isobj(target) && !istype(target, /obj/effect/decal/cleanable/crayon/gang))
 // [/CELADON-EDIT]

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -674,8 +674,10 @@
 
 		return
 
-
-	if(isobj(target) && !istype(target, /obj/effect/decal/cleanable/crayon/gang) && !istype(target, /obj/item/clothing))
+// [CELADON-EDIT] -
+	//if(isobj(target) && !istype(target, /obj/effect/decal/cleanable/crayon/gang) && !istype(target, /obj/item/clothing))
+	if(isobj(target) && !istype(target, /obj/effect/decal/cleanable/crayon/gang))
+// [/CELADON-EDIT]
 		if(actually_paints)
 			if(color_hex2num(paint_color) < 350 && !istype(target, /obj/structure/window) && !istype(target, /obj/effect/decal/cleanable/crayon)) //Colors too dark are rejected
 				to_chat(usr, span_warning("A color that dark on an object like this? Surely not..."))

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -17,6 +17,7 @@ ID мода: CELADON_QOL
 FIX_LATHE
 AUTOLATE_MAXSTACK
 ADMIN-PANEL
+UNFUCK_SPRAYCAN
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.


### PR DESCRIPTION
## Описание / Что этот PR делает
Включает перекраску одежды которая была выключена на Апстриме.

## Причина создания ПР / Почему это хорошо для игры
Отключаем нерф перекраски одежды, из-за тупой причины перекраски в темнейшие цвета на Астриме мета-генгом вместо того чтоб дать им ноты.

## Список изменений

```yml
🆑
add: Возвращает функционал перекраски одежды
/🆑
```
