### PR TITLE
MAP: Баг фикс Derelict Tradepost

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -277,29 +277,22 @@
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bb" = (
 /obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bc" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/hyper,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "bd" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
 	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/derelictoutpost/powerstorage)
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/plating/asteroid/smoothed,
+/area/ruin/space/has_grav/derelictoutpost)
 "be" = (
 /obj/structure/alien/weeds{
 	color = "#4BAE56";
@@ -428,6 +421,9 @@
 "br" = (
 /obj/machinery/power/terminal{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
@@ -1269,6 +1265,7 @@
 	icon_state = "trails_1";
 	name = "dried blood trail"
 	},
+/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/plating/asteroid/smoothed,
 /area/ruin/space/has_grav/derelictoutpost)
 "dp" = (
@@ -2022,6 +2019,15 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
+"BX" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium/blue,
+/area/ruin/space/has_grav/derelictoutpost/dockedship)
 "CW" = (
 /obj/structure/alien/weeds{
 	color = "#4BAE56";
@@ -2087,6 +2093,15 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
+"FW" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "HN" = (
 /obj/machinery/door/poddoor{
 	id = "bigderelictshipdock"
@@ -2094,6 +2109,15 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
+"In" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "Ir" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2384,7 +2408,7 @@ aC
 aC
 aA
 bc
-bs
+In
 bs
 bZ
 cp
@@ -2419,8 +2443,8 @@ ad
 aC
 aC
 aA
-bd
-br
+bb
+FW
 bJ
 ca
 cq
@@ -2635,7 +2659,7 @@ ax
 aE
 aO
 aO
-be
+BX
 bu
 be
 at
@@ -3615,7 +3639,7 @@ cF
 cS
 cZ
 do
-cR
+bd
 cm
 cm
 dR

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -80,7 +80,9 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "ar" = (
-/obj/machinery/power/shuttle/engine/electric,
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 2
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -111,7 +113,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/power/smes/shuttle,
+/obj/machinery/power/smes/shuttle{
+	dir = 2
+	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
@@ -124,7 +128,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/power/smes/shuttle,
+/obj/machinery/power/smes/shuttle{
+	dir = 2
+	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
@@ -1833,6 +1839,7 @@
 /obj/effect/turf_decal/corner/opaque/red{
 	dir = 8
 	},
+/obj/item/storage/box/ammo/c45,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/derelictoutpost)
 "kC" = (
@@ -1942,6 +1949,11 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
+"wZ" = (
+/obj/structure/table,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost/cargobay)
 "xA" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/multitool,
@@ -2007,6 +2019,16 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
+"DS" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/storage/box/ammo/c45,
+/turf/open/floor/plating/asteroid/smoothed,
+/area/ruin/space/has_grav/derelictoutpost)
 "Ei" = (
 /obj/structure/closet/crate,
 /obj/item/storage/pill_bottle/stimulant,
@@ -2021,10 +2043,19 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
 "EZ" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/derelictoutpost/cargobay)
+/obj/effect/turf_decal/corner/opaque/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/red,
+/obj/effect/turf_decal/corner/opaque/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/red{
+	dir = 8
+	},
+/obj/item/melee/knife/combat,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/derelictoutpost)
 "FV" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/storage/toolbox/mechanical,
@@ -2424,10 +2455,10 @@ af
 ai
 al
 ap
-aw
+wZ
 aw
 WJ
-EZ
+Rk
 aJ
 az
 bK
@@ -3005,7 +3036,7 @@ aa
 aa
 aY
 aK
-Xq
+EZ
 Oy
 Ir
 cz
@@ -3481,7 +3512,7 @@ cR
 cm
 dm
 cm
-dD
+DS
 cm
 cm
 cm

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -1869,6 +1869,15 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
+"nj" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/item/storage/box/ammo/a12g_buckshot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost)
 "of" = (
 /obj/structure/closet/crate,
 /obj/item/pda/clear,
@@ -2013,6 +2022,20 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
+"CW" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/effect/decal/cleanable/blood/old{
+	dir = 8;
+	icon_state = "trails_1";
+	name = "dried blood trail"
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/smoothed,
+/area/ruin/space/has_grav/derelictoutpost)
 "Dm" = (
 /obj/structure/closet/crate/medical,
 /obj/item/storage/firstaid/regular,
@@ -2195,6 +2218,15 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargostorage)
+"ZS" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/item/gun/ballistic/shotgun/brimstone/empty,
+/turf/open/floor/plating/asteroid/smoothed,
+/area/ruin/space/has_grav/derelictoutpost)
 
 (1,1,1) = {"
 aa
@@ -3476,7 +3508,7 @@ bF
 bF
 ci
 bF
-bl
+nj
 bF
 bl
 cm
@@ -3546,9 +3578,9 @@ aZ
 cE
 cR
 cm
-dn
+CW
 du
-cR
+ZS
 dt
 cR
 cR


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправил недочёты и ошибки, которые видимо появились при переносе  с другого билда на Целадон, также актуализровал лут, добавив пару ништяков которые были бы полезны для собирателей.

## Причина создания ПР / Почему это хорошо для игры
Ответ на Bug-Fix

## Демонстрация изменений / Тестирование
<img width="479" height="609" alt="image" src="https://github.com/user-attachments/assets/7837e82d-7e67-4458-ac0c-f847b99aeef7" />
<img width="340" height="243" alt="image" src="https://github.com/user-attachments/assets/69ac5925-0dc3-4e5e-8db3-79564ecc284e" />
<img width="129" height="156" alt="image" src="https://github.com/user-attachments/assets/bb0f0a3b-f798-4eff-ae4d-e62872a9ccd6" />


## Список изменений

```yml
🆑
tweak: Что-то изменено по мелочи
fix: Исправлена руинка Derelict Tradepost
/🆑
```
