### PR TITLE
ADD: Задержка сброса припасов

### DIFF
--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -265,6 +265,8 @@
 
 	flags_1 = NODECONSTRUCT_1
 	tgui_shared_states = list(outpostTab = "\"cargo\"")
+	
+	var/last_purchase_time = 0
 
 /obj/machinery/computer/cargo/faction/Initialize()
 	. = ..()
@@ -438,6 +440,13 @@
 /obj/machinery/computer/cargo/faction/independent/ui_static_data(mob/user)
 	var/list/data = faction_ui_static_data(user, /datum/faction/independent)
 	return data
+
+/obj/machinery/computer/cargo/faction/ui_act(action, params, datum/tgui/ui)
+	if(action == "add")
+		if(world.time < last_purchase_time + 50)
+			return FALSE
+		last_purchase_time = world.time
+	return ..()
 
 /obj/machinery/computer/cargo/faction/independent/computer_1
 	name = "Independent outpost console #1"

--- a/mod_celadon/outpost_console/code/console.dm
+++ b/mod_celadon/outpost_console/code/console.dm
@@ -443,7 +443,7 @@
 
 /obj/machinery/computer/cargo/faction/ui_act(action, params, datum/tgui/ui)
 	if(action == "add")
-		if(world.time < last_purchase_time + 50)
+		if(world.time < last_purchase_time + 10)
 			return FALSE
 		last_purchase_time = world.time
 	return ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет 1 секундную задержку для сброса ящиков в карго

## Причина создания ПР / Почему это хорошо для игры
Абьюз механик сброса ящиков по 5-10 штук на один тайл - не есть хорошо. Задержка может быть изменена по решению Шиптестхеда. Данный ПР был одобрен шиптест хэдом. Добавляет в игру небольшую эмерсивность происходящего.

## Список изменений

```yml
🆑
add: Задержка для сайплай подов
/🆑
```
