### PR TITLE
FIX: Непрозрачные стены EDGE

### DIFF
--- a/mod_celadon/maps/code/turfs_planet.dm
+++ b/mod_celadon/maps/code/turfs_planet.dm
@@ -165,6 +165,8 @@
 	light_power = 0
 	light_system = 0
 	dynamic_lighting = 0
+	opacity = 1
+	density = 1
 
 ///MARK: Тюрфы для модульной anima
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Вводим новые переменные для EDGE. Теперь сквозь них не видны объекты для мезон и эксрея, даже дебажным очкам не под силу увидеть что там за объекты на овермапе. Космос задник все ещё виден, но это максимум что можно будет увидеть

## Причина создания ПР / Почему это хорошо для игры
Фиксим баг кода на мету лайфхак овермапы через ангар

## Демонстрация изменений / Тестирование

<img width="1431" height="1014" alt="Screenshot_17" src="https://github.com/user-attachments/assets/9c15d40d-8dfb-4e39-993b-291b67c24273" />
<img width="1426" height="1017" alt="Screenshot_18" src="https://github.com/user-attachments/assets/b55aca2b-24f8-4347-826c-d0349b95aabb" />
<img width="1431" height="1004" alt="Screenshot_16" src="https://github.com/user-attachments/assets/25eedfa9-2bfc-4745-b048-4d1f3c09e7f3" />


## Список изменений

```yml
🆑
add: Добавлены параметры opacity = TRUE и density = TRUE для EDGE стен
/🆑
```
