### PR TITLE
FIX: Отображение амулета

### DIFF
--- a/mod_celadon/items/code/accessories.dm
+++ b/mod_celadon/items/code/accessories.dm
@@ -23,7 +23,7 @@
 
 /obj/item/clothing/accessory/tajaran/charm/raskariim
 	icon = 'mod_celadon/_storge_icons/icons/items/clothing/tajara_items_SORTIROVATI.dmi'
-	mob_overlay_icon = 'mod_celadon/_storge_icons/icons/items/clothing/tajara_items_overlay_SORTIROVATI.dmi'
+	mob_overlay_icon = null
 	name = "metal amulet"
 	desc = "An amulet made of some light metal."
 	icon_state = "raskara_amulet"


### PR DESCRIPTION
## Описание / Что этот PR делает
По канону, у этого амулета нету спрайтов оверлея. Я убрал обращение к атласу за спрайтом оверлея. Теперь амулет существует только как предмет, и на кукле не будет пока отображаться.

## Причина создания ПР / Почему это хорошо для игры
Closed #2015 

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
tweak: Зануление mob_overlay_icon
/🆑
```
