### PR TITLE
MAP: Коробка дисков для Flower

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_flower.dmm
@@ -1125,6 +1125,10 @@
 "MF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/item/storage/box/disks_plantgene{
+	pixel_x = 5;
+	pixel_y = 13
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/hydroponics)
 "MZ" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляем коробку дисков для Фловера

## Причина создания ПР / Почему это хорошо для игры
У всех есть диски, а у флавера нету. Не справедливо

## Демонстрация изменений / Тестирование
<img width="615" height="369" alt="image" src="https://github.com/user-attachments/assets/0a7c5b6d-9f57-4202-a5a4-405e49a9d15f" />


## Список изменений

```yml
🆑
add: Коробка дисков
/🆑
```
