### PR TITLE
MAP: Замена бракованного вента на Люксенбурге

### DIFF
--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
@@ -212,7 +212,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/open/floor/engine/plasma,


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняем вент на скрубер

## Причина создания ПР / Почему это хорошо для игры
Люксенбург не мог всасывать плазму с хранилища плазмы нормально

## Демонстрация изменений / Тестирование
<img width="773" height="684" alt="image" src="https://github.com/user-attachments/assets/883914bb-0abc-4dae-ac35-3b10f7757ff1" />


## Список изменений

```yml
🆑
tweak: Замена вента на скрубер
/🆑
```
