### PR TITLE
FIX: Автолат - Кнопки крафта стаков работают корректно

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -136,14 +136,16 @@
 				var/datum/component/material_container/mats = GetComponent(/datum/component/material_container)
 				for(var/datum/material/mat in D.materials)
 					max_multiplier = min(D.maxstack, round(mats.get_material_amount(mat)/D.materials[mat]))
-				if (max_multiplier>10 && !disabled)
-					m10 = TRUE
 // [CELADON-EDIT] - CELADON_QOL - AUTOLATE_MAXSTACK
+//				if (max_multiplier>10 && !disabled)
+//					m10 = TRUE
 //				if (max_multiplier>25 && !disabled)
 //					m25 = TRUE
-				if (max_multiplier>15 && !disabled)
+				if (max_multiplier>=10 && !disabled)
+					m10 = TRUE
+				if (max_multiplier>=15 && !disabled)
 					m15 = TRUE
-				if (max_multiplier>30 && !disabled)
+				if (max_multiplier>=30 && !disabled)
 					m30 = TRUE
 // [/CELADON-EDIT]
 		else


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет условия в функционале автолата, позволяя печатать стаки которые по некоторым причинам не были доступны когда все условия для их крафта были выполнены.

## Причина создания ПР / Почему это хорошо для игры
Изменение #1949 меняло `25` на `30`, но это в целом баг что был до этого в билде.
Заменяет `>` на `>=`

## Список изменений

```yml
🆑
fix: Кнопки стаков ( 10 / 15 / 30 ) в автолате работают корректно
/🆑
```
