### PR TITLE
FIX: Feeding another character Food

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -307,7 +307,8 @@ Behavior that's still missing from this component that original food items had t
 		return
 	var/fullness = eater.nutrition + 10 //The theoretical fullness of the person eating if they were to eat this
 
-	var/time_to_eat = (eater = feeder) ? eat_time : EAT_TIME_FORCE_FEED
+	var/time_to_eat = (eater == feeder) ? eat_time : EAT_TIME_FORCE_FEED
+
 	// [CELADON-ADD] - FIXES_VORACIOUS
 	// Voracious trait makes eating faster
 	if(eater == feeder && HAS_TRAIT(eater, TRAIT_VORACIOUS))


### PR DESCRIPTION
## Описание / Что этот PR делает
Кормление другого персонажа больше не приводит к тому, что кормящий персонаж ест то, что он пытается скормить другому

## Причина создания ПР / Почему это хорошо для игры
`var/time_to_eat` не присваивает значения, а сравнивает их, меняет логику `time_to_eat` - `=` -> `==` 
- Дубликат фикса: https://github.com/shiptest-ss13/Shiptest/pull/5291
- Discord/bugs-report: [Нельзя кормить других](https://canary.discord.com/channels/1100198143456465067/1402678427743420557)

## Демонстрация изменений / Тестирование
<details>
<summary>Видео</summary>

До:

https://github.com/user-attachments/assets/64f0ee7f-58ba-4d3c-89c1-5bf38e555282

После:

https://github.com/user-attachments/assets/25742a87-ff61-47b7-8a29-4d61c91ce73e

</details>

## Список изменений

```yml
🆑
fix: Кормление другого персонажа
/🆑
```