### PR TITLE
FIX: Исправляем сброс настроек торговых автоматов для аванпостов, часть 3

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -196,7 +196,11 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 
 	Radio = new /obj/item/radio(src)
 	Radio.listening = 0
-	if(istype(get_area(src.loc), /area/outpost) || istype(get_area(src.loc), /area/ruin))
+	// Машины на аванпостах сохранят значение all_items_free = TRUE если оно было установлено на карте.
+	// [CELADON-EDIT] - CELADON_BALANCE_VENDING - Машины на аванпостах сохранят значение all_items_free = TRUE если оно было установлено на карте
+	// if(istype(get_area(src.loc), /area/outpost) || istype(get_area(src.loc), /area/ruin))	// ORIGINAL
+	if(all_items_free && istype(get_area(src.loc), /area/ruin))
+	// [/CELADON-EDIT]
 		all_items_free = FALSE
 
 /obj/machinery/vending/Destroy()

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -19,6 +19,7 @@ ID мода:
 	CELADON_BALANCE_CHISEL
 	CELADON_BALANCE_OVERMAP_EVENTS
 	CELADON_BALANCE_SPECIES
+	CELADON_BALANCE_VENDING
 	BALLISTIC_SHIELD
 	YOU_NOT_SEPARATIST
 <!--
@@ -130,6 +131,9 @@ ADD: `code/game/objects/items/tools/chisel.dm` : видоизменяем дол
 
 YOU_NOT_SEPARATIST
 ADD: `code/modules/mob/dead/new_player/ship_select.dm` : Добавляем сокрытие определенных кораблей для определенных видов
+
+CELADON_BALANCE_VENDING
+EDIT: `code/modules/vending/_vending.dm` : Убираем автоматическое сбрасывание к платным покупкам у всех торрговых автоматах что НЕ относятся к руинкам
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь на картах аванпостов не будет принудительно выставляться настройка ТОЛЬКО платные торговые автоматы, даже если у автоматов в картах был прописан параметр БЕСПЛАТНО

## Список изменений

```yml
🆑
tweak: условие определения карты
/🆑
```
