### PR TITLE
ADD: Стороны света для неоновых ламп для карт аванпостов, часть 7

### DIFF
--- a/mod_celadon/neon_pack/code/light.dm
+++ b/mod_celadon/neon_pack/code/light.dm
@@ -30,11 +30,15 @@
 			icon_state = "tube-broken"
 			on = 0
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored, 13)
+
 /obj/machinery/light/colored/orange
 	base_state = "orange"		// base description and icon_state
 	icon_state = "orange1"
 	color = LIGHT_COLOR_ORANGE
 	light_color = LIGHT_COLOR_ORANGE
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/orange, 13)
 
 /obj/machinery/light/colored/purple
 	base_state = "purple"		// base description and icon_state
@@ -42,11 +46,15 @@
 	color = LIGHT_COLOR_PURPLE
 	light_color = LIGHT_COLOR_PURPLE
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/purple, 13)
+
 /obj/machinery/light/colored/red
 	base_state = "red"		// base description and icon_state
 	icon_state = "red1"
 	color = LIGHT_COLOR_RED
 	light_color = LIGHT_COLOR_RED
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/red, 13)
 
 /obj/machinery/light/colored/pink
 	base_state = "pink"		// base description and icon_state
@@ -54,11 +62,15 @@
 	color = LIGHT_COLOR_PINK
 	light_color = LIGHT_COLOR_PINK
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/pink, 13)
+
 /obj/machinery/light/colored/blue
 	base_state = "blue"		// base description and icon_state
 	icon_state = "blue1"
 	color = LIGHT_COLOR_BLUE
 	light_color = LIGHT_COLOR_BLUE
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/blue, 13)
 
 /obj/machinery/light/colored/green
 	base_state = "green"		// base description and icon_state
@@ -66,8 +78,12 @@
 	color = LIGHT_COLOR_GREEN
 	light_color = LIGHT_COLOR_GREEN
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/green, 13)
+
 /obj/machinery/light/colored/white
 	base_state = "white"		// base description and icon_state
 	icon_state = "white1"
 	color = "#f0ffff"
 	light_color = "#f0ffff"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/colored/white, 13)


### PR DESCRIPTION
## Описание / Что этот PR делает
У неоновых ламп, не было сторон света, теперь они есть. Удобно

## Список изменений

```yml
🆑
add: Направления для неоновых ламп
/🆑
```
