### PR TITLE
FIX: Коробки с кольцами

### DIFF
--- a/mod_celadon/items/code/rings.dm
+++ b/mod_celadon/items/code/rings.dm
@@ -42,19 +42,44 @@
 	desc = "A tiny box covered in soft red felt made for holding rings."
 	icon = 'mod_celadon/_storge_icons/icons/items/misc/ring.dmi'
 	icon_state = "gold ringbox"
+	base_icon_state = "gold ringbox"
 	w_class = WEIGHT_CLASS_TINY
 	spawn_type = /obj/item/clothing/gloves/ring
-	// spawn_count = 1
+	contents_tag = "ring"
 
-/obj/item/storage/fancy/ringbox/Initialize(mapload)
+/obj/item/storage/fancy/ringbox/ComponentInitialize()
 	. = ..()
-	// atom_storage.max_slots = 1
-	// atom_storage.can_hold = typecacheof(list(/obj/item/clothing/gloves/ring))
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 1
+	STR.set_holdable(list(/obj/item/clothing/gloves/ring))
+
+/obj/item/storage/fancy/ringbox/PopulateContents()
+	if(spawn_type)
+		new spawn_type(src)
+
+/obj/item/storage/fancy/ringbox/update_icon_state()
+	if(!is_open)
+		icon_state = base_icon_state
+		return ..()
+
+	if(!contents.len)
+		icon_state = "[base_icon_state]0"
+	else
+		var/obj/item/clothing/gloves/ring/ring = contents[1]
+		if(istype(ring, /obj/item/clothing/gloves/ring/diamond))
+			icon_state = "[base_icon_state]1"
+		else if(istype(ring, /obj/item/clothing/gloves/ring/silver))
+			icon_state = "[base_icon_state]1"
+		else
+			icon_state = "[base_icon_state]1"
+	return ..()
 
 /obj/item/storage/fancy/ringbox/diamond
 	icon_state = "diamond ringbox"
+	base_icon_state = "diamond ringbox"
 	spawn_type = /obj/item/clothing/gloves/ring/diamond
 
 /obj/item/storage/fancy/ringbox/silver
 	icon_state = "silver ringbox"
+	base_icon_state = "silver ringbox"
 	spawn_type = /obj/item/clothing/gloves/ring/silver


### PR DESCRIPTION
## Описание / Что этот PR делает
Существовал недоработанный ПР на кольца. Портировал криво, что аж при спавне коробки с 1 кольцом, владелец получал 8 брилиантовых колец, вместо 1. Исправлена логика спавна колец. А также добавлена свои спарйты для полуоткрытых коробок нажать Z держа в руке коробочку

## Причина создания ПР / Почему это хорошо для игры
Старое надо чинить. Данный предмет ляжет в основу другого ПРа

## Список изменений

```yml
🆑
fix: Логика и работа красных коробочек с кольцами
/🆑
```
