### PR TITLE
FIXES: Жукбокс и МУЗ-ТV

### DIFF
--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -113,10 +113,10 @@ SUBSYSTEM_DEF(jukeboxes)
 		var/list/virtual_ids = list(zone.id)
 		var/list/areas = list(get_area(jukebox))
 		if(above_turf && istransparentturf(above_turf))
-			virtual_ids += above_turf.virtual_z
+			// virtual_ids += above_turf.virtual_z	// [CELADON-REMOVE] - FIXES_JUKEBOX - Попытка починить баг со слышимостью на соседних вирт. уровнях
 			areas += get_area(above_turf)
 		if(below_turf && istransparentturf(below_turf))
-			virtual_ids += below_turf.virtual_z
+			// virtual_ids += below_turf.virtual_z	// [CELADON-REMOVE] - FIXES_JUKEBOX - Попытка починить баг со слышимостью на соседних вирт. уровнях
 			areas += get_area(below_turf)
 
 		song_played.falloff = jukeinfo[4]

--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -94,8 +94,12 @@ SUBSYSTEM_DEF(jukeboxes)
 		if(!istype(juketrack))
 			stack_trace("Invalid jukebox track datum.")
 			continue
-		var/obj/machinery/jukebox/jukebox = jukeinfo[3]
-		if(!istype(jukebox))
+		// [CELADON-EDIT] - FIXES_JUKEBOX - Убираем строгость, чтобы можно было обращаться и к другим подобным жукбоксам объектам
+		// var/obj/machinery/jukebox/jukebox = jukeinfo[3]
+		// if(!istype(jukebox))	// ORIGINAL
+		var/obj/jukebox = jukeinfo[3]
+		if(!jukebox)
+		// [/CELADON-EDIT]
 			stack_trace("Nonexistant or invalid object associated with jukebox.")
 			continue
 		var/sound/song_played = sound(juketrack.song_path)
@@ -123,14 +127,23 @@ SUBSYSTEM_DEF(jukeboxes)
 				continue
 
 			var/inrange = FALSE
-			if(jukebox.volume <= 0 || !(M.virtual_z() in virtual_ids))
+			// [CELADON-EDIT] - FIXES_JUKEBOX - Для работоспособности звука, выносим громкость в общий параметр объекта
+			// if(jukebox.volume <= 0 || !(M.virtual_z() in virtual_ids)) // ORIGINAL
+			var/juke_volume = 70
+			if(jukebox.vars.Find("volume"))
+				juke_volume = jukebox.vars["volume"]
+			if(juke_volume <= 0 || !(M.virtual_z() in virtual_ids))
+			// [/CELADON-EDIT]
 				song_played.status = SOUND_MUTE | SOUND_UPDATE
 			else
 				song_played.status = SOUND_UPDATE
 				if((get_area(M) in areas) || (M in hearerscache))
 					inrange = TRUE
 
-			M.playsound_local(currentturf, null, jukebox.volume, channel = jukeinfo[2], S = song_played, envwet = (inrange ? -250 : 0), envdry = (inrange ? 0 : -10000))
+			// [CELADON-EDIT] - FIXES_JUKEBOX - Для работоспособности звука, выносим громкость в общий параметр объекта
+			// M.playsound_local(currentturf, null, jukebox.volume, channel = jukeinfo[2], S = song_played, envwet = (inrange ? -250 : 0), envdry = (inrange ? 0 : -10000))
+			M.playsound_local(currentturf, null, juke_volume, channel = jukeinfo[2], S = song_played, envwet = (inrange ? -250 : 0), envdry = (inrange ? 0 : -10000))
+			// [/CELADON-EDIT]
 
 			if(MC_TICK_CHECK)
 				return

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -203,6 +203,10 @@ FIXES_TESLA_ON_OVERMAP
 FIXES_VORACIOUS
 - ADD: `code/datums/components/food/edible.dm` - добавляем проверку на квирк и ускоряем процес поедания в 2 раза
 
+FIXES_JUKEBOX
+- EDIT: `code/controllers/subsystem/jukeboxes.dm` - правим нахождение звука и типа, для работы muz-tv. Попытка исправить просачивание музыки сквозь EDGE
+
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/mod_celadon/moniq/code/moniq.dm
+++ b/mod_celadon/moniq/code/moniq.dm
@@ -18,6 +18,9 @@
 	pixel_x = -8
 	sign_path = /obj/structure/sign/moniq
 
+/obj/item/sign/moniq/proc/can_hear()
+	return TRUE
+
 /obj/item/sign/moniq/Initialize()
 	. = ..()
 	var/matrix/M = transform
@@ -123,7 +126,7 @@
 				return TRUE
 
 /obj/item/sign/moniq/proc/activate_music()
-	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection, 2) //WS Edit Cit #7367 & #7458
+	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection, 1) // Изменил falloff на 1
 	if(jukeboxslottotake)
 		active = TRUE
 		update_appearance()
@@ -160,7 +163,6 @@
 	icon = 'mod_celadon/moniq/icons/jukebox.dmi'
 	icon_state = "moniq_wallmount"
 	verb_say = "states"
-	verb_say = "states"
 	density = FALSE
 	var/active = FALSE
 	var/list/rangers = list()
@@ -169,6 +171,9 @@
 	/// Volume of the songs played
 	var/volume = 70
 	pixel_x = -8
+
+/obj/structure/sign/moniq/proc/can_hear()
+	return TRUE
 
 
 /obj/structure/sign/moniq/Destroy()
@@ -270,7 +275,7 @@
 				return TRUE
 
 /obj/structure/sign/moniq/proc/activate_music()
-	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection, 2) //WS Edit Cit #7367 & #7458
+	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection, 1) // Изменил falloff на 1
 	if(jukeboxslottotake)
 		active = TRUE
 		update_appearance()


### PR DESCRIPTION
## Описание / Что этот PR делает
Muz-TV был отремонтирован, теперь он воспроизводит музыку как и должен делать это жукбокс.
Также, сделана попытка пофиксить древний баг, когда люди могли слышать музыку с соседних вирт.уровней. 
Требуется тестирование

## Список изменений

```yml
🆑
fix: muz-tv
fix: просачивание музыки сквозь виртуальные уровни
/🆑
```
