### PR TITLE
ADD: Морг с трупом для аванпостов, часть 10

### DIFF
--- a/mod_celadon/effects/_effects.dme
+++ b/mod_celadon/effects/_effects.dme
@@ -3,6 +3,7 @@
 
 #include "_effects.dm"
 
+#include "code/morgue.dm"
 #include "code/smoke.dm"
 
 #endif

--- a/mod_celadon/effects/code/morgue.dm
+++ b/mod_celadon/effects/code/morgue.dm
@@ -1,0 +1,12 @@
+/obj/structure/bodycontainer/morgue/with_corpse
+	var/corpse_spawned = FALSE
+
+/obj/structure/bodycontainer/morgue/with_corpse/open()
+	if(!corpse_spawned)
+		corpse_spawned = TRUE
+		var/turf/T = get_step(src, dir)
+		var/mob/living/carbon/human/corpse = new(T)
+		corpse.death()
+		corpse.Drain()
+		playsound(src, 'sound/hallucinations/growl1.ogg', 100, TRUE)
+	. = ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
Оказывается нельзя просто так взять, и положить внутрь морга, контейнера заготовленынй труп. А как тогда коронеру в будущем жить? Теперь у него есть труп

## Список изменений

```yml
🆑
add: Объект морг с трупом внутри себя
/🆑
```
