### PR TITLE
ADD: Новый тип порталов с рандомизацией

### DIFF
--- a/mod_celadon/effects/_effects.dme
+++ b/mod_celadon/effects/_effects.dme
@@ -5,6 +5,7 @@
 
 #include "code/dirt_pile.dm"
 #include "code/morgue.dm"
+#include "code/random_portal.dm"
 #include "code/smoke.dm"
 #include "code/spawners.dm"
 

--- a/mod_celadon/effects/code/random_portal.dm
+++ b/mod_celadon/effects/code/random_portal.dm
@@ -14,7 +14,12 @@
 
 	if(possible_portals.len)
 		linked = pick(possible_portals)
+	else
+		linked = null
 
 /obj/effect/portal/permanent/random/teleport(atom/movable/M, force = FALSE)
 	set_linked()
+	if(!linked)
+		do_teleport(M, get_turf(src), 10)
+		return
 	. = ..(M, force)

--- a/mod_celadon/effects/code/random_portal.dm
+++ b/mod_celadon/effects/code/random_portal.dm
@@ -1,0 +1,20 @@
+/obj/effect/portal/permanent/random
+	name = "random portal"
+	desc = "A mysterious portal that leads to random destinations."
+	var/list/portal_ids = list()
+
+/obj/effect/portal/permanent/random/set_linked()
+	if(!portal_ids.len)
+		return
+
+	var/list/possible_portals = list()
+	for(var/obj/effect/portal/permanent/P in GLOB.portals - src)
+		if(P.id in portal_ids)
+			possible_portals += P
+
+	if(possible_portals.len)
+		linked = pick(possible_portals)
+
+/obj/effect/portal/permanent/random/teleport(atom/movable/M, force = FALSE)
+	set_linked()
+	. = ..(M, force)


### PR DESCRIPTION
## Описание / Что этот PR делает
Рандомный портал перманентный добавляет возможность перейти к рандомному порталу из списка. 
Задается portal_ids список вида
`list()` -> `list("name1";"name2"...)`
Где name это название другого портала.
Если, был указан неверно список, или портал не существует, то игрока переместит рандомно от портала в рандомную точку в пределах 10 тайлов

## Причина создания ПР / Почему это хорошо для игры
Требуется для аванпоста и для руинок

## Список изменений

```yml
🆑
add: Порталы с рандомизацией
/🆑
```
