### PR TITLE
FIX: Комната ошибка и порталы между уровнями

### DIFF
--- a/_maps/_mod_celadon/map_files/centcomm_ship.dmm
+++ b/_maps/_mod_celadon/map_files/centcomm_ship.dmm
@@ -579,10 +579,11 @@
 /area/centcom/control)
 "bG" = (
 /obj/effect/landmark/error,
-/turf/open/floor/plating/ashplanet/wateryrock{
+/turf/open/floor/plating/asteroid/waterplanet{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	planetary_atmos = 0
-	})
+	},
+/area/errorroom)
 "bH" = (
 /obj/structure/closet/crate/critter{
 	name = "DANGER: DO NOT OPEN"
@@ -2107,14 +2108,15 @@
 /area/abductor_ship)
 "gg" = (
 /obj/structure/signpost/salvation{
+	invisibility = 100;
 	icon = 'icons/obj/structures.dmi';
-	icon_state = "ladder10";
-	invisibility = 100
+	icon_state = "ladder10"
 	},
-/turf/open/floor/plating/ashplanet/wateryrock{
+/turf/open/floor/plating/asteroid/waterplanet{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	planetary_atmos = 0
-	})
+	},
+/area/errorroom)
 "gh" = (
 /turf/closed/indestructible/abductor,
 /area/abductor_ship)
@@ -2647,6 +2649,13 @@
 	light_range = 2
 	},
 /area/outpost/exterior)
+"hC" = (
+/obj/structure/flora/tree/dead_pine,
+/turf/open/floor/plating/asteroid/waterplanet{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/errorroom)
 "hD" = (
 /obj/effect/turf_decal/corner/transparent/neutral/full,
 /obj/structure/railing/modern/corner{
@@ -5102,6 +5111,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"oA" = (
+/obj/structure/flora/rock/asteroid,
+/turf/open/floor/plating/asteroid/waterplanet{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/errorroom)
 "oB" = (
 /obj/effect/turf_decal/elysium_logo/two_one,
 /turf/open/floor/marble/black,
@@ -7092,7 +7108,8 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
 "uo" = (
-/turf/closed/mineral/ash_rock)
+/turf/closed/mineral/random/waterplanet,
+/area/errorroom)
 "up" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/gun/energy/taser,
@@ -8437,6 +8454,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"yn" = (
+/obj/item/rupee,
+/turf/open/floor/plating/asteroid/waterplanet{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/errorroom)
 "yo" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north{
@@ -8804,6 +8828,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/control)
+"zs" = (
+/obj/structure/flora/rock/asteroid,
+/obj/item/rupee,
+/turf/open/floor/plating/asteroid/waterplanet{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+	planetary_atmos = 0
+	},
+/area/errorroom)
 "zt" = (
 /obj/structure/table/wood,
 /obj/structure/plaque/static_plaque/golden{
@@ -9243,7 +9275,8 @@
 /area/centcom)
 "AD" = (
 /obj/structure/speaking_tile,
-/turf/closed/mineral/ash_rock)
+/turf/closed/mineral/random/waterplanet,
+/area/errorroom)
 "AE" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -13633,7 +13666,8 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "MW" = (
-/turf/closed/indestructible/riveted)
+/turf/closed/indestructible/riveted,
+/area/errorroom)
 "MX" = (
 /obj/effect/turf_decal/corner/transparent/neutral{
 	dir = 8
@@ -15033,6 +15067,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"QY" = (
+/obj/item/rupee,
+/turf/open/water/stormy_planet_lit{
+	planetary_atmos = 0
+	},
+/area/errorroom)
 "QZ" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdomegen";
@@ -15408,11 +15448,10 @@
 /turf/open/floor/wood,
 /area/centcom/control)
 "RW" = (
-/obj/item/rupee,
-/turf/open/floor/plating/ashplanet/wateryrock{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
+/turf/open/water/stormy_planet_lit{
 	planetary_atmos = 0
-	})
+	},
+/area/errorroom)
 "RY" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien18"
@@ -17604,10 +17643,11 @@
 /turf/open/floor/plasteel/dark/wasteplanet,
 /area/outpost/exterior)
 "Yl" = (
-/turf/open/floor/plating/ashplanet/wateryrock{
+/turf/open/floor/plating/asteroid/waterplanet{
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15";
 	planetary_atmos = 0
-	})
+	},
+/area/errorroom)
 "Ym" = (
 /obj/effect/turf_decal/corner/opaque/red/three_quarters{
 	dir = 2
@@ -19075,13 +19115,13 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
+zs
+yn
 Yl
+yn
 RW
-RW
-RW
+QY
+zs
 uo
 MW
 gd
@@ -19268,11 +19308,11 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
 Yl
-RW
+hC
+Yl
+Yl
+Yl
 RW
 RW
 uo
@@ -19461,13 +19501,13 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
+yn
 Yl
+yn
+Yl
+hC
 RW
-RW
-RW
+QY
 uo
 MW
 gd
@@ -19654,13 +19694,13 @@ gd
 gd
 MW
 uo
+hC
 Yl
 Yl
 Yl
+oA
 Yl
-Yl
-Yl
-Yl
+RW
 uo
 MW
 gd
@@ -19847,10 +19887,10 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
+yn
 Yl
+Yl
+yn
 Yl
 Yl
 Yl
@@ -20040,9 +20080,9 @@ gd
 gd
 MW
 AD
-RW
-RW
-RW
+Yl
+Yl
+Yl
 Yl
 Yl
 bG
@@ -20233,10 +20273,10 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
 Yl
+yn
+Yl
+yn
 Yl
 Yl
 Yl
@@ -20426,7 +20466,7 @@ gd
 gd
 MW
 uo
-Yl
+hC
 Yl
 Yl
 Yl
@@ -20619,13 +20659,13 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
+oA
 Yl
-RW
-RW
-RW
+hC
+Yl
+yn
+hC
+yn
 uo
 MW
 gd
@@ -20812,13 +20852,13 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
 Yl
-RW
-RW
-RW
+yn
+Yl
+Yl
+Yl
+Yl
+Yl
 uo
 MW
 gd
@@ -21005,13 +21045,13 @@ gd
 gd
 MW
 uo
-RW
-RW
-RW
+yn
+hC
 Yl
-RW
-RW
-RW
+Yl
+zs
+yn
+hC
 uo
 MW
 gd

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -4357,11 +4357,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
@@ -10167,12 +10167,10 @@
 /turf/open/floor/plasteel/mono,
 /area/outpost/fraction/solfed)
 "fTD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/showroomfloor,
 /area/outpost/medical/hall_1)
 "fTX" = (
 /obj/structure/disposalpipe/segment{
@@ -15491,23 +15489,17 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "jaC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
@@ -17674,17 +17666,8 @@
 	},
 /area/outpost/medical/storage)
 "kqV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
@@ -22686,14 +22669,6 @@
 	light_range = 2
 	},
 /area/outpost/exterior)
-"nqj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/outpost/medical/hall_1)
 "nql" = (
 /obj/structure/chair/bench/grey/directional/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -22873,7 +22848,9 @@
 /turf/closed/indestructible/wood,
 /area/outpost/crew/lounge/cab_2)
 "ntV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "nui" = (
@@ -23404,11 +23381,6 @@
 	},
 /area/outpost/crew/lounge/cab_2)
 "nLY" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /obj/machinery/door/window{
 	req_ship_access = 1;
 	dir = 4
@@ -29272,21 +29244,6 @@
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/outpost/operations/outpost_command)
-"rjc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/outpost/medical/hall_1)
 "rjl" = (
 /obj/structure/painting_custom{
 	pixel_y = 32;
@@ -33141,16 +33098,7 @@
 	},
 /area/outpost/exterior)
 "twq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/corner/opaque/blue,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
@@ -40676,16 +40624,10 @@
 /turf/open/floor/plasteel/white,
 /area/outpost/fraction/solfed)
 "xSj" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/corner/opaque/blue/half,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
@@ -66526,7 +66468,7 @@ oUm
 oUm
 oUm
 oUm
-rgY
+oUm
 wes
 wes
 wes
@@ -66709,11 +66651,11 @@ ibZ
 rgP
 gEr
 vZQ
-rjc
+sTY
 oUm
 nLY
+fTD
 oUm
-rgY
 eQc
 eNA
 nBQ
@@ -66894,13 +66836,13 @@ ulU
 iiX
 nay
 ntV
-ntV
-ntV
-kqV
+sTY
+sTY
+sTY
 oWF
 lLv
 oUm
-eQc
+oUm
 eQc
 wgi
 wLi
@@ -67267,9 +67209,9 @@ tbZ
 mKO
 alx
 jaC
-fTD
-nqj
-nqj
+hxq
+hxq
+hxq
 xSj
 oUm
 oUm
@@ -67454,7 +67396,7 @@ iHZ
 wVy
 qtt
 cGJ
-sTY
+kqV
 sTY
 sTY
 sOn

--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -57,6 +57,21 @@
 	desc = "In the darkest times, we will find our way home."
 	resistance_flags = INDESTRUCTIBLE
 
+// [CELADON-ADD] - CELADON_FIXES_DEBUG_ROOM
+/obj/structure/signpost/salvation/interact(mob/user)
+	if(alert(question,name,"Yes","No") == "Yes" && Adjacent(user))
+		var/turf/T = locate(139, 31, 3)
+		if(T)
+			var/atom/movable/AM = user.pulling
+			if(AM)
+				AM.forceMove(T)
+			user.forceMove(T)
+			if(AM)
+				user.start_pulling(AM)
+			to_chat(user, span_notice("You blink and find yourself in [get_area_name(T)]."))
+		else
+			to_chat(user, "Nothing happens. You feel that this is a bad sign.")
+// [/CELADON-ADD]
 /obj/structure/signpost/exit
 	name = "exit"
 	desc = "Make sure to bring all your belongings with you when you \

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -112,7 +112,10 @@
 
 /obj/structure/speaking_tile/proc/SpeakPeace(list/statements)
 	for(var/i in 1 to statements.len)
-		say(span_deadsay("[statements[i]]"))
+		// [CELADON-EDIT] - CELADON_FIXES_DEBUG_ROOM
+		// say(span_deadsay("[statements[i]]"))	// ORIGINAL
+		visible_message(span_deadsay("[src] [verb_say], \"[statements[i]]\""))
+		// [/CELADON-EDIT]
 		if(i != statements.len)
 			sleep(30)
 

--- a/mod_celadon/effects/_effects.dme
+++ b/mod_celadon/effects/_effects.dme
@@ -7,5 +7,6 @@
 #include "code/morgue.dm"
 #include "code/smoke.dm"
 #include "code/spawners.dm"
+#include "code/z_level_portal.dm"
 
 #endif

--- a/mod_celadon/effects/code/z_level_portal.dm
+++ b/mod_celadon/effects/code/z_level_portal.dm
@@ -1,0 +1,47 @@
+/obj/machinery/z_level_teleporter
+	name = "dimensional gateway"
+	desc = "A powerful gateway that can transport between dimensional levels."
+	icon = 'icons/obj/stationobjs.dmi'
+	icon_state = "portal"
+	anchored = TRUE
+	density = TRUE
+	var/target_z
+	var/target_x
+	var/target_y
+	var/last_teleport = 0
+
+/obj/machinery/z_level_teleporter/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	teleport_user(user)
+
+/obj/machinery/z_level_teleporter/Bumped(atom/movable/bumper)
+	teleport_user(bumper)
+
+/obj/machinery/z_level_teleporter/proc/teleport_user(atom/movable/M)
+	if(!target_z || !target_x || !target_y)
+		return
+	if(world.time < last_teleport + 10)
+		return
+	var/turf/target = locate(target_x, target_y, target_z)
+	if(!target)
+		return
+	last_teleport = world.time
+	var/datum/effect_system/spark_spread/sparks = new
+	sparks.set_up(5, 1, get_turf(M))
+	sparks.start()
+	M.forceMove(target)
+	sparks = new
+	sparks.set_up(5, 1, target)
+	sparks.start()
+
+/obj/machinery/z_level_teleporter/centcomm_to_outpost
+	name = "outpost gateway"
+	desc = "A gateway leading to the frontier outpost."
+	// Установить координаты в мапе
+
+/obj/machinery/z_level_teleporter/outpost_to_centcomm
+	name = "centcomm gateway"
+	desc = "A gateway leading back to central command."
+	// Установить координаты в мапе

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -15,6 +15,7 @@
 ID мода: 
 CELADON_FIXES
 CELADON_FIXES_BLOOD
+CELADON_FIXES_DEBUG_ROOM
 FIX_DISPLAY_TRUSTER
 FIXES_ICON_IN_HAND_MOB
 FIXES_ICON
@@ -206,6 +207,9 @@ FIXES_VORACIOUS
 FIXES_JUKEBOX
 - EDIT: `code/controllers/subsystem/jukeboxes.dm` - правим нахождение звука и типа, для работы muz-tv. Попытка исправить просачивание музыки сквозь EDGE
 
+CELADON_FIXES_DEBUG_ROOM
+- EDIT: `code/modules/awaymissions/super_secret_room.dm` - фиксит сообщения для чата
+- ADD: `code/modules/awaymissions/signpost.dm` - фиксит лестницу, тепешает на координаты 139, 31, 3
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Ну, чинит комнату ошибки, делая возможным нормально клацать по странному камню, который нормально проявляет лестницу, а та в свою очередь отправляет игроков назад на аванпост уровень, к вагабондам.
Чинит заодно кривой атмос на аванпосту
Добавляет спец порталы между уровнями, по точным координатам.

## Причина создания ПР / Почему это хорошо для игры
Сломано - плохо

## Список изменений

```yml
🆑
add: спец порталы для телепорта между уровнями по координатам
fix: комната ошибки
fix: косячный атмос на аванпосту
fix: карта комнаты ошибки починена
/🆑
```
