### PR TITLE
MAP: Add train yard

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_trainyard.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_trainyard.dmm
@@ -1,0 +1,15348 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ad" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"af" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_gt_main"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"ak" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"al" = (
+/obj/effect/radiation,
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/power/port_gen/pacman/super/not_very,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/train)
+"am" = (
+/obj/structure/chair/bench/grey/directional/north,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"an" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "floor4"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/cargo)
+"ao" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"ap" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "tr_sh_st"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"ar" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ax" = (
+/obj/structure/table,
+/obj/item/storage/bottles/moonshine{
+	pixel_y = 1;
+	pixel_x = -7
+	},
+/obj/item/storage/bottles/moonshine{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/borderfloorblack/corner,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"az" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aA" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"aC" = (
+/obj/structure/table,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aF" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/marker_beacon/thirty{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/stack/marker_beacon/thirty{
+	pixel_y = 8;
+	pixel_x = -9
+	},
+/obj/item/gun/ballistic/shotgun/blasting_hammer,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"aK" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"aL" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 18
+	},
+/obj/item/cigbutt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"aO" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/hypospray/medipen/morphine{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/hypospray/medipen/survival{
+	pixel_x = 5;
+	pixel_y = 2;
+	name = "adrenaline stimpak"
+	},
+/obj/item/reagent_containers/pill/three_eye{
+	name = "strange pill";
+	desc = "A strange pill found in the depths of maintenance";
+	pixel_y = 12;
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"aP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"aQ" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"aS" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aT" = (
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"aV" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_x = -16;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_x = 16;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aY" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 16
+	},
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"ba" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"bb" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_gt_main"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"bg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "tr_sh_wes"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"bj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/slug,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/cargo)
+"bm" = (
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"bq" = (
+/obj/structure/frame,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"bz" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"bD" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 18
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"bF" = (
+/obj/effect/supplypod_rubble,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bH" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_st_dr"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "tr_sh_holo"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/shuttle)
+"bK" = (
+/obj/item/mine/directional/claymore/live{
+	dir = 4
+	},
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"bN" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"bO" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bR" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"bV" = (
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"bX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"cb" = (
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"cc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ce" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "mining"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"cf" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cg" = (
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"cj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"cm" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"cn" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"cq" = (
+/obj/structure/platform/military{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"cE" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"cM" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cP" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"cQ" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_y = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cT" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "Tr_sh_tr"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/train)
+"cW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "tr_wd_main"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"dd" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"de" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/stack/medical/suture/five,
+/obj/effect/spawner/random/trash/mess,
+/obj/effect/turf_decal/syndicateemblem/bottom/middle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"dm" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"dp" = (
+/obj/structure/girder,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dr" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"ds" = (
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"du" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"dv" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"dz" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "eng_secure"
+	},
+/obj/item/clothing/under/rank/engineering/engineer/nt,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"dB" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"dF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"dI" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"dJ" = (
+/obj/structure/table,
+/obj/item/storage/box/ammo/c9mm{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dO" = (
+/obj/structure/reagent_dispensers/beerkeg{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/sign/poster/contraband/bulldog{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"dT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"dU" = (
+/obj/structure/rack,
+/obj/item/door_seal{
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/obj/item/door_seal{
+	pixel_y = 3
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"ec" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plasteel/tech/grid,
+/area/overmap_encounter/planetoid/sand/explored)
+"eg" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = -9;
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"ej" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "pavement_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"em" = (
+/obj/structure/railing/thin{
+	dir = 10
+	},
+/obj/structure/safe{
+	number_of_tumblers = 5;
+	armor = list("melee" = 30, "bullet" = 60, "laser" = 60, "energy" = 100, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30);
+	desc = "A huge chunk of metal with a dial embedded in it. Fine print on the dial reads \"Scarborough Arms - 5 tumbler safe, guaranteed thermite resistant, explosion resistant, and assistant resistant.\""
+	},
+/obj/item/ammo_casing/caseless/rocket{
+	desc = "An 84mm high explosive rocket. Looks like they'd fit into a launcher"
+	},
+/obj/item/ammo_casing/caseless/rocket{
+	desc = "An 84mm high explosive rocket. Looks like they'd fit into a launcher"
+	},
+/obj/item/ammo_casing/caseless/rocket{
+	desc = "An 84mm high explosive rocket. Looks like they'd fit into a launcher"
+	},
+/obj/item/ammo_casing/caseless/rocket{
+	desc = "An 84mm high explosive rocket. Looks like they'd fit into a launcher"
+	},
+/obj/item/ammo_casing/caseless/rocket{
+	desc = "An 84mm high explosive rocket. Looks like they'd fit into a launcher"
+	},
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ep" = (
+/obj/structure/rack,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/grenade/chem_grenade/incendiary{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/grenade/chem_grenade/incendiary{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"er" = (
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
+	dir = 10
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"es" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"et" = (
+/obj/structure/sign/warning/radiation{
+	pixel_x = 32
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"eu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_y = 7
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"ev" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/sealed,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/engineering)
+"eA" = (
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eB" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/mine/directional/claymore/live{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"eE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"eG" = (
+/turf/closed/wall/r_wall,
+/area/ruin/whitesand/trainyard/hungar)
+"eJ" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eL" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"eM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"eO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"eU" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/surgeon/internals,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"eV" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"eW" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"fa" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fb" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"fc" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ff" = (
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"fh" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"fk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"fl" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/phone{
+	pixel_x = 10
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"fn" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/middle/right{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/mammoth{
+	pixel_y = -9;
+	pixel_x = 12;
+	list_reagents = null
+	},
+/obj/item/ammo_box/magazine/svd_rounds{
+	pixel_x = -13
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"fo" = (
+/obj/machinery/computer/monitor{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/machinery/button/door{
+	pixel_y = 26;
+	name = "Shutters button";
+	id = "Tr_sh_tr"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"fr" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ft" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1;
+	pixel_y = 14
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fv" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"fw" = (
+/obj/structure/table,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/spawner/random/entertainment/money_small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"fx" = (
+/obj/structure/closet/wall{
+	pixel_y = -25
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_y = -2;
+	pixel_x = -8
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_y = -2;
+	pixel_x = -8
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/head/ramzi{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/ramzi{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"fy" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fE" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"fH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/foamtank,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"fN" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"fR" = (
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/item/mop{
+	pixel_y = 10;
+	pixel_x = 6
+	},
+/obj/machinery/washing_machine{
+	pixel_y = 9;
+	pixel_x = -9
+	},
+/obj/structure/closet/wall/directional/north,
+/turf/open/floor/plastic,
+/area/ruin/whitesand/trainyard/dorm)
+"fS" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gibdown1"
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"fU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"fV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"fX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/proximity/spawner/manhack/live,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"ge" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"gf" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_y = 16;
+	pixel_x = 6
+	},
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"gg" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "mining"
+	},
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/syndicate/ramzi/overalls,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"gi" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_gt_main"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"gm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"go" = (
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"gq" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"gr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"gs" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"gC" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14;
+	pixel_x = 8
+	},
+/obj/item/toy/cards/deck/cas{
+	pixel_x = -3
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"gD" = (
+/obj/structure/rack,
+/obj/item/gun_maint_kit/small{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/gun_maint_kit/small,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"gF" = (
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gG" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "Tr_sh_tr"
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"gL" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -18;
+	pixel_y = -3
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gO" = (
+/obj/structure/deployable_barricade/sandbags{
+	pixel_y = -8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gQ" = (
+/obj/structure/chair/sofa/grey/right/directional/west,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"gU" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"gW" = (
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/clothing/under/syndicate/ramzi/officer{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/ramzi/beret{
+	pixel_y = 6;
+	pixel_x = -5
+	},
+/obj/item/clothing/head/ramzi/peaked{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/ramzi/captain{
+	pixel_y = -4;
+	pixel_x = 7
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"ha" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"hd" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"he" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"hl" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"hm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ho" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"hr" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "eng_secure"
+	},
+/obj/item/clothing/under/rank/engineering/engineer/nt,
+/obj/item/storage/belt/utility,
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/clothing/glasses/meson/engine/tray,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/hardhat/ramzi,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"hs" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"ht" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"hv" = (
+/turf/closed/wall/rust,
+/area/ruin/whitesand/trainyard/checkpoint)
+"hw" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hB" = (
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_x = 12
+	},
+/obj/effect/decal/cleanable/shreds,
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"hC" = (
+/mob/living/simple_animal/hostile/human/frontier/internals,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"hE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"hF" = (
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"hG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"hM" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"hU" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"hX" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/hooch{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = 3
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"ia" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"ic" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"id" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"if" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ig" = (
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ik" = (
+/obj/structure/chair/sofa/grey/corner/directional/west,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 6
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"il" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ip" = (
+/obj/machinery/blackbox_recorder{
+	name = "Backup Blackbox Recorder";
+	desc = "Some kind of machine backup."
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"iq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ir" = (
+/obj/effect/turf_decal/road/stripes,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"it" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/structure/closet/secure_closet/freezer{
+	anchored = 1;
+	name = "refrigerator"
+	},
+/obj/item/food/meat/slab/human/mutant/moth,
+/obj/item/food/meat/slab/human/mutant/moth,
+/obj/item/food/meat/slab/human/mutant/riol,
+/obj/item/food/meat/slab/human/mutant/riol,
+/obj/item/food/meat/slab/human/mutant/riol,
+/obj/item/food/meat/slab/human,
+/obj/item/food/meat/slab/human,
+/obj/item/food/meat/slab/human,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"iu" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"iv" = (
+/obj/effect/gibspawner/human/bodypartless,
+/obj/item/clothing/neck/dogtag/ramzi{
+	pixel_y = -5;
+	pixel_x = 13
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"iw" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ix" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"iD" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"iE" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"iG" = (
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iL" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/closet/secure_closet,
+/obj/item/weldingtool,
+/obj/item/weldingtool,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"iM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"iN" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/space)
+"iO" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"iQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/obj/item/folder/blue{
+	pixel_x = 9;
+	icon_state = "folder_syndie";
+	name = "folder- 'TOP SECRET'";
+	desc = "A folder stamped \"Top Secret - Property of The Syndicate.\"";
+	pixel_y = 13
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"iR" = (
+/obj/item/storage/box/emptysandbags{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/storage/box/emptysandbags{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/shovel{
+	pixel_y = 5
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"iS" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gib3";
+	dir = 1;
+	pixel_x = 5
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"iW" = (
+/obj/effect/turf_decal/road{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/road{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iY" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/space)
+"jb" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"jc" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"je" = (
+/obj/structure/platform{
+	dir = 1;
+	pixel_y = -12
+	},
+/obj/structure/platform{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jl" = (
+/obj/structure/chair/bench/grey/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jn" = (
+/obj/item/target,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"js" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"jt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 7
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jw" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"jx" = (
+/obj/item/target,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jB" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"jH" = (
+/obj/structure/chair/office/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"jK" = (
+/obj/structure/salvageable/computer{
+	dir = 4
+	},
+/obj/structure/sign/poster/nanotrasen/vigilitas_nonlethal{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"jL" = (
+/obj/structure/rack,
+/obj/item/storage/box/flares{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/storage/box/flares{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"jM" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/syndicate/white_red,
+/obj/item/clothing/head/helmet/space/syndicate/white_red,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jQ" = (
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"jR" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"jS" = (
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"jZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 7
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"kb" = (
+/turf/closed/indestructible/reinforced/rust,
+/area/ruin/whitesand/trainyard/hungar)
+"kd" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"ke" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"km" = (
+/obj/structure/closet/wall/blue/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"kn" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"kp" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ks" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/top/left{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	list_reagents = null;
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"kt" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ku" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"kw" = (
+/obj/effect/radiation,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"kx" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"kB" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_y = 4;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kG" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 18
+	},
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"kI" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/crate_shelf,
+/obj/item/modular_computer/tablet{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/modular_computer/tablet{
+	pixel_y = 2;
+	pixel_x = -1
+	},
+/obj/item/modular_computer/tablet{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/structure/closet/crate/eva,
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"kJ" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"kM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"kP" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"kQ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kR" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"kU" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"kW" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"la" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_y = 17;
+	pixel_x = 2
+	},
+/obj/item/radio/intercom/table{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"lc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ld" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lj" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ln" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"lp" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/template_noop)
+"ls" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"lt" = (
+/obj/effect/mob_spawn/human/corpse/frontier/internals,
+/obj/effect/gibspawner/human/bodypartless,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/melee/knife/combat{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/syndicateemblem/top/middle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"lu" = (
+/obj/effect/spawner/random/vending/cola,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 8
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"lv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/directional/east{
+	pixel_y = -5
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"lz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"lA" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus,
+/obj/item/clothing/head/helmet/space/syndicate/ramzi,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 9
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"lF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"lG" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"lH" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "floor2"
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"lI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"lL" = (
+/obj/structure/chair/bench/grey/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"lQ" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lR" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"lU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/rifle/internals,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"lV" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "eng_secure"
+	},
+/obj/item/clothing/under/rank/engineering/chief_engineer,
+/obj/item/clothing/suit/hazardvest/hardliners{
+	name = "Cheef Engineer hazard vest"
+	},
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/hardhat/hardliners{
+	name = "Cheef Engineer hard hat"
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/mask/gas/atmos,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 10
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"lW" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lY" = (
+/obj/effect/turf_decal/techfloor,
+/obj/structure/chair/handrail{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"lZ" = (
+/obj/item/target,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mb" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/safe{
+	number_of_tumblers = 5;
+	armor = list("melee" = 30, "bullet" = 60, "laser" = 60, "energy" = 100, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30);
+	desc = "A huge chunk of metal with a dial embedded in it. Fine print on the dial reads \"Scarborough Arms - 5 tumbler safe, guaranteed thermite resistant, explosion resistant, and assistant resistant.\""
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/middle{
+	dir = 4
+	},
+/obj/item/documents/syndicate/cybersun/biodynamics{
+	desc = "\"Top Secret\" Cybersun Biodynamics documents. A vast majority of the confidential documents require years of investment in internal code terms, prerequisite information and debriefings, and a bare minimum of a doctorate in biomechanical science. What can be gathered is a list of patients designated as potentially viable for the project in question, making notes of each patient's physiology in minute detail, down to their ability to accept nondescript terms for in-house medical procedures. While otherwise impenetrable, there is a personal note from a researcher involved in much less technical, more personal dialogue in Kalixcian Common. These documents are verified with a teal wax seal. These seem  to be a decade old.";
+	pixel_x = 4;
+	pixel_y = -2;
+	layer = 3
+	},
+/obj/item/melee/energy/sword/saber/red,
+/obj/item/folder/documents/syndicate/red,
+/obj/item/implanter/adrenalin,
+/obj/item/implantcase/adrenaline{
+	name = "implant case";
+	desc = "A glass case containing an implant."
+	},
+/obj/item/clothing/head/warden/cowboy{
+	name = "spy hat";
+	desc = "A menacing black stetson adorned with a spy badge. Made of thick imitation leather."
+	},
+/obj/item/clothing/mask/infiltrator,
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"md" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tr_wd_main"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"mf" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"mj" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_st_dr"
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "tr_sh_holo"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/shuttle)
+"mk" = (
+/obj/structure/closet/secure_closet,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/structure/sign/poster/tg/tg_10{
+	pixel_x = -32
+	},
+/obj/item/stack/cable_coil/cyan,
+/obj/item/weldingtool/empty,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"mq" = (
+/obj/structure/chair/bench/grey/directional/south,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"mr" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"mx" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"mz" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"mC" = (
+/obj/machinery/power/rtg,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"mD" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"mE" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"mG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"mK" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mL" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"mV" = (
+/obj/structure/chair/sofa/grey/directional/north,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"na" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"nb" = (
+/obj/item/cigbutt{
+	pixel_y = 13;
+	pixel_x = -8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nc" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"nd" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"nf" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ng" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_x = 24;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_x = -8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"nj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/briefcase{
+	icon = 'mod_celadon/_storage_icons/icons/structures/obj/barricade.dmi';
+	icon_state = "box_metal";
+	pixel_x = -6;
+	pixel_y = -9;
+	name = "C.U.C.K.S box";
+	desc = "Contains several deployable barricades."
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"nk" = (
+/obj/structure/railing/corner,
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"np" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"nr" = (
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"ns" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"nu" = (
+/obj/structure/closet/crate/large,
+/obj/item/toy/plush/carpplushie,
+/obj/item/toy/plush/carpplushie/gold,
+/obj/item/toy/plush/carpplushie/pink,
+/obj/item/toy/plush/carpplushie/toxin,
+/obj/item/toy/plush/carpplushie/void,
+/obj/item/toy/plush/carpplushie/ice,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"nx" = (
+/obj/structure/fence/door{
+	dir = 2
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nB" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"nC" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/train)
+"nE" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"nF" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/crowbar{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/syndicateemblem/bottom/middle{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack{
+	list_reagents = null;
+	pixel_x = 7;
+	pixel_y = -12
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimulants{
+	list_reagents = null;
+	pixel_y = -1;
+	pixel_x = -8
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"nI" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"nN" = (
+/obj/effect/turf_decal/road{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/road{
+	dir = 8;
+	pixel_y = -4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nO" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/storage/barricade,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"nS" = (
+/obj/item/cigbutt{
+	pixel_y = 15;
+	pixel_x = -21
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nT" = (
+/obj/structure/railing,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/obj/item/melee/knife/combat,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"nV" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/cigbutt{
+	pixel_x = -10
+	},
+/obj/item/cigbutt{
+	pixel_y = 1;
+	pixel_x = -3
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nX" = (
+/obj/structure/fence/cut/large{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"od" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"ol" = (
+/obj/structure/platform/industrial_alt,
+/obj/structure/railing,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"om" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"oo" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"oq" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/bottom/right{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"ot" = (
+/obj/structure/closet/body_bag,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mob_spawn/human/corpse/ramzi/space,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ou" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/dorm)
+"ow" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gib3";
+	dir = 1;
+	pixel_x = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"ox" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"oE" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"oI" = (
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"oK" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"oP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 4;
+	pixel_y = -2;
+	pixel_x = -12
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"oS" = (
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack{
+	list_reagents = null;
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	list_reagents = null;
+	pixel_y = -10;
+	pixel_x = 11
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"oU" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"oX" = (
+/obj/item/cigbutt{
+	pixel_y = 13
+	},
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"pb" = (
+/obj/machinery/porta_turret/ruin/ramzi/super_heavy{
+	dir = 10;
+	faction = list("Frontiersmen","turret")
+	},
+/turf/closed/indestructible/plastitanium,
+/area/ruin/whitesand/trainyard/train)
+"pd" = (
+/obj/structure/sign/warning/radiation{
+	pixel_x = 32
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"pe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pf" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pg" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"pj" = (
+/obj/structure/table,
+/obj/item/cutting_board{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/melee/knife,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"pr" = (
+/obj/structure/closet/secure_closet,
+/obj/item/storage/toolbox/syndicate/empty{
+	pixel_y = 1
+	},
+/obj/item/storage/toolbox/syndicate/empty{
+	pixel_y = -8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"pt" = (
+/obj/structure/closet/crate/large,
+/obj/item/melee/sword/mass,
+/obj/item/melee/sword/mass,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"pu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"pB" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 10;
+	pixel_x = -3
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = 7
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"pC" = (
+/obj/structure/table_frame,
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_y = -3;
+	pixel_x = 10
+	},
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pD" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/dorm)
+"pE" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"pM" = (
+/obj/structure/rack,
+/obj/item/stock_parts/capacitor{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -5
+	},
+/obj/item/stock_parts/micro_laser{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"pO" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pQ" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/shuttle)
+"pR" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"pT" = (
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pV" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pX" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/chair/handrail,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"pY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 10;
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/folder/blue{
+	pixel_x = 8;
+	icon_state = "folder_sred";
+	name = "folder- 'TOP SECRET'";
+	desc = "A folder stamped \"Top Secret - Property of Cybersun Industries.\"";
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"pZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"qd" = (
+/obj/structure/flora/tree/dead/tall,
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"qg" = (
+/obj/structure/chair/bench/grey/directional/south,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"qi" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 10;
+	pixel_x = -7
+	},
+/obj/item/paper_bin{
+	pixel_y = 3;
+	pixel_x = 7
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 10;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"qn" = (
+/obj/structure/railing{
+	dir = 10;
+	layer = 4.1
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"qq" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 6
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"qt" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left,
+/area/overmap_encounter/planetoid/sand/explored)
+"qu" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"qv" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qA" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/item/book/manual/wiki/hacking,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"qD" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 3
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"qE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"qG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"qI" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/item/storage/bag/trash,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"qK" = (
+/obj/item/stack/ore/salvage/scrapbluespace,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"qW" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qX" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plastitaniumglass{
+	pixel_x = -7;
+	amount = 20
+	},
+/obj/item/stack/sheet/mineral/plastitanium/fifty{
+	pixel_y = 6;
+	pixel_x = -2;
+	amount = 20
+	},
+/obj/item/stack/sheet/metal/twenty{
+	pixel_x = 3
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"rc" = (
+/obj/machinery/computer/security{
+	dir = 4;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"rf" = (
+/obj/structure/salvageable/computer,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"rj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"rn" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ro" = (
+/obj/structure/chair/bench/grey/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"rp" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"rr" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"rx" = (
+/obj/structure/rack,
+/obj/item/storage/box/stockparts/t2{
+	pixel_x = -6
+	},
+/obj/item/storage/box/emptysandbags{
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ry" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"rB" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"rF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"rG" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"rI" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_y = 8;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 8;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -20;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"rK" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 6
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"rM" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesand/trainyard/shuttle)
+"rR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash{
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"rS" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_y = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"rX" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"sb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/machinery/light/directional/east,
+/obj/item/clothing/shoes/magboots/syndie,
+/obj/item/clothing/shoes/magboots/syndie,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"sj" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"sn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"so" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall/orange/directional/north{
+	name = "closet"
+	},
+/obj/item/radio/weather_monitor{
+	pixel_y = 7
+	},
+/obj/item/radio/weather_monitor,
+/obj/item/radio/weather_monitor{
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"st" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sC" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"sD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"sF" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"sI" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"sK" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 4;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sQ" = (
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"sR" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"sT" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"sU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"sY" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right,
+/area/overmap_encounter/planetoid/sand/explored)
+"sZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"ta" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"ti" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"tj" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "floor4"
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"tm" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"tn" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"to" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"tp" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tr" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"ts" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"tw" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/obj/item/folder/red,
+/obj/item/folder/white,
+/obj/item/clipboard,
+/obj/item/folder/syndicate{
+	icon_state = "folder_sred"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"tz" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/train)
+"tE" = (
+/obj/machinery/vending/snack/teal,
+/obj/effect/turf_decal/borderfloorblack/corner,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 9
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"tI" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tJ" = (
+/obj/structure/closet/body_bag,
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"tM" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"tN" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"tO" = (
+/obj/item/stack/rods,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tP" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/closet/crate/coffin,
+/obj/item/food/grown/poppy,
+/obj/item/toy/plush/moth/punished{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"tR" = (
+/obj/structure/chair/e_chair{
+	dir = 8
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib5";
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"tU" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"tW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/engineering)
+"tX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"tY" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"ua" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/maintenance/seven,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uh" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ui" = (
+/obj/structure/chair/bench/grey/directional/north,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"um" = (
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/dorm)
+"un" = (
+/obj/structure/chair/sofa/red/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"uo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"up" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesand/trainyard/shuttle)
+"uu" = (
+/obj/structure/platform{
+	dir = 4;
+	pixel_x = -17
+	},
+/obj/structure/platform{
+	dir = 8;
+	pixel_x = 15
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uv" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uw" = (
+/obj/structure/flora/ash/garden/arid,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uA" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uI" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uJ" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uK" = (
+/obj/structure/chair/bench/grey/directional/north,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uO" = (
+/obj/structure/chair/comfy/shuttle{
+	name = "Helm";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/turretid/ship{
+	pixel_y = 38;
+	id = "haymaker";
+	pixel_x = 25
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_y = 62
+	},
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_y = 73
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"uT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"uU" = (
+/obj/item/stack/sheet/mineral/uranium/twenty,
+/obj/item/storage/firstaid/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/clothing/mask/gas/suns,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/storage/toolbox/drone,
+/obj/item/extinguisher/mini,
+/obj/structure/closet/wall/orange/directional/south{
+	name = "closet"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"uV" = (
+/obj/structure/chair/bench/grey/directional/south,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"uY" = (
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/cigbutt,
+/obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"vd" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ve" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"vf" = (
+/obj/machinery/door/poddoor/shutters,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/cargo)
+"vg" = (
+/obj/structure/closet/body_bag,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vj" = (
+/obj/effect/turf_decal/road/stripes,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"vl" = (
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	pixel_y = 25;
+	pixel_x = 2;
+	id = "tr_st_dr"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_y = 23;
+	id = "tr_sh_holo";
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"vn" = (
+/obj/structure/flora/ash,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vq" = (
+/obj/machinery/button/door{
+	pixel_y = -8;
+	name = "Shutters button";
+	id = "Tr_sh_h1";
+	pixel_x = 3
+	},
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"vv" = (
+/obj/structure/closet/body_bag,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"vw" = (
+/obj/structure/table/reinforced/glass,
+/obj/item/screwdriver{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"vz" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"vB" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vD" = (
+/obj/effect/supplypod_rubble,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"vH" = (
+/obj/structure/table,
+/obj/item/storage/fancy/nugget_box{
+	pixel_y = -5;
+	pixel_x = -5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"vI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"vJ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_y = 5;
+	pixel_x = 14
+	},
+/obj/structure/mirror{
+	pixel_y = 7;
+	pixel_x = 24
+	},
+/turf/open/floor/plastic,
+/area/ruin/whitesand/trainyard/dorm)
+"vN" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/brute{
+	pixel_y = 9
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid{
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"vP" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"vQ" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesand/trainyard/carriage)
+"vT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "tr_sh_wes";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"vW" = (
+/obj/structure/salvageable/circuit_imprinter,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vX" = (
+/obj/item/keycard{
+	puzzle_id = "Trainyard"
+	},
+/obj/structure/safe,
+/obj/item/storage/guncase/pistol/a357,
+/obj/item/storage/box/ammo/a357,
+/obj/item/clothing/accessory/holster,
+/obj/item/clothing/suit/armor/vest/duster,
+/obj/item/clothing/under/costume/jabroni,
+/obj/item/clothing/head/warden,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"vY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"vZ" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"wb" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"wl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"wm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"wn" = (
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ws" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"wt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"wu" = (
+/obj/structure/chair/sofa/red/right/directional/south,
+/obj/structure/sign/poster/contraband/steppyflag{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"wv" = (
+/obj/effect/spawner/random/vending/snack,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"wx" = (
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"wy" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_ar_main"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"wz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"wA" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"wC" = (
+/obj/structure/guncloset{
+	anchored = 1
+	},
+/obj/item/gun/ballistic/automatic/pistol/rattlesnake/no_mag,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"wG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"wI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"wL" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"wQ" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-4";
+	tag = null
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"wS" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"wT" = (
+/obj/machinery/door/airlock/multi_tile/security/v,
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/cargo)
+"wU" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"wY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xa" = (
+/obj/effect/spawner/random/vending/cola,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"xb" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"xh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"xl" = (
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"xn" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"xp" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/preopen{
+	id = "Tr_sh_h1"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"xy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -4;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 28;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xB" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xH" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"xJ" = (
+/obj/item/weldingtool/mini/empty{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"xM" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xN" = (
+/obj/structure/poddoor_assembly{
+	dir = 4
+	},
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"xX" = (
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -7;
+	pixel_x = 6
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = -6;
+	pixel_x = -5
+	},
+/obj/item/clothing/under/syndicate/combat{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/clothing/suit/armor/vest/marine/medium{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/clothing/mask/gas/suns{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/clothing/head/helmet/riot/gamma_vision{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"xZ" = (
+/obj/structure/salvageable/computer{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"ya" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yc" = (
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ye" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/turf_decal/syndicateemblem/middle/left{
+	dir = 4
+	},
+/obj/item/storage/backpack/duffelbag/syndie{
+	desc = "A large duffel bag containing a C-20r, some magazines, and a cheap looking suppressor.";
+	name = "Cobra bundle"
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/crisis{
+	pixel_x = -14;
+	list_reagents = null
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	list_reagents = null;
+	pixel_y = 9;
+	pixel_x = 11
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"yf" = (
+/obj/item/storage/box/ammo/a300{
+	pixel_y = 3
+	},
+/obj/item/storage/box/ammo/a300{
+	pixel_y = -4
+	},
+/obj/item/storage/box/ammo/x762_54{
+	pixel_y = 4
+	},
+/obj/item/storage/box/ammo/x762_54{
+	pixel_y = -8
+	},
+/obj/structure/closet/crate/secure/weapon,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"yg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"yh" = (
+/obj/structure/closet/wall/orange/directional/south{
+	name = "closet"
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/stack/sheet/glass/twenty,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"yi" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/item/cigbutt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"yk" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"ym" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/super/empty{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/stock_parts/cell/super/empty{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/cell/super/empty{
+	pixel_x = -3
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"yo" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/curtain/cloth/grey,
+/obj/machinery/light/directional/south,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"ys" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"yt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall/orange/directional/north{
+	name = "closet"
+	},
+/obj/item/extinguisher{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/extinguisher/mini{
+	pixel_y = -8
+	},
+/obj/item/extinguisher{
+	pixel_x = 4
+	},
+/obj/item/extinguisher/mini/empty{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/extinguisher/mini/empty{
+	pixel_x = -13;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"yu" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/smg{
+	health = 350;
+	maxHealth = 350
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"yw" = (
+/obj/machinery/fax/ruin,
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster/official/moth/smokey{
+	pixel_x = 31
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"yx" = (
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"yz" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/curtain/cloth/grey,
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"yA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/sealed,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"yB" = (
+/obj/structure/fence/cut/medium,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yC" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"yD" = (
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"yE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"yF" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"yI" = (
+/obj/effect/turf_decal/road{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/road{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"yO" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yQ" = (
+/obj/structure/tank_dispenser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 5
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"yS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"yV" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"za" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "tr_sh_et"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint)
+"ze" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zf" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/obj/item/folder/yellow,
+/obj/item/folder/blue,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"zg" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zq" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zt" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zv" = (
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zy" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/effect/spawner/random/waste/mechwreck,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"zC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"zD" = (
+/obj/structure/platform/industrial_alt{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 10;
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zF" = (
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zG" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 18
+	},
+/obj/effect/spawner/random/maintenance/six,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zJ" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zK" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/closet/body_bag,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/mob_spawn/human/corpse/ramzi/space,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"zP" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"zV" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"zW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zX" = (
+/obj/structure/closet{
+	icon_state = "syndicate";
+	anchored = 1
+	},
+/obj/item/clothing/gloves/tackler/combat/insulated{
+	pixel_y = -5
+	},
+/obj/item/restraints/legcuffs/bola/tactical{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Aa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Ad" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/edagger{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ae" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Af" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ag" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_y = 12;
+	pixel_x = 6
+	},
+/obj/item/pen/red{
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Ai" = (
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Aj" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ak" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/components/binary/valve/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Am" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
+/obj/item/clothing/mask/gas/ramzi,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Ar" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"Au" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/grenade/spawnergrenade/manhacks{
+	pixel_y = 7;
+	pixel_x = -7
+	},
+/obj/item/grenade/empgrenade{
+	pixel_y = 5;
+	pixel_x = 7
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Aw" = (
+/obj/structure/chair/sofa/grey/right/directional/east,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"AB" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"AE" = (
+/obj/structure/closet{
+	icon_state = "syndicate";
+	anchored = 1
+	},
+/obj/item/clothing/suit/armor/ramzi/bulletproof{
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/armor/ramzi/bulletproof{
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/obj/item/clothing/head/helmet/ramzi/bulletproof{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/clothing/head/helmet/ramzi/bulletproof{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/storage/belt/security/webbing/ramzi{
+	pixel_x = 7
+	},
+/obj/item/clothing/glasses/sunglasses/ballistic{
+	pixel_y = 10;
+	pixel_x = 9
+	},
+/obj/item/storage/belt/security/webbing/ramzi/alt{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/item/clothing/glasses/sunglasses/ballistic{
+	pixel_y = 10;
+	pixel_x = 9
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"AF" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"AI" = (
+/obj/structure/chair/sofa/grey/left/directional/south,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"AR" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"AU" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/item/cigbutt{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"AV" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"AW" = (
+/obj/machinery/door/window/brigdoor/southright,
+/obj/structure/table/reinforced,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters{
+	id = "tr_sh_wes"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"AZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "Helm"
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	dir = 8
+	},
+/obj/structure/closet/wall/red/directional/south{
+	name = "closet"
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/machinery/newscaster/directional/north{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"Bc" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Be" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_y = 2;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 8;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bf" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Bh" = (
+/obj/structure/closet/crate/large,
+/obj/item/kinetic_crusher/syndie_crusher,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"Bi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tr_sh_et"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Bk" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -2;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bn" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/cargo)
+"Br" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bs" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"By" = (
+/obj/structure/sign/poster/tg/tg_5{
+	pixel_x = 36;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"BB" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"BC" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_y = 3;
+	pixel_x = -2
+	},
+/obj/item/stack/sheet/glass/twenty{
+	pixel_y = -1;
+	pixel_x = 5
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"BF" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"BK" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"BL" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"BM" = (
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"BN" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"BP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"BR" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "floor4"
+	},
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"BS" = (
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"BU" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"BX" = (
+/turf/closed/wall/rust,
+/area/overmap_encounter/planetoid/sand/explored)
+"BY" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"BZ" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Ca" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"Cc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Cg" = (
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Cl" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Cn" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1;
+	pixel_y = 20
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cq" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"Cr" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesand/trainyard/shuttle)
+"Cs" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas/black{
+	pixel_y = 7;
+	pixel_x = 7
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Cz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"CH" = (
+/obj/structure/platform/industrial_alt{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"CJ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "pavement_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"CK" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "mining"
+	},
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/under/syndicate/ramzi/overalls,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"CN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"CR" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CS" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"CT" = (
+/obj/effect/turf_decal/road/stripes,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CZ" = (
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset/civilian,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Dc" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small/broken/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Dd" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Dg" = (
+/obj/structure/flora/ash/puce,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Dj" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Do" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Dp" = (
+/obj/structure/closet/crate/bin,
+/obj/item/folder/blue{
+	icon_state = "folder_sblue";
+	name = "folder- 'TOP SECRET'";
+	desc = "A folder stamped \"Top Secret - Property of The Syndicate.\""
+	},
+/obj/item/lighter/zippo/fox{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Dq" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer/light{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Dy" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"Dz" = (
+/obj/structure/flora/ash,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DB" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_x = -24;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_x = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"DC" = (
+/obj/structure/salvageable/computer,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"DH" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 6;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"DI" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DK" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DQ" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/sake/foxgirl{
+	pixel_y = 11;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
+	},
+/obj/item/candle/infinite{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"DR" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DS" = (
+/obj/structure/closet/crate/medical,
+/obj/effect/spawner/random/medical/medkit,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"DT" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gib3";
+	dir = 1;
+	pixel_x = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	pixel_y = 33
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DW" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"DX" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"DY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"DZ" = (
+/mob/living/simple_animal/hostile/human/ramzi/melee/machete{
+	health = 300;
+	maxHealth = 300;
+	armour_penetration = 15;
+	melee_damage_lower = 30;
+	melee_damage_upper = 30
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"Eb" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ec" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ee" = (
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Eh" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ek" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"El" = (
+/obj/structure/fluff/paper/stack{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Em" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Eo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Er" = (
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Eu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ey" = (
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ez" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"EA" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EC" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ED" = (
+/obj/structure/guncloset{
+	anchored = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"EH" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/sign/poster/retro/smile{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"EI" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"EJ" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"EM" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EP" = (
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"EQ" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"ER" = (
+/obj/structure/filingcabinet/double/grey,
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/clipboard,
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"ES" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"EU" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/item/book/manual/wiki/surgery,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"EW" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"EZ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fd" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/item/wirecutters{
+	pixel_y = 11;
+	pixel_x = -7
+	},
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Fg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Fh" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/item/stack/rods{
+	pixel_x = -17;
+	pixel_y = -7
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Fj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -24;
+	pixel_x = -6;
+	id = "Tr_sh_h1"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"Fk" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Fn" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Fo" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/internals,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Fp" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fs" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/cargo)
+"Fv" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Fw" = (
+/obj/machinery/computer/helm{
+	dir = 8;
+	pixel_x = 7
+	},
+/obj/machinery/button/door{
+	pixel_y = 26;
+	name = "Engine button";
+	id = "Tr_en_tr"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"Fx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/double,
+/obj/item/storage/pill_bottle/stimulant{
+	name = "unlabled pills"
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"FI" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/dorm)
+"FK" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/dried{
+	light_range = 2
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"FL" = (
+/obj/structure/chair/sofa/grey/corner/directional/east,
+/obj/effect/turf_decal/corner/opaque/syndiered,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 9
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"FM" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "pavement_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"FN" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/darkbrownfull/darkbrowncorners{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"FQ" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"FS" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"FT" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"FU" = (
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"Gc" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/moth/meth{
+	pixel_x = -31
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Gd" = (
+/obj/structure/chair/sofa/red/corner/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Ge" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/train)
+"Gf" = (
+/obj/structure/table,
+/obj/item/storage/guncase/vector{
+	pixel_y = 3
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gn" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/xeno_energy{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"Gt" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"Gx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Gy" = (
+/obj/structure/platform{
+	dir = 8;
+	pixel_x = 15
+	},
+/obj/structure/platform{
+	dir = 4;
+	pixel_x = -17
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"GC" = (
+/obj/structure/chair/bench/grey/directional/north,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"GF" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"GH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/structure/rack,
+/obj/item/chair/plastic,
+/obj/item/chair/plastic{
+	pixel_y = 3
+	},
+/obj/item/chair/plastic{
+	pixel_y = 6
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"GI" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"GJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"GK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"GM" = (
+/obj/effect/turf_decal/road/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"GO" = (
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/preopen{
+	id = "Tr_sh_h1"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"GS" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/syringe/contraband/crank{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"GT" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/closet/crate/coffin,
+/obj/item/food/grown/poppy,
+/obj/item/melee/knife/switchblade{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/neck/dogtag/ramzi{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"GW" = (
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"GX" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_y = 14;
+	pixel_x = -7
+	},
+/obj/item/radio/intercom/table{
+	dir = 1;
+	pixel_y = 7;
+	pixel_x = 15
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"GY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"GZ" = (
+/obj/structure/salvageable/server,
+/obj/structure/sign/poster/solgov/kepler{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Hb" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 18
+	},
+/obj/effect/spawner/random/maintenance/four,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"He" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hf" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Hi" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"Hk" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/large,
+/obj/item/mine/proximity/spawner/manhack,
+/obj/item/mine/proximity/spawner/manhack,
+/obj/item/mine/proximity/spawner/manhack,
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Hn" = (
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/cargo)
+"Hq" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Hr" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_y = 8;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hx" = (
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = -5;
+	pixel_y = -21;
+	id = "tr_sh_wes"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Hz" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/iv_drip{
+	pixel_x = 8;
+	pixel_y = 21;
+	anchored = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"HC" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"HE" = (
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_y = -7;
+	pixel_x = 6
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = -6;
+	pixel_x = -5
+	},
+/obj/item/clothing/under/syndicate/combat{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/gas/suns{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/item/clothing/head/helmet/riot/gamma_vision{
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"HF" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -9;
+	pixel_y = -4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HG" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint)
+"HH" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_box/magazine/svd_rounds{
+	pixel_y = 9
+	},
+/obj/item/gun/ballistic/automatic/marksman/svd/no_mag{
+	pixel_y = -8;
+	pixel_x = -9
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"HK" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"HN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"HP" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/curtain/cloth/grey,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"HR" = (
+/obj/machinery/door/poddoor/cannothit{
+	dir = 4;
+	id = "Tr_en_tr"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/train)
+"HS" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 2;
+	pixel_x = 9
+	},
+/obj/item/stamp/syndicate{
+	pixel_y = 2;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"HT" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
+/turf/open/floor/plastic,
+/area/ruin/whitesand/trainyard/dorm)
+"HU" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_y = -13;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_y = 1
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ib" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Ic" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesand/trainyard/shuttle)
+"Id" = (
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"If" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"Ig" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "tr_ar_main"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"Ij" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ik" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Is" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/item/cigbutt/cigarbutt,
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"It" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/deployable_barricade/sandbags{
+	dir = 4
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"Iu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/structure/closet/secure_closet/freezer{
+	anchored = 1;
+	name = "refrigerator"
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"Iz" = (
+/obj/item/ammo_casing/spent/slug,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IE" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	pixel_y = -5;
+	dir = 8;
+	pixel_x = -14
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"II" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"IJ" = (
+/turf/closed/wall/concrete/reinforced,
+/area/overmap_encounter/planetoid/sand/explored)
+"IM" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"IO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IP" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IQ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IS" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_y = 14;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IT" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "mining"
+	},
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/syndicate/ramzi/overalls,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 4
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"IU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IV" = (
+/obj/structure/salvageable/machine,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"IW" = (
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"IX" = (
+/obj/machinery/door/airlock/multi_tile/security/v,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/engineering)
+"Jc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Jh" = (
+/obj/effect/turf_decal/road/stripes{
+	dir = 1
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ji" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/turf_decal/syndicateemblem/bottom/right{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/pumpup{
+	list_reagents = null;
+	pixel_x = 12
+	},
+/obj/item/reagent_containers/hypospray/medipen/rabbit{
+	list_reagents = null;
+	pixel_y = -7;
+	pixel_x = -8
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Jj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/closet/crate/coffin,
+/obj/item/food/grown/poppy,
+/obj/item/dice/d20{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/clothing/neck/dogtag/ramzi{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Jl" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Jm" = (
+/obj/machinery/door/poddoor/cannothit{
+	id = "Carriage_Tr_2"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Jo" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jp" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jq" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/item/storage/firstaid/medical{
+	empty = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/middle/left{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Jr" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Ju" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Jv" = (
+/obj/structure/salvageable/server,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Jw" = (
+/obj/structure/closet{
+	icon_state = "syndicate";
+	anchored = 1
+	},
+/obj/item/melee/knife/combat{
+	pixel_y = 10;
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/tackler/combat/insulated{
+	pixel_y = -7
+	},
+/obj/item/binoculars{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/hardliners{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Jy" = (
+/obj/structure/salvageable/server,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"JA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"JE" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/ration{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"JF" = (
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"JG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"JH" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 2;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JI" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/trooper/internals,
+/obj/effect/gibspawner/human/bodypartless,
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"JL" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JO" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/internals{
+	maxHealth = 350;
+	health = 350
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"JP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"JT" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/effect/gibspawner/human/bodypartless,
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/internals,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"JW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"JY" = (
+/obj/machinery/suit_storage_unit/open,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"JZ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/pen/uplink{
+	pixel_y = 13
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Ka" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10;
+	layer = 2.030
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesand/trainyard/shuttle)
+"Kc" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ki" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Km" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Kr" = (
+/obj/structure/platform/industrial/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Kt" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Kw" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Kx" = (
+/obj/structure/closet/crate/large,
+/obj/item/storage/cans/sixbeer{
+	pixel_y = -4;
+	pixel_x = 2
+	},
+/obj/item/storage/cans/sixbeer{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"Kz" = (
+/obj/structure/flora/ash/fern,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"KE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/dorm)
+"KK" = (
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"KO" = (
+/obj/machinery/door/keycard{
+	puzzle_id = "Trainyard"
+	},
+/obj/machinery/door/poddoor/cannothit{
+	id = "Carriage_Tr_1"
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"KP" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"KS" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KU" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 8;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_y = 12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KX" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	pixel_y = 33
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"KZ" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"La" = (
+/obj/effect/turf_decal/techfloor,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"Li" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Lk" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Lr" = (
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/clothing/under/syndicate/ramzi/officer{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/ramzi/beret{
+	pixel_y = 6;
+	pixel_x = -5
+	},
+/obj/item/clothing/head/ramzi/peaked{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/armor/ramzi/officer{
+	pixel_y = -2;
+	pixel_x = 9
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Lu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Lv" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lx" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"LB" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LC" = (
+/obj/structure/chair/sofa/grey/directional/south,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"LH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"LJ" = (
+/obj/structure/closet/crate/large,
+/obj/item/tank/jetpack/oxygen/harness,
+/obj/item/tank/jetpack/oxygen/harness,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"LL" = (
+/obj/structure/flora/ash/tall_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 20;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 10;
+	pixel_y = -8;
+	pixel_x = -19
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"LO" = (
+/turf/template_noop,
+/area/template_noop)
+"LQ" = (
+/obj/machinery/blackbox_recorder{
+	empty = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"LU" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"LV" = (
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"LX" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gibdown1"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"LZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Mf" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/twenty{
+	pixel_x = -3
+	},
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"Mh" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Mi" = (
+/obj/structure/deployable_barricade/sandbags{
+	pixel_y = -7
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Mk" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Mn" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Mt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Mv" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Mw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"My" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack/corner,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"MB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 10
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"MD" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"MG" = (
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	pixel_y = 26;
+	pixel_x = 7;
+	id = "tr_sh_et"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"MI" = (
+/obj/effect/turf_decal/syndicateemblem/middle/right{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/pumpup{
+	list_reagents = null;
+	pixel_x = -2;
+	pixel_y = -11
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"ML" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/maintenance,
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/effect/spawner/random/trash/crushed_can,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"MM" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/syndicate/ramzi,
+/obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 10
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"MN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesand/trainyard/shuttle)
+"MP" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"MQ" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"MT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/grenade/frag{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/obj/item/grenade/chem_grenade/teargas{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/grenade/chem_grenade/teargas{
+	pixel_x = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"MZ" = (
+/turf/closed/wall/rust,
+/area/ruin/whitesand/trainyard/engineering)
+"Nb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Ni" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Nj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Nn" = (
+/obj/structure/railing/thin{
+	dir = 9
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Nt" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Nx" = (
+/obj/structure/fence{
+	dir = 2
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ny" = (
+/obj/structure/closet/wall{
+	pixel_y = -25
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/clothing/head/ramzi/flap{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/obj/item/clothing/head/ramzi/flap{
+	pixel_y = 9;
+	pixel_x = -8
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"NJ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/shotgun{
+	health = 350;
+	maxHealth = 350
+	},
+/obj/effect/turf_decal/syndicateemblem/bottom/left{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"NL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib4";
+	dir = 4;
+	pixel_y = -10
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/cargo)
+"NN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"NO" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor/corner,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"NP" = (
+/obj/structure/table,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/spawner/random/entertainment/money_small,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"NQ" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/turf_decal/syndicateemblem/top/left{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/crisis{
+	list_reagents = null;
+	pixel_y = 7
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"NT" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "med";
+	name = "medicine closet";
+	anchored = 1
+	},
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/stack/medical/splint,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/stack/medical/gauze/twelve,
+/obj/item/defibrillator/loaded,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"NU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -7
+	},
+/obj/item/pen/uplink{
+	pixel_y = 19;
+	pixel_x = -3
+	},
+/obj/item/stamp{
+	pixel_x = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"NW" = (
+/obj/structure/chair/sofa/grey/left/directional/north,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown,
+/area/ruin/whitesand/trainyard/cargo)
+"NX" = (
+/obj/machinery/porta_turret/ruin/ramzi/super_heavy{
+	dir = 6;
+	faction = list("Frontiersmen","turret")
+	},
+/turf/closed/indestructible/plastitanium,
+/area/ruin/whitesand/trainyard/train)
+"NY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall/directional/north,
+/obj/item/storage/box/shipping,
+/obj/item/megaphone/cargo,
+/obj/item/clipboard,
+/obj/item/clothing/head/hardhat/ramzi,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Ob" = (
+/turf/open/floor/plasteel/heavymetal,
+/area/ruin/whitesand/trainyard/shuttle)
+"Oe" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Of" = (
+/obj/structure/fence/door{
+	dir = 2
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Og" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Oi" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Oo" = (
+/obj/structure/chair/bench/grey/directional/south,
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"Os" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"Ot" = (
+/obj/structure/closet{
+	icon_state = "syndicate";
+	anchored = 1
+	},
+/obj/item/clothing/under/syndicate/cybersun/officer{
+	pixel_y = -7;
+	pixel_x = -8
+	},
+/obj/item/clothing/gloves/combat{
+	pixel_y = -9
+	},
+/obj/item/clothing/head/soft/cybersun{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/gas/syndicate{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/megaphone/sec{
+	name = "syndicate megaphone"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Ov" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 5
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Oy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Oz" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_x = -8;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_x = 24;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OB" = (
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"OH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/deployable_barricade/metal/plasteel{
+	dir = 1;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"OL" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"OP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"OQ" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset{
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"OR" = (
+/turf/closed/indestructible/plastitanium,
+/area/ruin/whitesand/trainyard/carriage)
+"OS" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "floor1"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"OT" = (
+/obj/structure/chair/bench/grey/directional/south,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"OV" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/closet/secure_closet,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/pink,
+/obj/item/stack/cable_coil/orange,
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/cyborg,
+/obj/item/stack/cable_coil/cyan,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"OW" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OX" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"OZ" = (
+/obj/structure/deployable_barricade/sandbags{
+	pixel_y = -9
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Pb" = (
+/obj/effect/radiation,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Pc" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Pe" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/right{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Pk" = (
+/obj/machinery/door/airlock/multi_tile/security/v,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"Pl" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Pq" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ps" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/internals/buckshot{
+	health = 350;
+	maxHealth = 350
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"Pv" = (
+/obj/machinery/vending/cigarette/syndicate,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 8
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"Pw" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"PA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial/corner{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"PD" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"PE" = (
+/obj/structure/table/reinforced,
+/obj/item/binoculars{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"PF" = (
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"PL" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/hungar)
+"PM" = (
+/obj/structure/filingcabinet/double/grey,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"PQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"PU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/secure_data/laptop{
+	dir = 8;
+	pixel_x = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"PV" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = -5
+	},
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_y = 42;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"PY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"PZ" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Qh" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Qk" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 12
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"Qn" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"Qs" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Qw" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"QD" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"QF" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"QG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"QJ" = (
+/obj/machinery/vending/mining_equipment,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 5
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"QK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"QP" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"QT" = (
+/obj/structure/table/reinforced,
+/obj/item/weldingtool{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"QV" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/welded,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"QY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Rc" = (
+/obj/machinery/power/shuttle/engine/electric,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/shuttle)
+"Rh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"Rk" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Rm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/dorm)
+"Rn" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -12;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 16;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ro" = (
+/obj/structure/table,
+/obj/item/clipboard{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/item/flashlight/flare{
+	pixel_x = 15
+	},
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Rq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = 29
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/hungar)
+"Rr" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Rs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/syndicateemblem/top/middle{
+	dir = 4
+	},
+/obj/item/storage/backpack/duffelbag/syndie{
+	desc = "A large duffel bag containing a Bulldog, some drums.";
+	name = "Bulldog bundle"
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimulants{
+	list_reagents = null;
+	pixel_y = -11;
+	pixel_x = -14
+	},
+/obj/item/reagent_containers/hypospray/medipen/rabbit{
+	list_reagents = null;
+	pixel_y = -7;
+	pixel_x = 15
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Rt" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"Rv" = (
+/obj/item/ammo_casing/spent/rifle_steel,
+/obj/item/reagent_containers/syringe/contraband/mammoth{
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Rz" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"RD" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = 4;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RE" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"RQ" = (
+/obj/structure/salvageable/server,
+/obj/machinery/button/door{
+	dir = 4;
+	id = "tr_sh_st";
+	pixel_x = -20;
+	pixel_y = -5
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"RR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"RW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"RX" = (
+/mob/living/simple_animal/hostile/human/ramzi/melee/space/stormtrooper/sledge{
+	maxHealth = 500;
+	health = 500;
+	melee_damage_lower = 50;
+	armour_penetration = 60;
+	armor = list("melee" = 75, "bullet" = 60, "laser" = 100, "energy" = 55, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100)
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/middle{
+	dir = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/rabbit{
+	list_reagents = null;
+	pixel_y = -7;
+	pixel_x = 15
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"RY" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_x = -9;
+	pixel_y = -16
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Sb" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/drone{
+	pixel_y = 10
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/borderfloorblack/corner,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Sd" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/bottle/sake/wolfgirl{
+	pixel_y = 9;
+	pixel_x = 13
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/candle/infinite{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/candle/infinite{
+	pixel_x = -11
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Se" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/supply/visible/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Sf" = (
+/obj/item/cigbutt{
+	pixel_x = 6
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sh" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Si" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Sj" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"So" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Sw" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/plastic,
+/area/ruin/whitesand/trainyard/dorm)
+"Sx" = (
+/obj/structure/chair/sofa/red/left/directional/west,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Sy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 18;
+	pixel_x = 5
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = -4;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Sz" = (
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/stack/ore/salvage/scraptitanium{
+	pixel_y = 17;
+	pixel_x = -6
+	},
+/obj/item/stack/cable_coil/cut/random,
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"SB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"SH" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 11;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"SJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"SK" = (
+/obj/item/gun/ballistic/rifle/scout{
+	pixel_x = -13
+	},
+/obj/item/ammo_box/a300/empty{
+	pixel_x = 15;
+	pixel_y = -6
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"SL" = (
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -25
+	},
+/mob/living/simple_animal/hostile/human/frontier/internals,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"SN" = (
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	pixel_y = -22;
+	pixel_x = -7;
+	dir = 1;
+	id = "tr_wd_main";
+	name = "Cargoway Shutters"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"SO" = (
+/obj/structure/salvageable/machine,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SP" = (
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -34;
+	pixel_x = 6;
+	name = "Carriage button";
+	id = "Carriage_Tr_8"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -34;
+	pixel_x = -6;
+	name = "Carriage button";
+	id = "Carriage_Tr_7"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -24;
+	pixel_x = -6;
+	name = "Carriage button";
+	id = "Carriage_Tr_5"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -24;
+	pixel_x = 6;
+	name = "Carriage button";
+	id = "Carriage_Tr_6"
+	},
+/turf/open/floor/suns/dark/plain,
+/area/ruin/whitesand/trainyard/train)
+"SU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Te" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Tg" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_x = -24;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_x = 8;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Th" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/curtain/cloth/grey,
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Tk" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable/yellow,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = 5;
+	pixel_x = -24;
+	name = "port shutter";
+	id = "tr_sh_eng"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"Tv" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"Tx" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Tz" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TA" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TE" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TG" = (
+/obj/effect/supplypod_rubble,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TH" = (
+/obj/machinery/computer/crew{
+	dir = 8;
+	pixel_x = 7
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/whitesand/trainyard/train)
+"TN" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TO" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TP" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 8;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TU" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"TV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"TW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ua" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"Ub" = (
+/obj/structure/railing,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ud" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ug" = (
+/obj/machinery/button/door{
+	pixel_y = 26;
+	name = "Shutters button";
+	id = "tr_ar_main";
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ui" = (
+/obj/structure/salvageable/computer{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Uj" = (
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Uk" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/emergency_oxygen/double/empty{
+	pixel_y = -5;
+	pixel_x = 7
+	},
+/obj/item/tank/internals/emergency_oxygen/double/empty{
+	pixel_y = -5;
+	pixel_x = -1
+	},
+/obj/item/tank/internals/emergency_oxygen/double/empty{
+	pixel_y = -5;
+	pixel_x = -9
+	},
+/turf/open/floor/pod/dark,
+/area/ruin/whitesand/trainyard/hungar)
+"Ul" = (
+/obj/effect/spawner/random/trash/grime,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Up" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -10;
+	pixel_y = -7
+	},
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Uq" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "floor6"
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_steel,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Ur" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plastic,
+/area/ruin/whitesand/trainyard/dorm)
+"Us" = (
+/obj/structure/closet/secure_closet{
+	icon_state = "brig_phys";
+	name = "Paramedic's locker";
+	req_access_txt = "5";
+	anchored = 1
+	},
+/obj/item/clothing/suit/ramzi/smock{
+	pixel_y = -8
+	},
+/obj/item/clothing/head/ramzi/surgical{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/item/clothing/gloves/color/latex/nitrile/evil{
+	pixel_y = -3;
+	pixel_x = 5
+	},
+/obj/item/clothing/mask/surgical{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/bottle/morphine,
+/obj/item/bodybag,
+/obj/item/bodybag,
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner,
+/obj/item/melee/baton/cattleprod/loaded,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"Uu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/checkpoint/control)
+"Uv" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Uz" = (
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"UB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 5;
+	pixel_y = 11;
+	layer = 2.89;
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"UC" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"UF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/hungar)
+"UG" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"UI" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/closed/wall/r_wall,
+/area/ruin/whitesand/trainyard/hungar)
+"UQ" = (
+/obj/structure/closet/crate/large,
+/obj/effect/turf_decal/spline/fancy/opaque/yellow,
+/obj/item/pipe_dispenser,
+/obj/item/storage/belt/utility/syndicate{
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"UR" = (
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"UV" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/pill/cyanide{
+	pixel_x = -5;
+	pixel_y = 12;
+	name = "strange pill";
+	desc = "A strange pill found in the depths of maintenance"
+	},
+/obj/item/reagent_containers/pill/epinephrine{
+	name = "strange pill";
+	desc = "A strange pill found in the depths of maintenance";
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/pill/tox{
+	pixel_x = 7;
+	pixel_y = 2;
+	name = "strange pill";
+	desc = "A strange pill found in the depths of maintenance"
+	},
+/obj/item/scalpel{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"UX" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"UY" = (
+/obj/machinery/jukebox,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"UZ" = (
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Va" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/item/stack/circuit_stack,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vb" = (
+/obj/machinery/door/airlock/multi_tile/security,
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"Vc" = (
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 4;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vf" = (
+/obj/machinery/door/airlock/multi_tile/security,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"Vg" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vi" = (
+/obj/structure/girder,
+/turf/open/floor/plating/rust{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vj" = (
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vk" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"Vl" = (
+/turf/closed/indestructible/plastitanium,
+/area/ruin/whitesand/trainyard/train)
+"Vm" = (
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/concrete,
+/area/ruin/whitesand/trainyard/engineering)
+"Vn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vu" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Vy" = (
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"VD" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VF" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"VG" = (
+/obj/structure/fans/tiny,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "Tr_sh_h1"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/checkpoint/storage)
+"VI" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VK" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"VN" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus,
+/obj/item/clothing/head/helmet/space/syndicate/ramzi,
+/turf/open/floor/plasteel/darkbrownfull/darkbrown{
+	dir = 5
+	},
+/area/ruin/whitesand/trainyard/cargo)
+"VO" = (
+/obj/structure/table_frame,
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"VT" = (
+/obj/effect/spawner/random/trash/grime,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wa" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10;
+	layer = 2.030
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"Wb" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Wf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Wg" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesand/trainyard/hungar)
+"Wi" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wq" = (
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Wr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Wt" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	pixel_y = 8;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wu" = (
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -34;
+	pixel_x = 6;
+	name = "Carriage button";
+	id = "Carriage_Tr_4"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -34;
+	pixel_x = -6;
+	name = "Carriage button";
+	id = "Carriage_Tr_3"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -24;
+	pixel_x = 6;
+	name = "Carriage button";
+	id = "Carriage_Tr_2"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -24;
+	pixel_x = -6;
+	name = "Carriage button";
+	id = "Carriage_Tr_1"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/suns/dark/plain,
+/area/ruin/whitesand/trainyard/train)
+"Wy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "pavement_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"WA" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/hungar)
+"WE" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 26;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WF" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -26;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WG" = (
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"WL" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/plasteel/strongdark,
+/area/ruin/whitesand/trainyard/cargo)
+"WM" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WO" = (
+/turf/closed/wall/concrete,
+/area/overmap_encounter/planetoid/sand/explored)
+"WP" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"WS" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal/var3{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"WU" = (
+/obj/machinery/shower{
+	pixel_y = 19
+	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/whitesand/trainyard/dorm)
+"WW" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	icon_state = "conc_smooth_1";
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Xe" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xf" = (
+/obj/item/stack/medical/suture/five,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 15;
+	pixel_y = -6;
+	empty = 1
+	},
+/turf/open/floor/suns/diagonal{
+	color = "#792f27"
+	},
+/area/ruin/whitesand/trainyard/dorm)
+"Xp" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack{
+	dir = 1;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Xq" = (
+/obj/structure/deployable_barricade/metal/plasteel{
+	dir = 1;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"Xs" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Xv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Xw" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/shuttle)
+"XA" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"XC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fluff/paper/stack{
+	dir = 10;
+	pixel_y = 16;
+	pixel_x = -17
+	},
+/obj/structure/fluff/paper/stack{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/item/mine/proximity/spawner/manhack/live,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"XD" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"XE" = (
+/obj/item/ammo_casing/spent/slug,
+/turf/open/floor/plasteel/stairs/stairs_pack/left{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"XK" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"XL" = (
+/turf/open/chasm{
+	initial_gas_mix = "SANDPLANET_ATMOS";
+	desc = "You can assume that it is very deep there, since you cannot see the bottom. Stay away!"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"XO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"XS" = (
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"XY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ya" = (
+/turf/closed/indestructible/reinforced,
+/area/ruin/whitesand/trainyard/hungar)
+"Yb" = (
+/turf/closed/wall/r_wall,
+/area/ruin/whitesand/trainyard/dorm)
+"Yd" = (
+/turf/closed/wall/r_wall,
+/area/ruin/whitesand/trainyard/cargo)
+"Ye" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = -10;
+	pixel_x = -8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yg" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	pixel_y = 20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -18;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 14;
+	density = 0
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Yk" = (
+/obj/structure/chair/bench/grey/directional/south,
+/turf/open/floor/concrete/slab_2{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Yl" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Yn" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/engineering)
+"Yp" = (
+/obj/structure/platform/industrial{
+	dir = 8;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Yq" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/officer/internals,
+/obj/effect/gibspawner/human/bodypartless,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/turf_decal/syndicateemblem/bottom/left{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/ruin/whitesand/trainyard/carriage)
+"Yr" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/shuttle)
+"Ys" = (
+/obj/item/kirbyplants/fullysynthetic,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/dorm)
+"Yv" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/light/floor/hangar,
+/turf/open/floor/concrete/slab_1,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yy" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/hungar)
+"YC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/tech/grid{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"YD" = (
+/obj/structure/flora/tree/dead/barren,
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YH" = (
+/obj/item/cigbutt{
+	pixel_y = 15;
+	pixel_x = -12
+	},
+/obj/item/cigbutt{
+	pixel_y = 15;
+	pixel_x = -21
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"YI" = (
+/obj/structure/salvageable/computer{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_y = 26;
+	name = "Shutters button";
+	id = "tr_gt_main";
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"YO" = (
+/obj/effect/turf_decal/spline/fancy/opaque/yellow{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/syndiemoth{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/hungar)
+"YQ" = (
+/obj/item/broken_bottle{
+	pixel_x = -10
+	},
+/obj/item/shard{
+	pixel_x = 1;
+	pixel_y = -15
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/hangar/plasteel/dark,
+/area/ruin/whitesand/trainyard/dorm)
+"YU" = (
+/turf/open/floor/plating{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"YV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesand/trainyard/checkpoint)
+"YX" = (
+/obj/structure/platform/industrial{
+	dir = 4;
+	density = 0
+	},
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"YY" = (
+/obj/machinery/door/airlock/grunge,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"YZ" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesand/trainyard/shuttle)
+"Zi" = (
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Zj" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"Zl" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/stand_clear,
+/turf/open/floor/concrete/reinforced/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Zm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tr_sh_et"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/checkpoint)
+"Zt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Zu" = (
+/obj/structure/chair/bench/grey/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Zx" = (
+/obj/machinery/smartfridge,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/whitesand/trainyard/dorm)
+"Zy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter/over_window{
+	icon_state = "gibdown1"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/stairs/stairs_pack/mid{
+	dir = 1
+	},
+/area/ruin/whitesand/trainyard/hungar)
+"Zz" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ZA" = (
+/obj/structure/platform/industrial{
+	dir = 1;
+	pixel_y = -20;
+	density = 0
+	},
+/obj/structure/platform/industrial{
+	pixel_y = 12;
+	density = 0
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZD" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZE" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "tr_sh_eng"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesand/trainyard/shuttle)
+"ZG" = (
+/obj/item/ammo_casing/spent/pistol_steel{
+	name = "spent .45 casing"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_3{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ZH" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesand/trainyard/shuttle)
+"ZI" = (
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/heavymetal/var5{
+	initial_gas_mix = "SANDPLANET_ATMOS"
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"ZJ" = (
+/obj/structure/filingcabinet/double/grey,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"ZP" = (
+/obj/structure/platform/military,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZQ" = (
+/obj/structure/table/reinforced/glass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/melee/knife/survival,
+/obj/item/hatchet/wooden{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/wirecutters{
+	pixel_x = 13
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/dorm)
+"ZS" = (
+/turf/closed/wall/rust,
+/area/ruin/whitesand/trainyard/checkpoint/second)
+"ZT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZV" = (
+/obj/structure/closet{
+	icon_state = "syndicate";
+	anchored = 1
+	},
+/obj/item/ammo_box/magazine/m9mm_rattlesnake/empty,
+/obj/item/ammo_box/magazine/m9mm_rattlesnake/empty{
+	pixel_x = 6
+	},
+/obj/item/storage/box/ammo/c9mm{
+	pixel_x = -2
+	},
+/obj/item/storage/box/ammo/c9mm_ap{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/whitesand/trainyard/hungar)
+"ZY" = (
+/obj/effect/turf_decal/road{
+	dir = 8;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/road{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/suns/dark,
+/area/ruin/whitesand/trainyard/dorm)
+
+(1,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+dp
+Va
+Ai
+Ai
+Ai
+vW
+WO
+JL
+JL
+ic
+JL
+JL
+JL
+JL
+JL
+JL
+xB
+xB
+xB
+JL
+JL
+JL
+JL
+JL
+JL
+aT
+aT
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(2,1,1) = {"
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+JL
+aT
+ZS
+ZS
+ZS
+vT
+vT
+ZS
+kx
+pO
+Gn
+Ig
+qv
+Ai
+JL
+JL
+JL
+JL
+FU
+JL
+JL
+JL
+JL
+xB
+xB
+xB
+YD
+xB
+xB
+JL
+JL
+JL
+JL
+JL
+aT
+JL
+LL
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(3,1,1) = {"
+LO
+LO
+LO
+JL
+JL
+JL
+TG
+JL
+JL
+JL
+JL
+JL
+ic
+aT
+ZS
+Jw
+dF
+la
+qi
+bg
+aT
+Ai
+BK
+so
+He
+Ai
+JL
+JL
+uw
+JL
+JL
+JL
+JL
+xB
+xB
+xB
+xB
+xB
+xB
+xB
+xB
+xB
+eA
+JL
+JL
+JL
+aT
+JL
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(4,1,1) = {"
+LO
+LO
+ZP
+Jh
+SU
+JL
+JL
+JL
+JL
+JL
+JL
+Jp
+kt
+aT
+ZS
+fb
+fX
+od
+kd
+bg
+aT
+Ai
+qW
+Ai
+xM
+Ai
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+xB
+xB
+xB
+xB
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(5,1,1) = {"
+LO
+LO
+JL
+JL
+SU
+JL
+JL
+JL
+JL
+ir
+cq
+JL
+aT
+JL
+ZS
+PM
+SB
+oP
+Ik
+AW
+JL
+Ai
+UX
+Ig
+pf
+Ai
+WO
+WO
+cf
+cf
+yB
+cf
+cf
+cf
+WO
+cf
+cf
+cf
+cf
+cf
+cf
+WO
+cf
+cf
+cf
+cf
+cf
+cf
+WO
+WO
+JL
+aT
+aT
+ic
+JL
+LO
+LO
+LO
+LO
+LO
+"}
+(6,1,1) = {"
+LO
+LO
+JL
+JL
+pT
+JL
+nN
+pT
+SU
+CT
+cq
+JL
+JL
+JL
+ZS
+rf
+UB
+XC
+Hx
+ZS
+JL
+Ai
+BK
+so
+He
+Ai
+JL
+JL
+ig
+ig
+ig
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+ig
+ig
+ig
+ig
+ig
+ig
+JL
+JL
+WO
+JL
+uw
+aT
+aT
+JL
+JL
+LO
+LO
+LO
+LO
+"}
+(7,1,1) = {"
+LO
+LO
+ZP
+pT
+pT
+pT
+iW
+SU
+SU
+CT
+cq
+JL
+AU
+eW
+ZS
+GZ
+Rt
+rR
+Dp
+ZS
+JL
+Ai
+qW
+Ai
+xM
+Ai
+Dg
+JL
+QY
+QY
+IW
+ar
+JL
+JL
+JL
+eA
+JL
+Vj
+pT
+IW
+HN
+QY
+Yl
+Yl
+Vj
+Vj
+ig
+JL
+JL
+Of
+JL
+JL
+aT
+aT
+JL
+JL
+JL
+LO
+LO
+LO
+"}
+(8,1,1) = {"
+LO
+JL
+ZP
+pT
+JL
+SU
+nN
+pT
+SU
+CT
+cq
+JL
+nV
+oX
+ZS
+ZS
+ZS
+yA
+ZS
+ZS
+sj
+Ai
+UX
+Ig
+pf
+Ai
+JL
+go
+cg
+QY
+Jc
+iS
+go
+JL
+cg
+go
+Vj
+Vj
+IW
+Jc
+Yl
+rn
+cg
+yE
+Jc
+Vj
+HC
+pT
+JL
+BU
+JL
+JL
+Jp
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+"}
+(9,1,1) = {"
+LO
+JL
+ZP
+pT
+SU
+SU
+nN
+SU
+SU
+CT
+cq
+JL
+VD
+YH
+go
+nE
+Yj
+Zt
+Jc
+QY
+VI
+Ai
+BK
+so
+He
+Ai
+JL
+IW
+xH
+cg
+Yl
+VK
+Vj
+go
+cg
+HN
+QY
+Jc
+Jc
+QY
+go
+go
+go
+Vj
+IW
+QY
+dv
+SU
+pT
+WO
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+WO
+WO
+LO
+"}
+(10,1,1) = {"
+LO
+JL
+JL
+JL
+pT
+SU
+iW
+pT
+JL
+JL
+JL
+JL
+VD
+Jc
+HN
+go
+Vj
+Cz
+id
+go
+VI
+Ai
+qW
+Ai
+xM
+Ai
+VD
+IW
+go
+cg
+Vj
+yE
+Hf
+Yl
+QY
+cg
+go
+go
+go
+go
+FI
+FI
+FI
+FI
+Yb
+Yb
+FI
+Af
+SU
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+WO
+LO
+"}
+(11,1,1) = {"
+JL
+vn
+JL
+JL
+ar
+Sh
+Sh
+SU
+pT
+uw
+aT
+JL
+VD
+go
+Jc
+HN
+Jc
+NN
+IW
+yE
+VI
+Ai
+UX
+Ig
+pf
+Ai
+VD
+IW
+QY
+cg
+PL
+PL
+PL
+PL
+eG
+eG
+eG
+PL
+PL
+PL
+FI
+gC
+Cs
+Gc
+Th
+Th
+FI
+fa
+fa
+pT
+Ob
+Ob
+WA
+up
+WA
+Ob
+Ob
+pT
+tI
+LO
+"}
+(12,1,1) = {"
+JL
+JL
+ZP
+Jh
+Sh
+Sh
+Sh
+SU
+SU
+JL
+aT
+aT
+VD
+go
+IW
+IW
+aP
+Mw
+wI
+gx
+Ub
+Ai
+BK
+so
+He
+Ai
+VD
+IW
+hd
+HN
+eG
+ds
+Am
+ht
+ds
+eG
+Sb
+QT
+Fk
+PD
+Yb
+ZZ
+mr
+Qk
+DZ
+Ny
+FI
+Sf
+pT
+pT
+Ob
+Ic
+Ai
+Ic
+Ai
+Ic
+Ob
+pT
+tI
+LO
+"}
+(13,1,1) = {"
+LO
+JL
+ZP
+GM
+Sh
+bF
+Sh
+Sh
+SU
+JL
+aT
+aT
+VD
+MZ
+MZ
+MZ
+tW
+IX
+MZ
+MZ
+TS
+Ai
+qW
+Ai
+xM
+Ai
+VD
+IW
+IW
+go
+eG
+lG
+FS
+zC
+bX
+wy
+Ij
+wQ
+Ju
+zy
+Yb
+Qh
+Xf
+SK
+yz
+yo
+FI
+fy
+pT
+pT
+ZD
+Ic
+Rc
+Ic
+Rc
+Ic
+af
+pT
+tI
+iN
+"}
+(14,1,1) = {"
+LO
+JL
+ZP
+GM
+Sh
+Sh
+Kz
+Sh
+SU
+CT
+cq
+aT
+yx
+MZ
+WP
+MZ
+Ak
+Ni
+Cl
+MZ
+Vn
+Ai
+UX
+Ig
+pf
+Ai
+pV
+IW
+go
+Jc
+PL
+Rq
+MT
+Au
+JO
+Ii
+xh
+jG
+Pq
+cm
+Yb
+Lr
+It
+Id
+pu
+fx
+FI
+ua
+nb
+pT
+Ic
+Ic
+ZE
+dr
+ZE
+Ic
+Ic
+pT
+tI
+iN
+"}
+(15,1,1) = {"
+LO
+JL
+ZP
+GM
+JL
+Sh
+Sh
+Sh
+ar
+vj
+cq
+JL
+JL
+MZ
+er
+Se
+et
+pg
+pd
+MZ
+Vn
+Ai
+BK
+so
+He
+Ai
+Pe
+Vj
+Vj
+cs
+PL
+vY
+es
+zC
+zC
+wy
+Cc
+wt
+JF
+ao
+Yb
+gW
+ys
+xJ
+HP
+Th
+FI
+ML
+SU
+pT
+Cr
+KK
+YZ
+Xw
+pQ
+Tk
+rM
+pT
+tI
+iN
+"}
+(16,1,1) = {"
+LO
+JL
+ZP
+GM
+JL
+JL
+Sh
+pT
+pT
+vj
+cq
+FU
+JL
+MZ
+MZ
+MZ
+MZ
+ev
+MZ
+MZ
+PQ
+UR
+PF
+PF
+PF
+zg
+dB
+TP
+Vj
+AR
+PL
+wC
+ED
+ZV
+AE
+eG
+Ug
+Os
+WD
+eG
+Yb
+Yb
+QV
+Yb
+Yb
+Yb
+FI
+FI
+nS
+pT
+bH
+Ka
+ES
+dm
+eV
+yh
+Ic
+pT
+nX
+iN
+"}
+(17,1,1) = {"
+LO
+JL
+ZP
+Jh
+ar
+JL
+JL
+pT
+pT
+vj
+cq
+JL
+pT
+MZ
+FQ
+mC
+Dc
+ve
+hM
+MZ
+fE
+ej
+qE
+hm
+qE
+FM
+IC
+wI
+RE
+iO
+PL
+eG
+eG
+eG
+eG
+eG
+cE
+rS
+Ek
+eG
+FL
+Aw
+hl
+vZ
+Yb
+fR
+Sw
+FI
+SU
+pT
+mj
+MN
+jR
+qu
+La
+ZH
+Ic
+JL
+tI
+iN
+"}
+(18,1,1) = {"
+LO
+JL
+JL
+JL
+pT
+pT
+JL
+pT
+SU
+CT
+cq
+JL
+pT
+MZ
+tn
+Pb
+Jr
+Em
+Oi
+MZ
+zW
+Ai
+BK
+ti
+He
+Ai
+dB
+rn
+Ud
+Wf
+eG
+Kx
+YO
+UQ
+Bh
+Qn
+OL
+rG
+Rz
+eG
+LC
+fw
+ls
+EI
+QD
+HT
+Ur
+FI
+SU
+pT
+Ic
+vl
+jR
+iR
+wx
+cn
+Ic
+JL
+tI
+iY
+"}
+(19,1,1) = {"
+LO
+LO
+ZP
+Jh
+pT
+SU
+ZY
+SU
+SU
+CT
+cq
+JL
+pT
+MZ
+jw
+GW
+wS
+Nj
+Vm
+MZ
+zW
+OR
+OR
+OR
+OR
+OR
+dB
+TP
+Ud
+Wf
+eG
+nu
+Uj
+jQ
+pt
+iM
+Fe
+nc
+iv
+eG
+AI
+NP
+aY
+GH
+Yb
+WU
+vJ
+Yb
+SU
+pT
+Ic
+Ic
+pX
+bm
+lY
+Ic
+Ic
+JL
+tI
+iN
+"}
+(20,1,1) = {"
+LO
+LO
+ZP
+Jh
+SU
+pT
+yI
+pT
+SU
+JL
+JL
+JL
+JL
+MZ
+BB
+kw
+kP
+Lu
+ip
+MZ
+cW
+OR
+GS
+UV
+aO
+OR
+Nt
+go
+Lk
+tX
+eG
+fH
+Uj
+KP
+DS
+HU
+ox
+hG
+OL
+Vf
+kS
+Is
+Pw
+Iu
+Yb
+Yb
+Yb
+Yb
+OW
+SU
+Ob
+Ic
+KZ
+Yr
+mz
+Ic
+Ob
+pT
+tI
+iN
+"}
+(21,1,1) = {"
+LO
+LO
+ZP
+Jh
+pT
+pT
+ZY
+pT
+pT
+JL
+JL
+WO
+yB
+MZ
+jw
+jw
+Yn
+GW
+LQ
+MZ
+cW
+OR
+km
+HH
+JT
+OR
+az
+go
+Lk
+jt
+gi
+eE
+eM
+Mt
+ep
+Uk
+ox
+nj
+sZ
+XO
+rB
+gm
+iE
+it
+Zx
+pj
+Wa
+Yb
+pT
+OW
+Ob
+Ic
+Ic
+AZ
+Ic
+Ic
+Ob
+pT
+tI
+LO
+"}
+(22,1,1) = {"
+LO
+JL
+JL
+JL
+pT
+pT
+ZY
+aT
+pT
+JL
+JL
+tI
+JL
+MZ
+MZ
+MZ
+MZ
+MZ
+MZ
+MZ
+yV
+Jm
+tU
+lt
+ks
+Jm
+VD
+QY
+RR
+tX
+gi
+rj
+BL
+Aa
+jL
+kI
+bV
+sD
+ha
+eG
+EU
+sQ
+Eo
+yi
+yg
+LV
+EH
+FI
+SU
+Iz
+ZD
+Ob
+Ic
+PV
+Ic
+Ob
+af
+pT
+tI
+LO
+"}
+(23,1,1) = {"
+LO
+JL
+JL
+JL
+pT
+SU
+ZY
+aT
+pT
+pT
+cq
+tI
+JL
+JL
+pT
+VD
+ig
+ig
+ig
+ig
+VI
+Jm
+fn
+RX
+Jq
+Jm
+tO
+Vj
+NN
+JG
+gi
+My
+oo
+lz
+Uq
+aQ
+OH
+sD
+Fe
+eG
+EQ
+sQ
+Tv
+qM
+yg
+LV
+MP
+FI
+SU
+pT
+ZD
+Ob
+Ic
+Ic
+Ic
+Ob
+af
+pT
+tI
+LO
+"}
+(24,1,1) = {"
+LO
+JL
+ZP
+SU
+pT
+SU
+yI
+pT
+Ul
+pT
+cq
+tI
+JL
+JL
+pT
+VD
+QY
+yE
+yE
+go
+tO
+Jm
+oq
+de
+Yq
+Jm
+VD
+yE
+wA
+TW
+bb
+BF
+CN
+EW
+Oy
+Zy
+BR
+oK
+gr
+eG
+xa
+sQ
+rp
+MQ
+lU
+yK
+ix
+FI
+pT
+SU
+Ov
+Ob
+XD
+Ic
+XD
+Ob
+IQ
+pT
+tI
+LO
+"}
+(25,1,1) = {"
+LO
+JL
+JL
+JL
+SU
+pT
+yI
+pT
+pT
+SU
+cq
+tI
+JL
+JL
+pT
+VD
+go
+go
+yE
+yE
+VI
+OR
+Rv
+vP
+Mn
+OR
+VD
+yE
+NN
+cg
+aj
+WG
+JW
+Uv
+II
+XE
+Xq
+OX
+yS
+eG
+AF
+Fo
+YQ
+GF
+Gr
+eg
+JE
+FI
+pT
+SU
+pT
+pT
+pT
+pT
+SU
+SU
+pT
+pT
+tI
+LO
+"}
+(26,1,1) = {"
+LO
+JL
+JL
+JL
+SU
+pT
+yI
+aT
+SU
+SU
+cq
+tI
+JL
+pT
+SU
+VD
+go
+GC
+uV
+Vj
+VI
+OR
+JI
+tR
+NT
+OR
+VD
+yE
+NN
+go
+PL
+yf
+Wg
+gD
+dU
+qD
+fv
+UF
+zK
+eG
+UY
+Gt
+om
+rK
+bt
+VF
+gq
+FI
+pT
+pT
+fy
+pT
+SU
+SU
+SU
+pT
+pT
+JL
+tI
+LO
+"}
+(27,1,1) = {"
+JL
+uh
+JL
+JL
+SU
+pT
+aT
+aT
+SU
+JL
+JL
+tI
+JL
+pT
+SU
+VD
+go
+ui
+uV
+go
+VI
+OR
+OR
+OR
+OR
+OR
+VD
+go
+IO
+QY
+PL
+dc
+dc
+dc
+eG
+hX
+bV
+wt
+Bc
+eG
+ax
+TV
+fh
+Yb
+Yb
+Yb
+Yb
+FI
+fc
+fc
+IJ
+Vc
+zt
+xb
+WO
+eJ
+eJ
+eJ
+WO
+LO
+"}
+(28,1,1) = {"
+JL
+JL
+JL
+JL
+pT
+aT
+aT
+aT
+SU
+JL
+JL
+tI
+JL
+SU
+SU
+VD
+Vj
+go
+Hb
+IW
+kQ
+Ai
+qW
+vQ
+xM
+Ai
+TE
+go
+DY
+yE
+eG
+YI
+Wb
+HS
+md
+Sd
+DW
+GJ
+GT
+eG
+dO
+KE
+tY
+Yb
+Us
+Zj
+JY
+FI
+Ai
+Ai
+VI
+vv
+Vj
+cg
+LB
+JL
+JL
+JL
+JL
+LO
+"}
+(29,1,1) = {"
+JL
+JL
+ZP
+Jh
+pT
+aT
+aT
+vD
+pT
+CT
+cq
+tI
+JL
+pT
+pT
+VD
+Vj
+QY
+QY
+go
+EZ
+OR
+OR
+OR
+OR
+OR
+Zl
+HN
+ab
+yE
+eG
+NY
+ws
+Ag
+md
+DQ
+bV
+wt
+tP
+eG
+mq
+ou
+na
+YY
+eU
+um
+Cq
+Yb
+Ai
+Ai
+HC
+IW
+fS
+cg
+LB
+JL
+Jp
+JL
+LO
+LO
+"}
+(30,1,1) = {"
+JL
+JL
+ZP
+Jh
+JL
+JL
+JL
+zq
+aT
+CT
+cq
+tI
+pT
+pT
+ar
+VD
+Vj
+cg
+QY
+HN
+Jo
+OR
+HE
+uo
+ff
+OR
+Lx
+QY
+du
+go
+eG
+Fx
+pY
+SN
+eG
+kU
+fV
+OX
+Jj
+eG
+Oo
+pD
+wz
+Yb
+Hz
+Rm
+ZQ
+Yb
+Ai
+Ai
+dv
+go
+Zi
+IW
+LB
+JL
+JL
+ic
+LO
+LO
+"}
+(31,1,1) = {"
+JL
+BX
+BX
+gG
+gG
+xN
+xN
+xN
+xN
+gG
+BX
+BX
+pT
+pT
+pT
+VD
+cg
+am
+OT
+QY
+Jo
+OR
+xX
+yu
+ff
+OR
+Lx
+go
+DY
+go
+PL
+yw
+IG
+lv
+DX
+rj
+Fg
+tM
+kn
+eG
+IM
+PY
+Ys
+Yb
+fN
+zP
+vw
+FI
+KS
+mK
+VI
+go
+cg
+tj
+LB
+JL
+JL
+LO
+LO
+LO
+"}
+(32,1,1) = {"
+JL
+BX
+Xs
+Xs
+Xs
+RY
+ku
+hF
+Up
+Xs
+Xs
+BX
+SU
+pT
+pT
+VD
+cg
+am
+qg
+QY
+Jo
+KO
+oS
+Rs
+NQ
+KO
+Lx
+IW
+DY
+go
+kb
+Ya
+Ya
+eG
+eG
+eG
+fU
+Pk
+eG
+eG
+Yb
+Ca
+Yb
+Yb
+Yb
+Yb
+Yb
+FI
+Bn
+Fs
+Fs
+go
+go
+Vj
+LB
+Dg
+JL
+LO
+LO
+LO
+"}
+(33,1,1) = {"
+JL
+BX
+Xs
+NO
+hU
+jY
+Fv
+hF
+hF
+Vu
+Xs
+BX
+pT
+SU
+pT
+VD
+cg
+cg
+cg
+go
+Jo
+KO
+MI
+mc
+ye
+KO
+Lx
+IW
+RR
+go
+go
+Vj
+Ya
+ZJ
+Te
+SL
+Ec
+JP
+pF
+eG
+tE
+Ua
+Pv
+iL
+mk
+pr
+OV
+Mf
+sI
+lV
+Yd
+Jl
+bR
+oE
+WO
+JL
+JL
+LO
+LO
+LO
+"}
+(34,1,1) = {"
+JL
+BX
+iw
+hF
+hF
+aT
+aT
+aT
+hF
+So
+sC
+BX
+pT
+SU
+pT
+VD
+yE
+Jc
+yE
+HN
+Jo
+KO
+Ji
+nF
+NJ
+KO
+Lx
+cg
+RR
+QY
+HN
+HN
+Ya
+DC
+Vk
+Bs
+Gx
+Oe
+BM
+UI
+ow
+NL
+an
+bj
+Ar
+vk
+ot
+LX
+Ez
+dz
+Yd
+pT
+SU
+SU
+Kt
+xB
+JL
+LO
+LO
+LO
+"}
+(35,1,1) = {"
+JL
+BX
+hF
+Dj
+vD
+aT
+Sh
+Sh
+UG
+Cg
+Xs
+BX
+pT
+SU
+SU
+VD
+Vj
+IW
+zG
+HN
+EZ
+OR
+nR
+Hm
+kM
+OR
+Zl
+cg
+RR
+Jc
+QY
+QY
+PL
+fm
+jZ
+qA
+js
+hC
+ge
+eG
+QJ
+ce
+CK
+IT
+gg
+FN
+FW
+wl
+cc
+hr
+Yd
+SU
+SU
+pT
+Kt
+xB
+JL
+JL
+LO
+LO
+"}
+(36,1,1) = {"
+JL
+Mv
+bK
+Fv
+aT
+Sh
+Sh
+Sh
+hF
+Cg
+Xs
+EJ
+pT
+pT
+SU
+VD
+cg
+GC
+Yk
+HN
+Xe
+OR
+LJ
+sb
+vN
+OR
+Fp
+cg
+NN
+IW
+HN
+go
+PL
+wv
+lu
+Eu
+OP
+BZ
+xZ
+eG
+Yd
+Yd
+Yd
+Yd
+Yd
+pB
+FW
+qf
+FW
+ba
+Fs
+SU
+pT
+pT
+Kt
+xB
+xB
+JL
+LO
+LO
+"}
+(37,1,1) = {"
+JL
+EC
+Fv
+Fv
+Sh
+Sh
+xB
+Sh
+bF
+Dj
+Xs
+hB
+SU
+pT
+pT
+VD
+IW
+uK
+Yk
+cg
+VI
+OR
+OR
+OR
+OR
+OR
+VD
+cg
+Ud
+cg
+HN
+Pe
+Vb
+qJ
+qJ
+JF
+mE
+eu
+NU
+eG
+lA
+rx
+If
+MM
+Yd
+aF
+yk
+if
+wG
+nr
+Fs
+SU
+pT
+pT
+WO
+cf
+cf
+cf
+WO
+LO
+"}
+(38,1,1) = {"
+JL
+EC
+Xs
+aT
+Sh
+Sh
+qd
+xB
+Sh
+aT
+Xs
+Bf
+pT
+pT
+pT
+pV
+Jc
+go
+cg
+HN
+gF
+Ai
+UX
+ti
+pf
+Ai
+VD
+Jc
+NN
+IW
+Jc
+Nt
+Yy
+Oe
+Si
+Si
+BP
+Sy
+JZ
+eG
+sp
+BS
+BN
+If
+Sz
+vz
+Rh
+mx
+MD
+NW
+Fs
+pT
+SU
+pT
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(39,1,1) = {"
+LO
+sR
+eB
+aT
+Sh
+xB
+xB
+xB
+Sh
+aT
+Xs
+mD
+pT
+nO
+SU
+Pe
+QY
+QY
+HN
+yE
+VI
+Ai
+BK
+so
+He
+Ai
+VD
+yE
+Ud
+HN
+IW
+IW
+PL
+wu
+CZ
+vH
+SZ
+jH
+xZ
+eG
+yt
+GK
+fk
+fk
+vf
+ad
+uT
+QK
+vd
+mV
+Fs
+pT
+pT
+SU
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(40,1,1) = {"
+LO
+BX
+Xs
+Dj
+Sh
+Sh
+Sh
+Sh
+Sh
+nf
+Xs
+EJ
+pT
+pT
+SU
+dB
+go
+QY
+QY
+go
+VI
+Ai
+mb
+Ai
+kp
+Ai
+VD
+yE
+IO
+Vj
+cg
+cg
+PL
+Gd
+un
+Sx
+Aj
+sU
+UC
+eG
+VN
+ym
+pM
+qq
+Yd
+yQ
+WL
+Hi
+gQ
+ik
+Fs
+pT
+pT
+SU
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(41,1,1) = {"
+LO
+BX
+Xs
+Dj
+Sh
+Kz
+Sh
+Sh
+aT
+nf
+hF
+EJ
+pT
+SU
+SU
+dB
+go
+QY
+Jc
+go
+VI
+Ai
+WE
+Ig
+aS
+Ai
+pV
+Jl
+pZ
+XK
+XK
+XK
+eG
+eG
+eG
+eG
+eG
+eG
+eG
+eG
+Yd
+Yd
+Yd
+Yd
+Yd
+Yd
+Hn
+wT
+Yd
+Yd
+Fs
+pT
+pT
+SU
+wY
+pT
+pT
+JL
+tI
+LO
+"}
+(42,1,1) = {"
+LO
+BX
+Xs
+So
+Sh
+aT
+Sh
+aT
+aT
+hF
+Xs
+BX
+pT
+SU
+pT
+Nt
+yE
+yE
+IW
+QY
+VI
+Ai
+CR
+so
+lQ
+Ai
+pT
+pT
+Vn
+pT
+SU
+SU
+pT
+pT
+pT
+pT
+ig
+ig
+OB
+OB
+IW
+IW
+OB
+OB
+OB
+OB
+LU
+rF
+pe
+Kc
+pT
+fy
+pT
+SU
+SU
+pT
+pT
+JL
+nX
+LO
+"}
+(43,1,1) = {"
+JL
+BX
+iw
+So
+kJ
+aT
+vD
+aT
+hF
+hF
+sC
+BX
+SU
+SU
+pT
+az
+go
+Vj
+IW
+QY
+gF
+Ai
+Eb
+Ai
+uJ
+Ai
+SU
+SU
+Vn
+pT
+JL
+SU
+SU
+pT
+ig
+ig
+ig
+OB
+OB
+OB
+OB
+OB
+cg
+Vj
+Vj
+xl
+nd
+wL
+nI
+MB
+MB
+pT
+SU
+pT
+pT
+SU
+pT
+JL
+tI
+LO
+"}
+(44,1,1) = {"
+JL
+BX
+Xs
+So
+Xs
+Xs
+aT
+hF
+hF
+YC
+Xs
+BX
+SU
+SU
+pT
+VD
+go
+uK
+uV
+go
+gF
+Ai
+Qs
+Ig
+DH
+Ai
+pT
+SU
+dT
+JL
+uw
+pT
+pT
+ig
+ig
+OB
+IW
+QP
+Lv
+PZ
+jB
+XL
+XL
+XL
+DI
+Fh
+Fd
+gU
+tJ
+ld
+vg
+ig
+SU
+pT
+pT
+SU
+pT
+JL
+tI
+LO
+"}
+(45,1,1) = {"
+JL
+BX
+NO
+uA
+IE
+IE
+jY
+dd
+IE
+JA
+wm
+BX
+SU
+SU
+pT
+VD
+go
+uK
+uV
+Vj
+gF
+Ai
+CR
+so
+He
+Bk
+Ai
+SU
+Vn
+JL
+JL
+pT
+ig
+ig
+IW
+QP
+PZ
+rr
+XL
+XL
+WO
+Gy
+Gy
+Gy
+WO
+XL
+XL
+jb
+Lv
+gU
+OB
+ig
+ig
+pT
+pT
+pT
+pT
+pT
+tI
+LO
+"}
+(46,1,1) = {"
+JL
+BX
+YC
+Nn
+vI
+FT
+em
+So
+Wq
+jM
+jM
+BX
+pT
+SU
+pT
+VD
+HN
+go
+aL
+Vj
+nT
+Ai
+sK
+RD
+xM
+Rn
+Ai
+pT
+Vn
+pT
+pT
+ig
+ig
+IW
+nk
+TA
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+jb
+sF
+OB
+ig
+ig
+pT
+SU
+pT
+pT
+WO
+LO
+"}
+(47,1,1) = {"
+JL
+BX
+YC
+oI
+wm
+wm
+oI
+So
+BX
+BX
+BX
+BX
+pT
+SU
+pT
+VD
+cg
+QY
+yE
+Vj
+VI
+Ai
+UX
+xy
+pf
+ya
+Ai
+Ai
+PQ
+SU
+pT
+ig
+IW
+DI
+TA
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+jb
+IP
+Vj
+ig
+pT
+SU
+SU
+pT
+tI
+LO
+"}
+(48,1,1) = {"
+lp
+BX
+YC
+wm
+oI
+wm
+wm
+So
+BX
+pT
+pT
+pT
+SU
+SU
+pT
+VD
+cg
+go
+QY
+yE
+VI
+Ai
+BK
+LM
+He
+JH
+Hk
+Ai
+Wy
+pT
+ig
+ig
+Vj
+Tz
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+eO
+xl
+ig
+ig
+pT
+SU
+pT
+tI
+JL
+"}
+(49,1,1) = {"
+JL
+BX
+sT
+wm
+wm
+Pl
+oI
+Kw
+BX
+pT
+pT
+SU
+SU
+SU
+pT
+VD
+cg
+GC
+OT
+yE
+VI
+Ai
+qW
+ZA
+Hr
+hw
+Be
+Hk
+CJ
+il
+ig
+OB
+Ae
+rr
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+jb
+IP
+OB
+ig
+pT
+pT
+SU
+tI
+JL
+"}
+(50,1,1) = {"
+LO
+BX
+YC
+Ro
+TU
+wm
+oI
+DK
+ec
+pT
+pT
+SU
+pT
+SU
+pT
+VD
+cg
+GC
+uV
+Vj
+VI
+Ai
+UX
+PA
+KU
+Wt
+AV
+rI
+Ee
+PF
+Ai
+OB
+wU
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+eO
+Vj
+ig
+pT
+pT
+SU
+tI
+FU
+"}
+(51,1,1) = {"
+LO
+BX
+YC
+Ad
+VO
+pR
+oI
+So
+BX
+pT
+SU
+pT
+pT
+SU
+pT
+VD
+cg
+cg
+IW
+IW
+VI
+Ai
+BK
+so
+He
+vB
+cQ
+Kr
+Ee
+PF
+Ai
+Ai
+lW
+Xp
+UZ
+UZ
+ho
+UZ
+UZ
+Uz
+UZ
+UZ
+ho
+UZ
+UZ
+UZ
+Uz
+UZ
+ho
+ho
+UZ
+Ki
+ns
+OB
+ig
+ig
+pT
+SU
+tI
+aT
+"}
+(52,1,1) = {"
+LO
+BX
+xn
+IE
+IE
+IE
+IE
+JA
+BX
+SU
+SU
+pT
+pT
+SU
+pT
+VD
+HN
+cg
+cg
+Jc
+VI
+Ai
+qW
+Ai
+xM
+Cn
+Yg
+kB
+Ee
+PF
+DB
+aV
+Oz
+Mh
+WS
+WS
+WS
+WS
+Vl
+cT
+cT
+tz
+SJ
+SJ
+Er
+Er
+SJ
+zD
+wn
+WS
+WS
+WO
+xl
+xl
+cg
+ig
+pT
+pT
+kW
+aT
+"}
+(53,1,1) = {"
+LO
+BX
+BX
+BX
+Vi
+Vi
+lj
+Vi
+BX
+pT
+pT
+pT
+SU
+pT
+SU
+VD
+QY
+go
+bD
+IW
+VI
+Ai
+UX
+Ig
+pf
+Ai
+ft
+IS
+Ee
+PF
+XY
+Ai
+yD
+Pc
+lR
+ln
+Vg
+Vl
+Vl
+fo
+rc
+Wu
+Vl
+HR
+HR
+HR
+pb
+Er
+zD
+iD
+ln
+je
+XL
+cg
+OB
+ig
+pT
+SU
+kW
+aT
+"}
+(54,1,1) = {"
+LO
+Of
+JL
+JL
+HF
+gL
+pT
+fl
+pT
+pT
+pT
+SU
+SU
+SU
+SU
+VD
+yE
+ro
+jl
+go
+VI
+Ai
+BK
+so
+He
+Ai
+pT
+Do
+Ee
+PF
+XY
+Ai
+yD
+Eh
+zF
+ZI
+YU
+Vl
+vX
+uO
+Ps
+uU
+Vl
+Ge
+al
+nC
+Vl
+Er
+ol
+XS
+ZI
+je
+XL
+cg
+xl
+ig
+SU
+pT
+tI
+JL
+"}
+(55,1,1) = {"
+LO
+WO
+JL
+JL
+JL
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+SU
+pT
+VD
+yE
+ui
+OT
+IW
+bO
+Ai
+UX
+Ig
+pf
+Ai
+pT
+pT
+Ee
+PF
+Tg
+aV
+ng
+yF
+YX
+cP
+Sj
+Vl
+Vl
+Fw
+TH
+SP
+Vl
+HR
+HR
+HR
+NX
+Er
+CH
+mf
+cP
+je
+XL
+Vj
+xl
+ig
+SU
+pT
+WO
+JL
+"}
+(56,1,1) = {"
+LO
+tI
+JL
+FU
+JL
+pT
+pT
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+pT
+VD
+Vj
+go
+IW
+IW
+qt
+UR
+PF
+PF
+PF
+zg
+pT
+pT
+QF
+cM
+Ai
+Ai
+Ai
+Yp
+TO
+TO
+TO
+TO
+Vl
+cT
+cT
+tz
+aA
+aA
+aA
+aA
+aA
+CH
+wn
+TO
+TO
+WO
+OB
+OB
+OB
+ig
+pT
+JL
+tI
+JL
+"}
+(57,1,1) = {"
+LO
+WO
+JL
+JL
+JL
+pT
+pT
+pT
+pT
+pT
+qI
+pT
+ts
+pT
+pT
+kR
+yE
+cg
+cg
+go
+sY
+UR
+PF
+PF
+PF
+zg
+pT
+pT
+Vn
+pT
+ig
+IW
+Ae
+Vy
+UZ
+mL
+mL
+mL
+mL
+Uz
+UZ
+UZ
+UZ
+UZ
+UZ
+UZ
+ke
+UZ
+UZ
+UZ
+UZ
+Li
+gU
+Vj
+ig
+ig
+pT
+JL
+tI
+JL
+"}
+(58,1,1) = {"
+LO
+WO
+jx
+gs
+pE
+tp
+tp
+pE
+SU
+OZ
+dJ
+ts
+VT
+WO
+pT
+VD
+Jc
+Jc
+HN
+cg
+qn
+Ai
+BK
+so
+He
+Ai
+pT
+pT
+Vn
+pT
+ig
+cg
+Tz
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+eO
+Vj
+ig
+pT
+pT
+JL
+tI
+LO
+"}
+(59,1,1) = {"
+JL
+WO
+JL
+JL
+pT
+pT
+SU
+pT
+pT
+OZ
+Gf
+Vr
+ts
+Kt
+pT
+VD
+go
+GC
+Zu
+cg
+VI
+Ai
+UX
+Ig
+pf
+Ai
+pT
+pT
+WW
+qo
+lc
+lc
+rX
+uv
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+Og
+BY
+OB
+ig
+pT
+JL
+JL
+tI
+LO
+"}
+(60,1,1) = {"
+JL
+WO
+JL
+JL
+lZ
+pT
+pT
+SU
+pT
+pT
+ts
+Vr
+ts
+Kt
+pT
+VD
+go
+uK
+lL
+IW
+VI
+Ai
+BK
+so
+He
+Ai
+pT
+hs
+hs
+hs
+hs
+vq
+du
+DR
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+eO
+Vj
+ig
+ig
+pT
+JL
+JL
+tI
+LO
+"}
+(61,1,1) = {"
+JL
+WO
+JL
+JL
+pT
+pT
+pT
+SU
+SU
+gO
+aC
+Vr
+Vr
+Kt
+pT
+VD
+go
+Jc
+kG
+IW
+VI
+Ai
+qW
+Ai
+xM
+Ai
+pT
+hs
+BC
+tr
+hE
+xp
+ia
+Wi
+aK
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+Og
+iu
+OB
+ig
+pT
+pT
+JL
+uh
+tI
+LO
+"}
+(62,1,1) = {"
+JL
+WO
+jn
+JL
+JL
+pT
+SU
+SU
+pT
+Mi
+pC
+ts
+ts
+Kt
+pT
+VD
+Jc
+Jc
+go
+yE
+gF
+Ai
+UX
+Ig
+pf
+Ai
+pT
+hs
+qX
+qG
+KB
+GO
+Fn
+OB
+ry
+uv
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+np
+Yv
+OB
+ig
+ig
+pT
+pT
+JL
+JL
+tI
+LO
+"}
+(63,1,1) = {"
+JL
+WO
+cf
+cf
+cf
+cf
+cf
+Nx
+Nx
+cf
+cf
+WO
+cf
+WO
+pT
+VD
+go
+IW
+Jc
+yE
+VI
+Ai
+BK
+so
+He
+Ai
+pT
+hs
+LH
+tu
+ta
+VG
+ze
+zV
+OB
+Wi
+Xv
+EM
+XL
+XL
+WO
+uu
+uu
+Gy
+WO
+XL
+XL
+Og
+to
+BY
+OB
+ig
+ig
+pT
+pT
+pT
+JL
+JL
+tI
+JL
+"}
+(64,1,1) = {"
+JL
+Jp
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+tI
+pT
+VD
+QY
+QY
+Jc
+Jc
+VI
+Ai
+qW
+Ai
+xM
+Ai
+pT
+hs
+jc
+tu
+Fj
+hs
+hs
+Tx
+he
+Vj
+OB
+Km
+Xv
+to
+AB
+XL
+XL
+XL
+Km
+Xv
+Xv
+iu
+Vj
+cg
+ig
+ig
+pT
+SU
+ar
+pT
+JL
+JL
+WO
+JL
+"}
+(65,1,1) = {"
+JL
+JL
+JL
+JL
+cb
+cb
+cb
+ic
+JL
+wb
+wb
+JL
+JL
+tI
+JL
+VD
+IW
+cg
+QY
+Jc
+VI
+Ai
+UX
+Ig
+pf
+Ai
+pT
+hs
+dI
+tr
+Lz
+RW
+hs
+zl
+iK
+cg
+OB
+Vj
+Vj
+Vj
+cg
+cg
+OB
+OB
+cg
+rn
+cg
+cg
+ig
+ig
+ig
+pT
+pT
+SU
+pT
+pT
+uw
+JL
+tI
+ic
+"}
+(66,1,1) = {"
+JL
+JL
+JL
+cb
+cb
+cb
+cb
+cb
+JL
+Ye
+Dq
+JL
+Sh
+tI
+JL
+VD
+Jc
+Jc
+QY
+go
+VI
+Ai
+BK
+so
+iG
+Ai
+pT
+hs
+tN
+Dy
+tu
+oU
+hs
+fr
+iK
+ig
+ig
+ig
+cg
+cg
+cg
+Vj
+OB
+Rk
+CS
+rn
+Rr
+Rr
+ap
+ap
+ap
+Rr
+Rr
+pT
+SU
+pT
+JL
+JL
+tI
+JL
+"}
+(67,1,1) = {"
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+cb
+JL
+Br
+Br
+Sh
+Sh
+XA
+Sh
+pV
+XK
+HK
+HK
+eL
+bO
+Ai
+qW
+Ai
+xM
+Ai
+fy
+hs
+hs
+hs
+hs
+hs
+hs
+Ey
+ZT
+pT
+pT
+ig
+ig
+ig
+cg
+OB
+cg
+cg
+cg
+ig
+Rr
+RQ
+ak
+Ui
+Ui
+cj
+Rr
+pT
+SU
+pT
+JL
+JL
+tI
+JL
+"}
+(68,1,1) = {"
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+cb
+cb
+JL
+xB
+Sh
+Sh
+WO
+Sh
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+Gn
+Ig
+WF
+Ai
+pT
+SU
+pT
+pT
+pT
+SU
+SU
+Ey
+ZT
+pT
+SU
+pT
+pT
+ig
+ig
+ig
+ig
+ig
+ig
+ig
+Rr
+Jv
+ak
+Uu
+Mk
+OQ
+Rr
+pT
+pT
+SU
+JL
+JL
+tI
+LO
+"}
+(69,1,1) = {"
+LO
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+cb
+xB
+xB
+Sh
+Sh
+WO
+WO
+eJ
+eJ
+eJ
+eJ
+WO
+WO
+Ai
+BK
+so
+GY
+Ai
+pT
+SU
+SU
+SU
+SU
+SU
+pT
+Ey
+Vn
+pT
+ar
+SU
+SU
+pT
+pT
+pT
+yO
+pT
+st
+pT
+Rr
+IV
+sn
+iQ
+gf
+SH
+Rr
+pT
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(70,1,1) = {"
+LO
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+cb
+xB
+Sh
+Kz
+Sh
+Sh
+Sh
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+qW
+Ai
+yc
+Ai
+pT
+hv
+hv
+hv
+hv
+hv
+hv
+fc
+lI
+xb
+fc
+qn
+SU
+SU
+pT
+pT
+pT
+SU
+SU
+pT
+Rr
+Ot
+LN
+El
+Rr
+Rr
+Rr
+pT
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(71,1,1) = {"
+LO
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+cb
+xB
+Sh
+Sh
+Sh
+Sh
+Sh
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+UX
+Ig
+jS
+Ai
+pT
+hv
+uY
+Dd
+jK
+Jy
+hv
+cg
+Qw
+IW
+go
+VI
+pT
+pT
+SU
+pT
+SU
+pT
+pT
+pT
+Rr
+ER
+By
+Nb
+Rr
+pT
+pT
+SU
+SU
+pT
+JL
+JL
+tI
+LO
+"}
+(72,1,1) = {"
+LO
+LO
+JL
+cb
+cb
+cb
+cb
+cb
+xB
+xB
+Sh
+Sh
+Sh
+Sh
+uw
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+BK
+so
+zv
+Ai
+pT
+hv
+MG
+Ib
+eY
+bN
+HG
+bz
+ZG
+lH
+tm
+HC
+pT
+pT
+SU
+SU
+pT
+pT
+pT
+pT
+Rr
+Rr
+Rr
+nB
+Rr
+pT
+pT
+SU
+pT
+JL
+Dg
+JL
+tI
+LO
+"}
+(73,1,1) = {"
+LO
+LO
+LO
+cb
+cb
+cb
+cb
+cb
+xB
+xB
+xB
+xB
+xB
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+qW
+Ai
+yc
+Ai
+pT
+Bi
+QG
+nU
+YV
+zf
+hv
+DT
+OS
+TN
+iq
+IU
+qo
+qo
+qo
+qo
+Wr
+qo
+qo
+qo
+qo
+qo
+qo
+GI
+EA
+pT
+SU
+SU
+pT
+JL
+JL
+JL
+tI
+JL
+"}
+(74,1,1) = {"
+LO
+LO
+LO
+JL
+cb
+cb
+cb
+cb
+JL
+xB
+xB
+xB
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+Ai
+UX
+Ig
+jS
+Ai
+pT
+Zm
+LZ
+EP
+YV
+tw
+hv
+KX
+cg
+Zz
+tm
+VI
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+pT
+ar
+pT
+SU
+SU
+SU
+SU
+pT
+pT
+JL
+JL
+JL
+JL
+WO
+JL
+"}
+(75,1,1) = {"
+LO
+LO
+LO
+LO
+JL
+cb
+cb
+JL
+JL
+xB
+xB
+xB
+JL
+JL
+JL
+JL
+uh
+JL
+JL
+JL
+WM
+Ai
+BK
+so
+zv
+Ai
+pT
+Bi
+GX
+Hq
+mG
+lF
+hv
+zJ
+Jl
+oE
+zJ
+WO
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+WO
+eJ
+yB
+eJ
+eJ
+eJ
+WO
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+WO
+WO
+JL
+"}
+(76,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+xB
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+WM
+qK
+UX
+Ig
+jS
+Ai
+pT
+Bi
+yC
+PU
+PE
+zX
+hv
+pT
+pT
+pT
+pT
+XA
+Sh
+Sh
+JL
+aT
+aT
+aT
+JL
+JL
+eA
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+Jp
+JL
+"}
+(77,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+WO
+bq
+Ai
+Ai
+Ai
+SO
+WO
+hv
+za
+za
+za
+hv
+hv
+pT
+pT
+pT
+pT
+nx
+Sh
+uw
+aT
+FK
+aT
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+JL
+JL
+LO
+"}
+(78,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+Dg
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+JL
+Of
+JL
+JL
+pT
+pT
+JL
+JL
+JL
+pT
+Sh
+XA
+Kz
+JL
+aT
+aT
+aT
+JL
+JL
+JL
+JL
+JL
+uh
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(79,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+JL
+WO
+eJ
+uI
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+WO
+Sh
+aT
+aT
+JL
+FU
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}
+(80,1,1) = {"
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+JL
+JL
+JL
+Dz
+aT
+aT
+JL
+JL
+JL
+LO
+LO
+LO
+LO
+JL
+JL
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+LO
+"}

--- a/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_trainyard.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_trainyard.dmm
@@ -18,7 +18,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "af" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -33,10 +33,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ak" = (
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "al" = (
 /obj/effect/radiation,
 /obj/effect/decal/cleanable/greenglow,
@@ -50,7 +50,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "am" = (
 /obj/structure/chair/bench/grey/directional/north,
 /turf/open/floor/concrete/slab_4{
@@ -72,11 +72,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ao" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ap" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -84,7 +84,7 @@
 	id = "tr_sh_st"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "ar" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/concrete/whitesands/lit,
@@ -100,7 +100,7 @@
 	},
 /obj/effect/turf_decal/borderfloorblack/corner,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "az" = (
 /obj/structure/railing{
 	dir = 9
@@ -134,7 +134,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "aK" = (
 /obj/structure/railing{
 	dir = 10
@@ -176,7 +176,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "aP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -191,7 +191,7 @@
 /turf/open/floor/plasteel/stairs/stairs_pack/right{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "aS" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -247,11 +247,11 @@
 	dir = 4
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ba" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "bb" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/cable{
@@ -267,14 +267,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "bg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	id = "tr_sh_wes"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "bj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/slug,
@@ -285,10 +285,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "bm" = (
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "bq" = (
 /obj/structure/frame,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -301,7 +301,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "bz" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable{
@@ -343,7 +343,7 @@
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "bK" = (
 /obj/item/mine/directional/claymore/live{
 	dir = 4
@@ -360,7 +360,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "bO" = (
 /obj/structure/railing{
 	dir = 6
@@ -376,14 +376,14 @@
 "bV" = (
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "bX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "cb" = (
 /turf/open/water/whitesands,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -391,7 +391,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/slug/buck,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ce" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "mining"
@@ -402,7 +402,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "cf" = (
 /obj/structure/fence{
 	dir = 2
@@ -422,19 +422,19 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "cm" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "cn" = (
 /obj/machinery/computer/security{
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "cq" = (
 /obj/structure/platform/military{
 	dir = 1
@@ -453,7 +453,7 @@
 "cE" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "cM" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 8
@@ -489,7 +489,7 @@
 	id = "Tr_sh_tr"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "cW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -503,7 +503,7 @@
 	id = "tr_wd_main"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "dd" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -526,7 +526,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "dm" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -538,7 +538,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "dp" = (
 /obj/structure/girder,
 /turf/open/floor/plating/whitesands/lit,
@@ -550,11 +550,11 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "ds" = (
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "du" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -584,7 +584,7 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "dB" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/mid{
 	dir = 1;
@@ -596,12 +596,12 @@
 /obj/machinery/fax/ruin,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "dI" = (
 /obj/machinery/pipedispenser,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "dJ" = (
 /obj/structure/table,
 /obj/item/storage/box/ammo/c9mm{
@@ -620,7 +620,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "dT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -647,7 +647,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ec" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
@@ -660,7 +660,7 @@
 	pixel_x = -6
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ej" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -717,18 +717,18 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2{
 	dir = 10
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "es" = (
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "et" = (
 /obj/structure/sign/warning/radiation{
 	pixel_x = 32
@@ -738,7 +738,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "eu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -748,7 +748,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ev" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4
@@ -758,7 +758,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "eA" = (
 /obj/structure/flora/ash/leaf_shroom,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -778,10 +778,10 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "eG" = (
 /turf/closed/wall/r_wall,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/cargo)
 "eJ" = (
 /obj/structure/fence,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -797,7 +797,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "eO" = (
 /obj/structure/railing{
 	dir = 1
@@ -814,7 +814,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "eV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -823,7 +823,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "eW" = (
 /obj/structure/railing{
 	dir = 8
@@ -842,7 +842,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "fa" = (
 /obj/item/ammo_casing/spent/slug/buck,
 /turf/open/floor/concrete/whitesands/lit,
@@ -850,7 +850,7 @@
 "fb" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "fc" = (
 /obj/structure/railing{
 	dir = 8
@@ -862,7 +862,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "fh" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/corpse/ramzi,
@@ -870,13 +870,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "fk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "fl" = (
 /obj/item/stack/ore/salvage/scrapmetal{
 	pixel_x = -10;
@@ -897,7 +897,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "fn" = (
 /obj/item/ammo_casing/spent/pistol_steel,
 /obj/effect/decal/cleanable/dirt,
@@ -915,7 +915,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "fo" = (
 /obj/machinery/computer/monitor{
 	dir = 4;
@@ -927,7 +927,7 @@
 	id = "Tr_sh_tr"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "fr" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 8
@@ -950,14 +950,14 @@
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "fw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/borderfloorblack/full,
 /obj/effect/spawner/random/entertainment/money_small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "fx" = (
 /obj/structure/closet/wall{
 	pixel_y = -25
@@ -995,7 +995,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "fy" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/concrete/whitesands/lit,
@@ -1023,7 +1023,7 @@
 /obj/structure/reagent_dispensers/foamtank,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "fN" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -1032,7 +1032,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "fR" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_y = 9;
@@ -1048,7 +1048,7 @@
 	},
 /obj/structure/closet/wall/directional/north,
 /turf/open/floor/plastic,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "fS" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "gibdown1"
@@ -1067,18 +1067,18 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "fV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "fX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mine/proximity/spawner/manhack/live,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "ge" = (
 /obj/structure/filingcabinet/double/grey{
 	dir = 1
@@ -1087,7 +1087,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "gf" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/old{
@@ -1100,7 +1100,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "gg" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "mining"
@@ -1113,7 +1113,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "gi" = (
 /obj/structure/fans/tiny/invisible,
 /obj/machinery/door/poddoor/preopen{
@@ -1124,7 +1124,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "gm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack/full,
@@ -1138,7 +1138,7 @@
 	dir = 8
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "go" = (
 /turf/open/floor/concrete/slab_3{
 	light_power = 0.6;
@@ -1154,7 +1154,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "gr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -1162,7 +1162,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "gs" = (
 /obj/structure/railing/thin{
 	dir = 8
@@ -1191,7 +1191,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "gD" = (
 /obj/structure/rack,
 /obj/item/gun_maint_kit/small{
@@ -1200,7 +1200,7 @@
 	},
 /obj/item/gun_maint_kit/small,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "gF" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -1238,7 +1238,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "gU" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -1270,7 +1270,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ha" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/pistol_steel,
@@ -1278,7 +1278,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "hd" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_x = 7
@@ -1321,7 +1321,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "hm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1353,18 +1353,18 @@
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/head/hardhat/ramzi,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "hs" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "ht" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "hv" = (
 /turf/closed/wall/rust,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "hw" = (
 /obj/structure/platform/industrial/corner{
 	dir = 1;
@@ -1385,7 +1385,7 @@
 "hC" = (
 /mob/living/simple_animal/hostile/human/frontier/internals,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -1393,7 +1393,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "hF" = (
 /turf/open/floor/plating/rust{
 	initial_gas_mix = "SANDPLANET_ATMOS"
@@ -1403,11 +1403,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "hM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "hU" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -1433,7 +1433,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ia" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1469,7 +1469,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ig" = (
 /turf/open/floor/concrete/reinforced/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -1478,7 +1478,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 6
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "il" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 4
@@ -1491,7 +1491,7 @@
 	desc = "Some kind of machine backup."
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "iq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1527,7 +1527,7 @@
 /obj/item/food/meat/slab/human,
 /obj/item/food/meat/slab/human,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "iu" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -1547,7 +1547,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "iw" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/machinery/light/broken/directional/north,
@@ -1561,7 +1561,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "iD" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -1584,7 +1584,7 @@
 	dir = 9
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "iG" = (
 /obj/structure/platform/industrial{
 	density = 0
@@ -1622,7 +1622,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "iM" = (
 /obj/structure/railing{
 	dir = 1
@@ -1632,7 +1632,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "iN" = (
 /turf/open/floor/plating/asteroid/whitesands/lit,
 /area/space)
@@ -1662,7 +1662,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "iR" = (
 /obj/item/storage/box/emptysandbags{
 	pixel_x = -5;
@@ -1677,7 +1677,7 @@
 	},
 /obj/structure/rack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "iS" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "gib3";
@@ -1717,7 +1717,7 @@
 	req_access = null
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "je" = (
 /obj/structure/platform{
 	dir = 1;
@@ -1753,7 +1753,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "jt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1773,7 +1773,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "jx" = (
 /obj/item/target,
 /obj/structure/railing/thin{
@@ -1802,12 +1802,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "jH" = (
 /obj/structure/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "jK" = (
 /obj/structure/salvageable/computer{
 	dir = 4
@@ -1816,7 +1816,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "jL" = (
 /obj/structure/rack,
 /obj/item/storage/box/flares{
@@ -1827,7 +1827,7 @@
 	pixel_x = 3
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "jM" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/syndicate/white_red,
@@ -1839,13 +1839,13 @@
 "jQ" = (
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "jR" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "jS" = (
 /obj/structure/platform/industrial{
 	density = 0
@@ -1884,15 +1884,15 @@
 	pixel_x = 7
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "kb" = (
 /turf/closed/indestructible/reinforced/rust,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "kd" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "ke" = (
 /obj/structure/railing/thin{
 	dir = 4
@@ -1910,7 +1910,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "kn" = (
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 1
@@ -1920,7 +1920,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "kp" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -1955,7 +1955,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "kt" = (
 /obj/structure/flora/ash/cap_shroom,
 /turf/open/floor/plating/asteroid/whitesands/dried{
@@ -1985,7 +1985,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "kx" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/asteroid/whitesands/dried{
@@ -2030,7 +2030,7 @@
 	},
 /obj/structure/closet/crate/eva,
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "kJ" = (
 /obj/item/flashlight/flare/burnt,
 /turf/open/floor/plating{
@@ -2045,7 +2045,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "kP" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -2054,7 +2054,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "kQ" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 9
@@ -2078,11 +2078,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "kU" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "kW" = (
 /obj/structure/fence{
 	dir = 8
@@ -2103,7 +2103,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "lc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2144,7 +2144,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "lt" = (
 /obj/effect/mob_spawn/human/corpse/frontier/internals,
 /obj/effect/gibspawner/human/bodypartless,
@@ -2158,14 +2158,14 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "lu" = (
 /obj/effect/spawner/random/vending/cola,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 8
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "lv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/east{
@@ -2175,7 +2175,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "lz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/pistol_steel,
@@ -2192,7 +2192,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "lA" = (
 /obj/machinery/suit_storage_unit/inherit/industrial,
 /obj/item/tank/internals/oxygen/yellow,
@@ -2201,16 +2201,16 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 9
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "lF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "lG" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "lH" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "floor2"
@@ -2284,7 +2284,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "lV" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "eng_secure"
@@ -2304,7 +2304,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 10
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "lW" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -2317,7 +2317,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "lZ" = (
 /obj/item/target,
 /turf/open/floor/concrete/whitesands/lit,
@@ -2373,14 +2373,14 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "md" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "tr_wd_main"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "mf" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -2403,7 +2403,7 @@
 	id = "tr_sh_holo"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "mk" = (
 /obj/structure/closet/secure_closet,
 /obj/effect/turf_decal/borderfloorblack/corner{
@@ -2417,13 +2417,13 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "mq" = (
 /obj/structure/chair/bench/grey/directional/south,
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "mr" = (
 /obj/structure/chair{
 	dir = 8
@@ -2431,14 +2431,14 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "mx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "mz" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -2447,11 +2447,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "mC" = (
 /obj/machinery/power/rtg,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "mD" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/structure/poddoor_assembly,
@@ -2465,14 +2465,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "mG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "mK" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 6
@@ -2491,7 +2491,7 @@
 /obj/structure/chair/sofa/grey/directional/north,
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "na" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -2500,7 +2500,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "nb" = (
 /obj/item/cigbutt{
 	pixel_y = 13;
@@ -2514,7 +2514,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "nd" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2571,7 +2571,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "nk" = (
 /obj/structure/railing/corner,
 /obj/machinery/light/floor/hangar,
@@ -2593,7 +2593,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ns" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -2610,7 +2610,7 @@
 /obj/item/toy/plush/carpplushie/ice,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "nx" = (
 /obj/structure/fence/door{
 	dir = 2
@@ -2632,7 +2632,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "nC" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/effect/decal/cleanable/greenglow,
@@ -2643,7 +2643,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "nE" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4,
 /turf/open/floor/concrete/slab_1{
@@ -2674,7 +2674,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "nI" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -2703,7 +2703,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "nS" = (
 /obj/item/cigbutt{
 	pixel_y = 15;
@@ -2723,7 +2723,7 @@
 /obj/effect/mob_spawn/human/corpse/ramzi,
 /obj/item/melee/knife/combat,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "nV" = (
 /obj/structure/railing{
 	dir = 1
@@ -2749,7 +2749,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "ol" = (
 /obj/structure/platform/industrial_alt,
 /obj/structure/railing,
@@ -2765,14 +2765,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "oo" = (
 /obj/item/ammo_casing/spent/rifle_brass,
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "oq" = (
 /obj/item/ammo_casing/spent/slug/buck,
 /obj/effect/decal/cleanable/dirt,
@@ -2782,7 +2782,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "ot" = (
 /obj/structure/closet/body_bag,
 /obj/structure/cable{
@@ -2792,7 +2792,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mob_spawn/human/corpse/ramzi/space,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -2806,7 +2806,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ow" = (
 /obj/effect/turf_decal/borderfloorblack,
 /obj/effect/decal/cleanable/blood/splatter/over_window{
@@ -2818,11 +2818,11 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ox" = (
 /obj/item/ammo_casing/spent/pistol_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "oE" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/left{
 	dir = 8;
@@ -2846,7 +2846,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "oP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack{
@@ -2861,7 +2861,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "oS" = (
 /obj/effect/turf_decal/syndicateemblem/top/right{
 	dir = 4
@@ -2879,14 +2879,14 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "oU" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "oX" = (
 /obj/item/cigbutt{
 	pixel_y = 13
@@ -2906,7 +2906,7 @@
 	faction = list("Frontiersmen","turret")
 	},
 /turf/closed/indestructible/plastitanium,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "pd" = (
 /obj/structure/sign/warning/radiation{
 	pixel_x = 32
@@ -2916,7 +2916,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "pe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/concrete/reinforced/whitesands/lit,
@@ -2944,7 +2944,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "pj" = (
 /obj/structure/table,
 /obj/item/cutting_board{
@@ -2956,7 +2956,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "pr" = (
 /obj/structure/closet/secure_closet,
 /obj/item/storage/toolbox/syndicate/empty{
@@ -2969,13 +2969,13 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "pt" = (
 /obj/structure/closet/crate/large,
 /obj/item/melee/sword/mass,
 /obj/item/melee/sword/mass,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "pu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2983,7 +2983,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "pB" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs{
@@ -2997,7 +2997,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "pC" = (
 /obj/structure/table_frame,
 /obj/item/stack/ore/salvage/scrapmetal{
@@ -3022,7 +3022,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "pE" = (
 /obj/structure/railing/thin{
 	dir = 8
@@ -3035,7 +3035,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "pM" = (
 /obj/structure/rack,
 /obj/item/stock_parts/capacitor{
@@ -3055,7 +3055,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "pO" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -3071,7 +3071,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "pR" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/shreds,
@@ -3095,7 +3095,7 @@
 	},
 /obj/structure/chair/handrail,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "pY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack{
@@ -3111,7 +3111,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "pZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3142,7 +3142,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "qg" = (
 /obj/structure/chair/bench/grey/directional/south,
 /turf/open/floor/concrete/slab_4{
@@ -3166,7 +3166,7 @@
 	pixel_x = 12
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "qn" = (
 /obj/structure/railing{
 	dir = 10;
@@ -3192,14 +3192,14 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 6
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "qt" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/left,
 /area/overmap_encounter/planetoid/sand/explored)
 "qu" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "qv" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -3221,7 +3221,7 @@
 	},
 /obj/item/book/manual/wiki/hacking,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "qD" = (
 /obj/structure/railing{
 	dir = 9
@@ -3231,7 +3231,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "qE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3248,7 +3248,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "qI" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/ammo_casing/spent/pistol_steel,
@@ -3266,7 +3266,7 @@
 "qJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "qK" = (
 /obj/item/stack/ore/salvage/scrapbluespace,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -3278,7 +3278,7 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "qW" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -3306,7 +3306,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "rc" = (
 /obj/machinery/computer/security{
 	dir = 4;
@@ -3314,15 +3314,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "rf" = (
 /obj/structure/salvageable/computer,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "rj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "rn" = (
 /obj/item/ammo_casing/spent/rifle_brass,
 /turf/open/floor/concrete/slab_4{
@@ -3345,7 +3345,7 @@
 /obj/effect/turf_decal/borderfloorblack/full,
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "rr" = (
 /obj/structure/railing{
 	dir = 6
@@ -3361,7 +3361,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ry" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3387,7 +3387,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "rF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -3399,7 +3399,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "rI" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -3429,11 +3429,11 @@
 	},
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "rM" = (
 /obj/effect/turf_decal/industrial/warning,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "rR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash{
@@ -3449,7 +3449,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "rS" = (
 /obj/effect/decal/cleanable/ash{
 	pixel_y = 1
@@ -3457,7 +3457,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "rX" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -3483,7 +3483,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "sj" = (
 /obj/structure/railing,
 /turf/open/floor/plasteel/stairs/stairs_pack{
@@ -3494,7 +3494,7 @@
 "sn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "so" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -3514,7 +3514,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "st" = (
 /obj/item/ammo_casing/spent/rifle_brass,
 /obj/effect/decal/cleanable/dirt,
@@ -3538,7 +3538,7 @@
 	},
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "sF" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -3551,7 +3551,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "sK" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -3579,7 +3579,7 @@
 	dir = 4
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "sR" = (
 /obj/structure/girder,
 /obj/structure/barricade/wooden,
@@ -3601,7 +3601,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "sY" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/right,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -3613,13 +3613,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ta" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "ti" = (
 /obj/structure/catwalk,
 /turf/open/floor/plating/whitesands,
@@ -3652,7 +3652,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "to" = (
 /obj/structure/railing{
 	dir = 8
@@ -3668,7 +3668,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "tr" = (
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "ts" = (
 /obj/item/ammo_casing/spent/pistol_brass,
 /turf/open/floor/concrete/whitesands/lit,
@@ -3676,7 +3676,7 @@
 "tu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "tw" = (
 /obj/structure/filingcabinet/double/grey{
 	dir = 1
@@ -3689,21 +3689,21 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "tz" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "tE" = (
 /obj/machinery/vending/snack/teal,
 /obj/effect/turf_decal/borderfloorblack/corner,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 9
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "tI" = (
 /obj/structure/fence{
 	dir = 8
@@ -3728,11 +3728,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "tN" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "tO" = (
 /obj/item/stack/rods,
 /turf/open/floor/concrete/reinforced/whitesands/lit,
@@ -3748,7 +3748,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "tR" = (
 /obj/structure/chair/e_chair{
 	dir = 8
@@ -3762,7 +3762,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "tU" = (
 /obj/item/ammo_casing/spent/pistol_steel,
 /obj/effect/decal/cleanable/dirt,
@@ -3775,13 +3775,13 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "tW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3799,7 +3799,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ua" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/maintenance/seven,
@@ -3826,24 +3826,24 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "un" = (
 /obj/structure/chair/sofa/red/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "uo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "up" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "uu" = (
 /obj/structure/platform{
 	dir = 4;
@@ -3938,7 +3938,7 @@
 	pixel_y = 73
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "uT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -3946,7 +3946,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "uU" = (
 /obj/item/stack/sheet/mineral/uranium/twenty,
 /obj/item/storage/firstaid/radiation,
@@ -3961,7 +3961,7 @@
 	name = "closet"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "uV" = (
 /obj/structure/chair/bench/grey/directional/south,
 /turf/open/floor/concrete/slab_1{
@@ -3979,7 +3979,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "vd" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -3991,18 +3991,18 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ve" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "vf" = (
 /obj/machinery/door/poddoor/shutters,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "vg" = (
 /obj/structure/closet/body_bag,
 /turf/open/floor/concrete/reinforced/whitesands/lit,
@@ -4020,7 +4020,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "vl" = (
 /obj/structure/chair/handrail{
 	dir = 8
@@ -4042,7 +4042,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "vn" = (
 /obj/structure/flora/ash,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -4055,7 +4055,7 @@
 	pixel_x = 3
 	},
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "vv" = (
 /obj/structure/closet/body_bag,
 /obj/effect/mob_spawn/human/corpse/ramzi,
@@ -4075,13 +4075,13 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "vz" = (
 /obj/item/ammo_casing/spent/slug/buck,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "vB" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -4107,7 +4107,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/thin{
@@ -4128,7 +4128,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plastic,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "vN" = (
 /obj/structure/crate_shelf,
 /obj/structure/closet/crate/medical,
@@ -4144,7 +4144,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "vP" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -4154,11 +4154,11 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "vQ" = (
 /obj/structure/catwalk,
 /turf/open/floor/plating/whitesands,
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "vT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -4166,7 +4166,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "vW" = (
 /obj/structure/salvageable/circuit_imprinter,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -4183,13 +4183,13 @@
 /obj/item/clothing/under/costume/jabroni,
 /obj/item/clothing/head/warden,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "vY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "vZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -4199,7 +4199,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "wb" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -4217,7 +4217,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "wm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark{
@@ -4238,7 +4238,7 @@
 	},
 /mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -4252,14 +4252,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wu" = (
 /obj/structure/chair/sofa/red/right/directional/south,
 /obj/structure/sign/poster/contraband/steppyflag{
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wv" = (
 /obj/effect/spawner/random/vending/snack,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
@@ -4267,11 +4267,11 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wx" = (
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "wy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "tr_ar_main"
@@ -4281,7 +4281,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -4292,7 +4292,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "wA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4316,14 +4316,14 @@
 	},
 /obj/item/gun/ballistic/automatic/pistol/rattlesnake/no_mag,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "wI" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4349,7 +4349,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "wS" = (
 /obj/machinery/power/rtg,
 /obj/structure/cable/yellow{
@@ -4357,7 +4357,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "wT" = (
 /obj/machinery/door/airlock/multi_tile/security/v,
 /obj/structure/fans/tiny,
@@ -4371,7 +4371,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "wU" = (
 /obj/structure/railing,
 /turf/open/floor/concrete/slab_3,
@@ -4390,7 +4390,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "xb" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/right{
 	dir = 4;
@@ -4404,7 +4404,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "xl" = (
 /turf/open/floor/concrete/slab_1,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -4429,7 +4429,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "xy" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -4463,7 +4463,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "xM" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -4516,13 +4516,13 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "xZ" = (
 /obj/structure/salvageable/computer{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ya" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -4571,7 +4571,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "yf" = (
 /obj/item/storage/box/ammo/a300{
 	pixel_y = 3
@@ -4587,7 +4587,7 @@
 	},
 /obj/structure/closet/crate/secure/weapon,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "yg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/pistol_steel,
@@ -4595,7 +4595,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "yh" = (
 /obj/structure/closet/wall/orange/directional/south{
 	name = "closet"
@@ -4607,7 +4607,7 @@
 /obj/item/stack/sheet/metal/twenty,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "yi" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
@@ -4615,11 +4615,11 @@
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /obj/item/cigbutt,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "yk" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "ym" = (
 /obj/structure/rack,
 /obj/item/stock_parts/cell/super/empty{
@@ -4634,13 +4634,13 @@
 	pixel_x = -3
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "yo" = (
 /obj/effect/spawner/bunk_bed,
 /obj/structure/curtain/cloth/grey,
 /obj/machinery/light/directional/south,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ys" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -4649,7 +4649,7 @@
 	dir = 4
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "yt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall/orange/directional/north{
@@ -4674,7 +4674,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "yu" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/smg{
@@ -4684,7 +4684,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "yw" = (
 /obj/machinery/fax/ruin,
 /obj/structure/table/reinforced,
@@ -4692,7 +4692,7 @@
 	pixel_x = 31
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "yx" = (
 /turf/open/floor/plasteel/stairs/stairs_pack{
 	dir = 8;
@@ -4712,7 +4712,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "yA" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -4729,7 +4729,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "yB" = (
 /obj/structure/fence/cut/medium,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -4739,7 +4739,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "yD" = (
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/heavymetal{
@@ -4782,7 +4782,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "yO" = (
 /obj/item/ammo_casing/spent/rifle_brass,
 /turf/open/floor/concrete/whitesands/lit,
@@ -4793,7 +4793,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 5
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "yS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -4801,7 +4801,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "yV" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4818,7 +4818,7 @@
 	id = "tr_sh_et"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "ze" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4840,7 +4840,7 @@
 /obj/item/folder/yellow,
 /obj/item/folder/blue,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "zg" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -4889,11 +4889,11 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "zC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "zD" = (
 /obj/structure/platform/industrial_alt{
 	dir = 10
@@ -4942,14 +4942,14 @@
 	},
 /obj/effect/mob_spawn/human/corpse/ramzi/space,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "zP" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "zV" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4986,7 +4986,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Aa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/pistol_steel,
@@ -4998,7 +4998,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ad" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -5033,7 +5033,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ai" = (
 /turf/open/floor/concrete/pavement/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -5044,7 +5044,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ak" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable{
@@ -5055,14 +5055,14 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Am" = (
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
 /obj/item/clothing/mask/gas/ramzi,
 /obj/item/tank/internals/oxygen,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ar" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/slug,
@@ -5075,7 +5075,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Au" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -5089,7 +5089,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Aw" = (
 /obj/structure/chair/sofa/grey/right/directional/east,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -5100,7 +5100,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "AB" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -5149,7 +5149,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "AF" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -5159,7 +5159,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "AI" = (
 /obj/structure/chair/sofa/grey/left/directional/south,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -5170,7 +5170,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "AR" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_y = 16
@@ -5208,7 +5208,7 @@
 	id = "tr_sh_wes"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "AZ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -5228,13 +5228,13 @@
 	pixel_x = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Bc" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Be" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -5266,14 +5266,14 @@
 /obj/structure/closet/crate/large,
 /obj/item/kinetic_crusher/syndie_crusher,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Bi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "tr_sh_et"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Bk" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -5297,7 +5297,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Br" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -5309,20 +5309,20 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "By" = (
 /obj/structure/sign/poster/tg/tg_5{
 	pixel_x = 36;
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "BB" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "BC" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/twenty{
@@ -5339,7 +5339,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "BF" = (
 /obj/effect/turf_decal/borderfloorblack,
 /obj/structure/cable{
@@ -5348,7 +5348,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "BK" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -5367,7 +5367,7 @@
 /obj/item/ammo_casing/spent/rifle_brass,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "BM" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
@@ -5375,7 +5375,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "BN" = (
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
 /obj/effect/decal/cleanable/dirt,
@@ -5385,7 +5385,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "BP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
@@ -5396,7 +5396,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "BR" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "floor4"
@@ -5408,10 +5408,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "BS" = (
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "BU" = (
 /obj/structure/fence{
 	dir = 4
@@ -5430,7 +5430,7 @@
 "BZ" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ca" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4
@@ -5454,12 +5454,12 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/cargo)
 "Cc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Cg" = (
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plating/rust{
@@ -5474,7 +5474,7 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Cn" = (
 /obj/structure/platform/industrial/corner{
 	dir = 1;
@@ -5490,13 +5490,13 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Cr" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Cs" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/cas/black{
@@ -5505,7 +5505,7 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Cz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5562,7 +5562,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "CN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/rifle_brass,
@@ -5573,7 +5573,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "CR" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -5613,7 +5613,7 @@
 /obj/structure/table,
 /obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Dc" = (
 /obj/machinery/power/rtg,
 /obj/structure/cable/yellow{
@@ -5622,14 +5622,14 @@
 /obj/structure/window/reinforced,
 /obj/machinery/light/small/broken/directional/west,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Dd" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Dg" = (
 /obj/structure/flora/ash/puce,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -5661,7 +5661,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Dq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer/light{
@@ -5677,7 +5677,7 @@
 "Dy" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "Dz" = (
 /obj/structure/flora/ash,
 /turf/open/floor/plating/asteroid/whitesands/dried{
@@ -5703,7 +5703,7 @@
 "DC" = (
 /obj/structure/salvageable/computer,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "DH" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -5756,7 +5756,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "DR" = (
 /obj/structure/railing,
 /turf/open/floor/concrete/slab_4{
@@ -5769,7 +5769,7 @@
 /obj/structure/closet/crate/medical,
 /obj/effect/spawner/random/medical/medkit,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "DT" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "gib3";
@@ -5792,11 +5792,11 @@
 /obj/effect/turf_decal/borderfloorblack,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "DX" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "DY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5825,7 +5825,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Eb" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -5854,7 +5854,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ee" = (
 /obj/effect/turf_decal/borderfloorblack/full,
 /obj/structure/cable{
@@ -5880,7 +5880,7 @@
 "Ek" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "El" = (
 /obj/structure/fluff/paper/stack{
 	pixel_y = -5;
@@ -5897,7 +5897,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Em" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -5906,12 +5906,12 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Eo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack/full,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Er" = (
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
@@ -5924,7 +5924,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ey" = (
 /turf/open/floor/concrete/slab_1{
 	light_power = 0.6;
@@ -5943,7 +5943,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "EA" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 1
@@ -5963,14 +5963,14 @@
 	anchored = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "EH" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/sign/poster/retro/smile{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "EI" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
@@ -5978,7 +5978,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "EJ" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating{
@@ -5993,7 +5993,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "EP" = (
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "EQ" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -6004,7 +6004,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ER" = (
 /obj/structure/filingcabinet/double/grey,
 /obj/item/folder,
@@ -6013,7 +6013,7 @@
 /obj/item/clipboard,
 /obj/item/pen/blue,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "ES" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -6025,7 +6025,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "EU" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -6037,7 +6037,7 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "EW" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
@@ -6050,7 +6050,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "EZ" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -6077,14 +6077,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/pistol_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Fg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Fh" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -6112,14 +6112,14 @@
 	id = "Tr_sh_h1"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "Fk" = (
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Fn" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6147,7 +6147,7 @@
 	dir = 4
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Fp" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 6
@@ -6156,7 +6156,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "Fs" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Fv" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2";
@@ -6174,7 +6174,7 @@
 	id = "Tr_en_tr"
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "Fx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/double,
@@ -6183,10 +6183,10 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "FI" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "FK" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/whitesands/dried{
@@ -6201,7 +6201,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "FM" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -6222,17 +6222,17 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrowncorners{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "FQ" = (
 /obj/machinery/power/rtg,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "FS" = (
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "FT" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plasteel/dark{
@@ -6246,7 +6246,7 @@
 "FW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Gc" = (
 /obj/structure/chair{
 	dir = 1
@@ -6255,11 +6255,11 @@
 	pixel_x = -31
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Gd" = (
 /obj/structure/chair/sofa/red/corner/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ge" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6273,7 +6273,7 @@
 /turf/open/floor/plating{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "Gf" = (
 /obj/structure/table,
 /obj/item/storage/guncase/vector{
@@ -6305,7 +6305,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Gt" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 9
@@ -6324,7 +6324,7 @@
 	},
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Gx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner,
@@ -6335,7 +6335,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Gy" = (
 /obj/structure/platform{
 	dir = 8;
@@ -6364,7 +6364,7 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "GH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -6380,7 +6380,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "GI" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6410,12 +6410,12 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "GK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "GM" = (
 /obj/effect/turf_decal/road/stripes{
 	dir = 1
@@ -6434,7 +6434,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "GS" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/latex{
@@ -6452,7 +6452,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "GT" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 1
@@ -6468,10 +6468,10 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "GW" = (
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "GX" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/old{
@@ -6484,7 +6484,7 @@
 	pixel_x = 15
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "GY" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -6505,7 +6505,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Hb" = (
 /obj/structure/closet/crate/bin{
 	pixel_y = 18
@@ -6548,7 +6548,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Hk" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -6565,7 +6565,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Hn" = (
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -6578,13 +6578,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Hq" = (
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Hr" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -6610,7 +6610,7 @@
 	id = "tr_sh_wes"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Hz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -6622,7 +6622,7 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "HC" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/left{
 	initial_gas_mix = "SANDPLANET_ATMOS"
@@ -6654,7 +6654,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "HF" = (
 /obj/item/stack/ore/salvage/scrapmetal{
 	pixel_x = -9;
@@ -6672,7 +6672,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "HH" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /obj/item/ammo_casing/spent/slug/buck,
@@ -6686,7 +6686,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "HK" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/mid{
 	dir = 8
@@ -6707,14 +6707,14 @@
 	dir = 9
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "HR" = (
 /obj/machinery/door/poddoor/cannothit{
 	dir = 4;
 	id = "Tr_en_tr"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "HS" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -6726,11 +6726,11 @@
 	pixel_x = -10
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "HT" = (
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
 /turf/open/floor/plastic,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "HU" = (
 /obj/structure/railing{
 	dir = 1
@@ -6743,7 +6743,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ib" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6755,20 +6755,20 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Ic" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Id" = (
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "If" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Ig" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -6788,15 +6788,15 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ij" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ik" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Is" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -6804,7 +6804,7 @@
 /obj/item/cigbutt/cigarbutt,
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "It" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_y = 16
@@ -6818,7 +6818,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Iu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/corner/opaque/syndiered{
@@ -6839,7 +6839,7 @@
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Iz" = (
 /obj/item/ammo_casing/spent/slug,
 /turf/open/floor/concrete/whitesands/lit,
@@ -6874,7 +6874,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "II" = (
 /obj/item/ammo_casing/spent/slug,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
@@ -6884,7 +6884,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "IJ" = (
 /turf/closed/wall/concrete/reinforced,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -6894,7 +6894,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "IO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6953,7 +6953,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 4
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "IU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6967,7 +6967,7 @@
 /obj/structure/salvageable/machine,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "IW" = (
 /turf/open/floor/concrete/slab_1{
 	light_power = 0.6;
@@ -6981,7 +6981,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Jc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/concrete/slab_1{
@@ -7014,7 +7014,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Jj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -7031,7 +7031,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Jl" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/right{
 	dir = 8;
@@ -7045,7 +7045,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Jo" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -7068,7 +7068,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Jr" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -7080,7 +7080,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Ju" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack{
@@ -7090,12 +7090,12 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Jv" = (
 /obj/structure/salvageable/server,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Jw" = (
 /obj/structure/closet{
 	icon_state = "syndicate";
@@ -7118,11 +7118,11 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Jy" = (
 /obj/structure/salvageable/server,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "JA" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -7143,10 +7143,10 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "JF" = (
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "JG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7179,7 +7179,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "JL" = (
 /turf/open/floor/plating/asteroid/whitesands/lit,
 /area/overmap_encounter/planetoid/sand/explored)
@@ -7193,7 +7193,7 @@
 	dir = 10
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "JP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -7202,7 +7202,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "JT" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /obj/effect/gibspawner/human/bodypartless,
@@ -7210,7 +7210,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "JW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
@@ -7220,14 +7220,14 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "JY" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered/corner{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "JZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -7237,7 +7237,7 @@
 	pixel_y = 13
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ka" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10;
@@ -7247,7 +7247,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Kc" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 1
@@ -7308,7 +7308,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Kz" = (
 /obj/structure/flora/ash/fern,
 /turf/open/floor/plating/asteroid/whitesands/grass/lit,
@@ -7319,7 +7319,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "KE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -7333,7 +7333,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "KK" = (
 /obj/structure/chair/handrail{
 	dir = 4
@@ -7347,7 +7347,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "KO" = (
 /obj/machinery/door/keycard{
 	puzzle_id = "Trainyard"
@@ -7358,7 +7358,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "KP" = (
 /mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
@@ -7366,7 +7366,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "KS" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -7416,13 +7416,13 @@
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "La" = (
 /obj/effect/turf_decal/techfloor,
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Li" = (
 /obj/structure/railing/thin{
 	dir = 4
@@ -7471,13 +7471,13 @@
 	pixel_x = 9
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Lu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Lv" = (
 /obj/structure/railing{
 	max_integrity = 70;
@@ -7495,7 +7495,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "LB" = (
 /obj/structure/fence{
 	dir = 8
@@ -7512,14 +7512,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "LH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = null
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "LJ" = (
 /obj/structure/closet/crate/large,
 /obj/item/tank/jetpack/oxygen/harness,
@@ -7527,7 +7527,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "LL" = (
 /obj/structure/flora/ash/tall_shroom,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -7556,7 +7556,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "LO" = (
 /turf/template_noop,
 /area/template_noop)
@@ -7565,7 +7565,7 @@
 	empty = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "LU" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -7574,7 +7574,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "LV" = (
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "LX" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window{
 	icon_state = "gibdown1"
@@ -7589,11 +7589,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "LZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Mf" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/twenty{
@@ -7607,7 +7607,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Mh" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -7629,13 +7629,13 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Mn" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Mt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
@@ -7643,7 +7643,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Mv" = (
 /obj/structure/girder,
 /obj/structure/barricade/wooden/crude,
@@ -7672,7 +7672,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/borderfloorblack/corner,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "MB" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -7687,7 +7687,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "MG" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/door{
@@ -7696,7 +7696,7 @@
 	id = "tr_sh_et"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "MI" = (
 /obj/effect/turf_decal/syndicateemblem/middle/right{
 	dir = 4
@@ -7709,7 +7709,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "ML" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/maintenance,
@@ -7724,25 +7724,25 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 10
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "MN" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "MP" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "MQ" = (
 /obj/effect/turf_decal/corner/opaque/syndiered{
 	dir = 5
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "MT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -7759,10 +7759,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "MZ" = (
 /turf/closed/wall/rust,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Nb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7774,7 +7774,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Ni" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow{
@@ -7787,7 +7787,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Nj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -7796,7 +7796,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Nn" = (
 /obj/structure/railing/thin{
 	dir = 9
@@ -7855,7 +7855,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "NJ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/shotgun{
@@ -7868,7 +7868,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "NL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter{
@@ -7887,7 +7887,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "NN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7916,7 +7916,7 @@
 /obj/effect/turf_decal/borderfloorblack/full,
 /obj/effect/spawner/random/entertainment/money_small,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "NQ" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/turf_decal/syndicateemblem/top/left{
@@ -7929,7 +7929,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "NT" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "med";
@@ -7946,7 +7946,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "NU" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7967,19 +7967,19 @@
 	pixel_y = 12
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "NW" = (
 /obj/structure/chair/sofa/grey/left/directional/north,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/darkbrownfull/darkbrown,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "NX" = (
 /obj/machinery/porta_turret/ruin/ramzi/super_heavy{
 	dir = 6;
 	faction = list("Frontiersmen","turret")
 	},
 /turf/closed/indestructible/plastitanium,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "NY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wall/directional/north,
@@ -7988,16 +7988,16 @@
 /obj/item/clipboard,
 /obj/item/clothing/head/hardhat/ramzi,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ob" = (
 /turf/open/floor/plasteel/heavymetal,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Oe" = (
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered{
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Of" = (
 /obj/structure/fence/door{
 	dir = 2
@@ -8017,13 +8017,13 @@
 "Oi" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Oo" = (
 /obj/structure/chair/bench/grey/directional/south,
 /obj/effect/turf_decal/borderfloorblack,
 /obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Os" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/ore/salvage/scrapmetal{
@@ -8032,7 +8032,7 @@
 	},
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ot" = (
 /obj/structure/closet{
 	icon_state = "syndicate";
@@ -8061,7 +8061,7 @@
 	name = "syndicate megaphone"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Ov" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 5
@@ -8079,7 +8079,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Oz" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -8104,12 +8104,12 @@
 	},
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "OL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "OP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
@@ -8120,7 +8120,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "OQ" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset{
@@ -8128,10 +8128,10 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "OR" = (
 /turf/closed/indestructible/plastitanium,
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "OS" = (
 /obj/item/ammo_casing/spent/pistol_steel{
 	name = "spent .45 casing"
@@ -8173,7 +8173,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "OW" = (
 /obj/item/ammo_casing/spent/slug,
 /obj/effect/decal/cleanable/dirt,
@@ -8191,7 +8191,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "OZ" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -8207,7 +8207,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Pc" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -8241,7 +8241,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Pl" = (
 /obj/item/flashlight/flare/burnt,
 /turf/open/floor/plasteel/dark{
@@ -8253,7 +8253,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ps" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
@@ -8262,7 +8262,7 @@
 	maxHealth = 350
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "Pv" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/effect/turf_decal/borderfloorblack{
@@ -8271,7 +8271,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 8
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Pw" = (
 /obj/item/ammo_casing/spent/pistol_steel,
 /obj/effect/turf_decal/borderfloorblack/full,
@@ -8282,7 +8282,7 @@
 	dir = 4
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "PA" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -8299,14 +8299,14 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "PE" = (
 /obj/structure/table/reinforced,
 /obj/item/binoculars{
 	pixel_x = 5
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "PF" = (
 /obj/effect/turf_decal/borderfloorblack/full,
 /turf/open/floor/concrete/slab_1{
@@ -8317,14 +8317,14 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "PL" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "PM" = (
 /obj/structure/filingcabinet/double/grey,
 /obj/item/folder/blue,
 /obj/item/folder/blue,
 /obj/item/folder/blue,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "PQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8347,7 +8347,7 @@
 	pixel_x = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "PV" = (
 /obj/machinery/computer/helm{
 	dir = 8
@@ -8360,7 +8360,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "PY" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8379,7 +8379,7 @@
 	},
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "PZ" = (
 /obj/structure/railing{
 	max_integrity = 70;
@@ -8394,7 +8394,7 @@
 "Qh" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Qk" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_y = 12
@@ -8402,7 +8402,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Qn" = (
 /obj/structure/railing{
 	dir = 1
@@ -8414,7 +8414,7 @@
 /obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Qs" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -8459,7 +8459,7 @@
 	name = "Bathroom"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "QF" = (
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 8
@@ -8481,7 +8481,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/fax/ruin,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "QJ" = (
 /obj/machinery/vending/mining_equipment,
 /obj/effect/turf_decal/borderfloorblack/corner{
@@ -8490,7 +8490,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 5
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "QK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -8499,7 +8499,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "QP" = (
 /obj/structure/railing/corner,
 /turf/open/floor/concrete/slab_3,
@@ -8515,7 +8515,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "QV" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4
@@ -8534,7 +8534,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "QY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/concrete/slab_3{
@@ -8550,7 +8550,7 @@
 	},
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Rh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/spent/slug/buck,
@@ -8558,7 +8558,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Rk" = (
 /obj/item/ammo_casing/spent/rifle_brass,
 /turf/open/floor/concrete/slab_2{
@@ -8572,7 +8572,7 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Rn" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -8607,10 +8607,10 @@
 	dir = 6
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Rr" = (
 /turf/closed/wall/r_wall/rust,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Rs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/syndicateemblem/top/middle{
@@ -8633,14 +8633,14 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Rt" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "Rv" = (
 /obj/item/ammo_casing/spent/rifle_steel,
 /obj/item/reagent_containers/syringe/contraband/mammoth{
@@ -8651,12 +8651,12 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Rz" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "RD" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -8689,7 +8689,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "RR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8710,7 +8710,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "RX" = (
 /mob/living/simple_animal/hostile/human/ramzi/melee/space/stormtrooper/sledge{
 	maxHealth = 500;
@@ -8730,7 +8730,7 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "RY" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/item/stack/ore/salvage/scraptitanium{
@@ -8751,7 +8751,7 @@
 	},
 /obj/effect/turf_decal/borderfloorblack/corner,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Sd" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/sake/wolfgirl{
@@ -8770,12 +8770,12 @@
 	pixel_x = -11
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Se" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2,
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Sf" = (
 /obj/item/cigbutt{
 	pixel_x = 6
@@ -8791,7 +8791,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Sj" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -8819,12 +8819,12 @@
 	pixel_x = -4
 	},
 /turf/open/floor/plastic,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Sx" = (
 /obj/structure/chair/sofa/red/left/directional/west,
 /mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Sy" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -8839,7 +8839,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Sz" = (
 /obj/item/stack/ore/salvage/scrapmetal{
 	pixel_x = 3;
@@ -8854,14 +8854,14 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "SB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fluff/paper/stack{
 	dir = 9
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "SH" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -8872,7 +8872,7 @@
 	pixel_x = -1
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "SJ" = (
 /obj/structure/railing{
 	dir = 8
@@ -8892,7 +8892,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "SL" = (
 /obj/structure/noticeboard{
 	dir = 4;
@@ -8903,7 +8903,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "SN" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/door{
@@ -8914,7 +8914,7 @@
 	name = "Cargoway Shutters"
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "SO" = (
 /obj/structure/salvageable/machine,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -8949,7 +8949,7 @@
 	id = "Carriage_Tr_6"
 	},
 /turf/open/floor/suns/dark/plain,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "SU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/concrete/whitesands/lit,
@@ -8961,11 +8961,11 @@
 	},
 /obj/effect/turf_decal/spline/fancy/opaque/syndiered,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Te" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Tg" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -8983,7 +8983,7 @@
 /obj/effect/spawner/bunk_bed,
 /obj/structure/curtain/cloth/grey,
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Tk" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/structure/cable/yellow,
@@ -8995,7 +8995,7 @@
 	id = "tr_sh_eng"
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Tv" = (
 /obj/effect/decal/cleanable/blood/drip{
 	pixel_y = 9
@@ -9003,7 +9003,7 @@
 /obj/effect/turf_decal/borderfloorblack/full,
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Tx" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -9050,7 +9050,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "TN" = (
 /obj/item/ammo_casing/spent/pistol_steel{
 	name = "spent .45 casing"
@@ -9119,7 +9119,7 @@
 	},
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "TW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9151,7 +9151,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "Ub" = (
 /obj/structure/railing,
 /obj/structure/cable{
@@ -9184,19 +9184,19 @@
 	pixel_x = -4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ui" = (
 /obj/structure/salvageable/computer{
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Uj" = (
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Uk" = (
 /obj/structure/railing{
 	dir = 1
@@ -9216,7 +9216,7 @@
 	pixel_x = -9
 	},
 /turf/open/floor/pod/dark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ul" = (
 /obj/effect/spawner/random/trash/grime,
 /obj/effect/decal/cleanable/dirt,
@@ -9244,11 +9244,11 @@
 	},
 /obj/item/ammo_casing/spent/rifle_steel,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Ur" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plastic,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Us" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "brig_phys";
@@ -9281,14 +9281,14 @@
 /obj/item/melee/baton/cattleprod/loaded,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Uu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/checkpoint/control)
+/area/ruin/whitesands/trainyard/checkpoint/control)
 "Uv" = (
 /obj/item/ammo_casing/spent/slug,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
@@ -9298,7 +9298,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Uz" = (
 /obj/machinery/light/floor/hangar,
 /turf/open/floor/plasteel/heavymetal{
@@ -9314,13 +9314,13 @@
 	pixel_x = -8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "UC" = (
 /obj/structure/filingcabinet/double/grey{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "UF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/catwalk/over/plated_catwalk/dark,
@@ -9334,7 +9334,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "UG" = (
 /obj/item/flashlight/flare/burnt,
 /turf/open/floor/plating/rust{
@@ -9344,7 +9344,7 @@
 "UI" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/closed/wall/r_wall,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/cargo)
 "UQ" = (
 /obj/structure/closet/crate/large,
 /obj/effect/turf_decal/spline/fancy/opaque/yellow,
@@ -9353,7 +9353,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "UR" = (
 /obj/effect/turf_decal/borderfloorblack,
 /turf/open/floor/concrete/pavement/whitesands/lit,
@@ -9386,7 +9386,7 @@
 /turf/open/floor/plasteel/tech/grid{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "UX" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -9410,7 +9410,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "UZ" = (
 /turf/open/floor/plasteel/heavymetal{
 	initial_gas_mix = "SANDPLANET_ATMOS"
@@ -9429,7 +9429,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Vc" = (
 /turf/open/floor/plasteel/stairs/stairs_pack/left{
 	dir = 4;
@@ -9443,7 +9443,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/dorm)
 "Vg" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -9474,17 +9474,17 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Vl" = (
 /turf/closed/indestructible/plastitanium,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "Vm" = (
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/concrete,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Vn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9535,7 +9535,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "VG" = (
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9547,7 +9547,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/checkpoint/storage)
+/area/ruin/whitesands/trainyard/checkpoint/storage)
 "VI" = (
 /obj/structure/railing,
 /turf/open/floor/concrete/reinforced/whitesands/lit,
@@ -9569,7 +9569,7 @@
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{
 	dir = 5
 	},
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "VO" = (
 /obj/structure/table_frame,
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -9590,12 +9590,12 @@
 	layer = 2.030
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Wb" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Wf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -9608,7 +9608,7 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "Wg" = (
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Wi" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -9673,7 +9673,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/suns/dark/plain,
-/area/ruin/whitesand/trainyard/train)
+/area/ruin/whitesands/trainyard/train)
 "Wy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9702,7 +9702,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "WE" = (
 /obj/structure/platform/industrial{
 	dir = 1;
@@ -9751,13 +9751,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "WL" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/cargo)
 "WM" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -9770,7 +9770,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "WS" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -9786,7 +9786,7 @@
 	},
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "WW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -9818,7 +9818,7 @@
 /turf/open/floor/suns/diagonal{
 	color = "#792f27"
 	},
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Xp" = (
 /obj/structure/railing/thin{
 	dir = 8
@@ -9834,7 +9834,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Xs" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plating{
@@ -9862,7 +9862,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "XA" = (
 /obj/structure/fence{
 	dir = 8
@@ -9888,7 +9888,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "XD" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 4
@@ -9900,7 +9900,7 @@
 /turf/open/floor/plasteel/stairs/stairs_pack/left{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "XK" = (
 /obj/structure/railing{
 	max_integrity = 70;
@@ -9925,7 +9925,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/dorm)
 "XS" = (
 /obj/structure/platform/industrial_alt{
 	dir = 1
@@ -9942,13 +9942,13 @@
 /area/overmap_encounter/planetoid/sand/explored)
 "Ya" = (
 /turf/closed/indestructible/reinforced,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Yb" = (
 /turf/closed/wall/r_wall,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Yd" = (
 /turf/closed/wall/r_wall,
-/area/ruin/whitesand/trainyard/cargo)
+/area/ruin/whitesands/trainyard/hangar)
 "Ye" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -10014,7 +10014,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/engineering)
+/area/ruin/whitesands/trainyard/engineering)
 "Yp" = (
 /obj/structure/platform/industrial{
 	dir = 8;
@@ -10034,21 +10034,21 @@
 /turf/open/floor/mineral/plastitanium/red{
 	initial_gas_mix = "SANDPLANET_ATMOS"
 	},
-/area/ruin/whitesand/trainyard/carriage)
+/area/ruin/whitesands/trainyard/carriage)
 "Yr" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Ys" = (
 /obj/item/kirbyplants/fullysynthetic,
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Yv" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -10063,7 +10063,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "YC" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 1
@@ -10104,7 +10104,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "YO" = (
 /obj/effect/turf_decal/spline/fancy/opaque/yellow{
 	dir = 1
@@ -10113,7 +10113,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "YQ" = (
 /obj/item/broken_bottle{
 	pixel_x = -10
@@ -10127,7 +10127,7 @@
 	dir = 1
 	},
 /turf/open/floor/hangar/plasteel/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "YU" = (
 /turf/open/floor/plating{
 	initial_gas_mix = "SANDPLANET_ATMOS"
@@ -10139,7 +10139,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/tech,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "YX" = (
 /obj/structure/platform/industrial{
 	dir = 4;
@@ -10154,7 +10154,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "YZ" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -10163,7 +10163,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/tech/grid,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "Zi" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /turf/open/floor/concrete/slab_1{
@@ -10178,7 +10178,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Zl" = (
 /obj/effect/turf_decal/industrial/warning,
 /obj/effect/turf_decal/industrial/stand_clear,
@@ -10192,7 +10192,7 @@
 	id = "tr_sh_et"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/checkpoint)
+/area/ruin/whitesands/trainyard/checkpoint/second)
 "Zt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10225,7 +10225,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/patterned/grid,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "Zy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/splatter/over_window{
@@ -10239,7 +10239,7 @@
 /turf/open/floor/plasteel/stairs/stairs_pack/mid{
 	dir = 1
 	},
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "Zz" = (
 /obj/item/ammo_casing/spent/pistol_steel{
 	name = "spent .45 casing"
@@ -10279,7 +10279,7 @@
 	id = "tr_sh_eng"
 	},
 /turf/open/floor/plating,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "ZG" = (
 /obj/item/ammo_casing/spent/pistol_steel{
 	name = "spent .45 casing"
@@ -10304,7 +10304,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/mono/dark,
-/area/ruin/whitesand/trainyard/shuttle)
+/area/ruin/whitesands/trainyard/shuttle)
 "ZI" = (
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/heavymetal/var5{
@@ -10314,7 +10314,7 @@
 "ZJ" = (
 /obj/structure/filingcabinet/double/grey,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ZP" = (
 /obj/structure/platform/military,
 /turf/open/floor/plating/asteroid/whitesands/lit,
@@ -10336,10 +10336,10 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 "ZS" = (
 /turf/closed/wall/rust,
-/area/ruin/whitesand/trainyard/checkpoint/second)
+/area/ruin/whitesands/trainyard/checkpoint)
 "ZT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10366,7 +10366,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/whitesand/trainyard/hungar)
+/area/ruin/whitesands/trainyard/hangar)
 "ZY" = (
 /obj/effect/turf_decal/road{
 	dir = 8;
@@ -10384,7 +10384,7 @@
 	dir = 8
 	},
 /turf/open/floor/suns/dark,
-/area/ruin/whitesand/trainyard/dorm)
+/area/ruin/whitesands/trainyard/dorm)
 
 (1,1,1) = {"
 LO
@@ -11041,9 +11041,9 @@ PL
 PL
 PL
 PL
-eG
-eG
-eG
+Yd
+Yd
+Yd
 PL
 PL
 PL
@@ -11099,12 +11099,12 @@ VD
 IW
 hd
 HN
-eG
+Yd
 ds
 Am
 ht
 ds
-eG
+Yd
 Sb
 QT
 Fk
@@ -11161,7 +11161,7 @@ VD
 IW
 IW
 go
-eG
+Yd
 lG
 FS
 zC
@@ -11352,11 +11352,11 @@ wC
 ED
 ZV
 AE
-eG
+Yd
 Ug
 Os
 WD
-eG
+Yb
 Yb
 Yb
 QV
@@ -11410,15 +11410,15 @@ wI
 RE
 iO
 PL
-eG
-eG
-eG
-eG
-eG
+Yd
+Yd
+Yd
+Yd
+Yd
 cE
 rS
 Ek
-eG
+Yb
 FL
 Aw
 hl
@@ -11471,7 +11471,7 @@ dB
 rn
 Ud
 Wf
-eG
+Yd
 Kx
 YO
 UQ
@@ -11480,7 +11480,7 @@ Qn
 OL
 rG
 Rz
-eG
+Yb
 LC
 fw
 ls
@@ -11533,7 +11533,7 @@ dB
 TP
 Ud
 Wf
-eG
+Yd
 nu
 Uj
 jQ
@@ -11542,7 +11542,7 @@ iM
 Fe
 nc
 iv
-eG
+Yb
 AI
 NP
 aY
@@ -11595,7 +11595,7 @@ Nt
 go
 Lk
 tX
-eG
+Yd
 fH
 Uj
 KP
@@ -11728,7 +11728,7 @@ kI
 bV
 sD
 ha
-eG
+Yb
 EU
 sQ
 Eo
@@ -11790,7 +11790,7 @@ aQ
 OH
 sD
 Fe
-eG
+Yb
 EQ
 sQ
 Tv
@@ -11852,7 +11852,7 @@ Zy
 BR
 oK
 gr
-eG
+Yb
 xa
 sQ
 rp
@@ -11914,7 +11914,7 @@ XE
 Xq
 OX
 yS
-eG
+Yb
 AF
 Fo
 YQ
@@ -11976,7 +11976,7 @@ qD
 fv
 UF
 zK
-eG
+Yb
 UY
 Gt
 om
@@ -12033,12 +12033,12 @@ PL
 dc
 dc
 dc
-eG
+Yd
 hX
 bV
 wt
 Bc
-eG
+Yb
 ax
 TV
 fh
@@ -12091,7 +12091,7 @@ TE
 go
 DY
 yE
-eG
+Yd
 YI
 Wb
 HS
@@ -12100,7 +12100,7 @@ Sd
 DW
 GJ
 GT
-eG
+Yb
 dO
 KE
 tY
@@ -12153,7 +12153,7 @@ Zl
 HN
 ab
 yE
-eG
+Yd
 NY
 ws
 Ag
@@ -12162,7 +12162,7 @@ DQ
 bV
 wt
 tP
-eG
+Yb
 mq
 ou
 na
@@ -12215,16 +12215,16 @@ Lx
 QY
 du
 go
-eG
+Yd
 Fx
 pY
 SN
-eG
+Yd
 kU
 fV
 OX
 Jj
-eG
+Yb
 Oo
 pD
 wz
@@ -12286,7 +12286,7 @@ rj
 Fg
 tM
 kn
-eG
+Yb
 IM
 PY
 Ys
@@ -12342,21 +12342,21 @@ go
 kb
 Ya
 Ya
-eG
-eG
-eG
+Yd
+Yd
+Yd
 fU
 Pk
+Yd
 eG
 eG
-Yb
 Ca
-Yb
-Yb
-Yb
-Yb
-Yb
-FI
+eG
+eG
+eG
+eG
+eG
+Fs
 Bn
 Fs
 Fs
@@ -12421,7 +12421,7 @@ OV
 Mf
 sI
 lV
-Yd
+eG
 Jl
 bR
 oE
@@ -12483,7 +12483,7 @@ ot
 LX
 Ez
 dz
-Yd
+eG
 pT
 SU
 SU
@@ -12545,7 +12545,7 @@ FW
 wl
 cc
 hr
-Yd
+eG
 SU
 SU
 pT
@@ -12597,11 +12597,11 @@ OP
 BZ
 xZ
 eG
-Yd
-Yd
-Yd
-Yd
-Yd
+eG
+eG
+eG
+eG
+eG
 pB
 FW
 qf
@@ -12663,7 +12663,7 @@ lA
 rx
 If
 MM
-Yd
+eG
 aF
 yk
 if
@@ -12849,7 +12849,7 @@ VN
 ym
 pM
 qq
-Yd
+eG
 yQ
 WL
 Hi
@@ -12899,24 +12899,24 @@ pZ
 XK
 XK
 XK
-eG
-eG
-eG
-eG
-eG
-eG
-eG
-eG
 Yd
 Yd
 Yd
 Yd
 Yd
 Yd
+Yd
+eG
+eG
+eG
+eG
+eG
+eG
+eG
 Hn
 wT
-Yd
-Yd
+eG
+eG
 Fs
 pT
 pT

--- a/_maps/_mod_celadon/map_catalogue.txt
+++ b/_maps/_mod_celadon/map_catalogue.txt
@@ -181,6 +181,9 @@ Find the key for using this catalogue in "map_catalogue_key.txt"
 		Size = (x = 68)(y = 64)(z = 1)
 		Tags = "High Combat Challenge", "Major Loot", "Shelter"
 
+		File Name = "_maps\RandomRuins\Ruins\whitesands_surface_trainyard.dmm"
+		Size = (x = 80)(y = 60)(z = 1)
+		Tags = "High Combat Challenge", "Medium Loot", "Shelter"
 
 	SpaceRuins:
 		File Name = "_maps\RandomRuins\SpaceRuins\astraeus.dmm"

--- a/mod_celadon/areas/code/ruin.dm
+++ b/mod_celadon/areas/code/ruin.dm
@@ -219,3 +219,38 @@
 /area/ruin/jungle/syndifortshuttle
 	name = "Syndi Fort Shuttle"
 	icon_state = "green"
+
+/// MARK: Whitesand
+/area/ruin/whitesand/trainyard/shuttle
+	name = "shuttle"
+	icon_state = "shuttle"
+/area/ruin/whitesand/trainyard/engineering
+	name = "engineering"
+	icon_state = "yellow"
+/area/ruin/whitesand/trainyard/train
+	name = "train"
+	icon_state = "bridge"
+/area/ruin/whitesand/trainyard/cargo
+	name = "cargo"
+	icon_state = "mining"
+/area/ruin/whitesand/trainyard/dorm
+	name = "dorm"
+	icon_state = "crew_quarters"
+/area/ruin/whitesand/trainyard/hungar
+	name = "hungar"
+	icon_state = "storage"
+/area/ruin/whitesand/trainyard/carriage
+	name = "carriage"
+	icon_state = "green"
+/area/ruin/whitesand/trainyard/checkpoint
+	name = "checkpoint"
+	icon_state = "red"
+/area/ruin/whitesand/trainyard/checkpoint/second
+	name = "checkpoint 2"
+	icon_state = "blue"
+/area/ruin/whitesand/trainyard/checkpoint/storage
+	name = "storage"
+	icon_state = "quartstorage"
+/area/ruin/whitesand/trainyard/checkpoint/control
+	name = "control room"
+	icon_state = "captain"

--- a/mod_celadon/areas/code/ruin.dm
+++ b/mod_celadon/areas/code/ruin.dm
@@ -220,37 +220,38 @@
 	name = "Syndi Fort Shuttle"
 	icon_state = "green"
 
-/// MARK: Whitesand
-/area/ruin/whitesand/trainyard/shuttle
+/// MARK: Whitesands
+
+/area/ruin/whitesands/trainyard/shuttle
 	name = "shuttle"
 	icon_state = "shuttle"
-/area/ruin/whitesand/trainyard/engineering
+/area/ruin/whitesands/trainyard/engineering
 	name = "engineering"
 	icon_state = "yellow"
-/area/ruin/whitesand/trainyard/train
+/area/ruin/whitesands/trainyard/train
 	name = "train"
 	icon_state = "bridge"
-/area/ruin/whitesand/trainyard/cargo
+/area/ruin/whitesands/trainyard/cargo
 	name = "cargo"
 	icon_state = "mining"
-/area/ruin/whitesand/trainyard/dorm
+/area/ruin/whitesands/trainyard/dorm
 	name = "dorm"
 	icon_state = "crew_quarters"
-/area/ruin/whitesand/trainyard/hungar
-	name = "hungar"
+/area/ruin/whitesands/trainyard/hangar
+	name = "hangar"
 	icon_state = "storage"
-/area/ruin/whitesand/trainyard/carriage
+/area/ruin/whitesands/trainyard/carriage
 	name = "carriage"
 	icon_state = "green"
-/area/ruin/whitesand/trainyard/checkpoint
+/area/ruin/whitesands/trainyard/checkpoint
 	name = "checkpoint"
 	icon_state = "red"
-/area/ruin/whitesand/trainyard/checkpoint/second
+/area/ruin/whitesands/trainyard/checkpoint/second
 	name = "checkpoint 2"
 	icon_state = "blue"
-/area/ruin/whitesand/trainyard/checkpoint/storage
+/area/ruin/whitesands/trainyard/checkpoint/storage
 	name = "storage"
 	icon_state = "quartstorage"
-/area/ruin/whitesand/trainyard/checkpoint/control
+/area/ruin/whitesands/trainyard/checkpoint/control
 	name = "control room"
 	icon_state = "captain"

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -1006,6 +1006,14 @@
 	suffix = "whitesands_brazillianlab.dmm"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_INHOSPITABLE)
 
+/datum/map_template/ruin/whitesands/trainyard	// NEW
+	id = "train-yard"
+	name = "Train Yard"
+	description = "Attacked train station. What the hell are train doing on a sand planet?"
+	suffix = "whitesands_surface_trainyard.dmm"
+	cost = 3
+	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
+
 //							///
 //		MARK: Plasma
 //							///


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет новую руинку для песка - железнодорожная станция.
## Причина создания ПР / Почему это хорошо для игры
Расширяем пулл руин, добавляем разнообразие в генерации.
## Демонстрация изменений / Тестирование
![IMG_2868](https://github.com/user-attachments/assets/b457d0ae-0e65-4cc5-a8fd-cc7c8a9bb5f9)

## Список изменений

```yml
🆑
add: Добавляет новую карту - Train yard
/🆑
```
