### PR TITLE
ADD: Overload - Remove SHITCODE from YANDERO-DEV

### DIFF
--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -1,20 +1,28 @@
 //[CELADON-ADD] - перегрузка
 #define OVERLOAD_FACTOR 32
 
+// MARK: Эффект перегрузки
+
 /datum/overmap/ship/controlled
 	var/last_overload_alarm = 0
 	var/last_overload_throw = 0
 
 /datum/overmap/ship/controlled/adjust_speed(n_x, n_y)
 	. = ..()
-	var/overload = ((abs(n_x) + abs(n_y))/acceleration_speed)
-	if(overload == 0)
+	var/overload = ((abs(n_x) + abs(n_y)) / acceleration_speed)
+	if(overload <= 0)
 		return
-	if(world.time-last_overload_alarm > 20)
+
+	if(world.time - last_overload_alarm > 20)
 		last_overload_alarm = world.time
 		for(var/obj/i in helms)
 			if(i)
 				playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
+
+	var/speeding_angle = get_angle_raw(0, 0, 0, 0, round((n_x/acceleration_speed) * OVERLOAD_FACTOR * 10), round((n_y/acceleration_speed) * OVERLOAD_FACTOR * 10), 0, 0 )
+	var/ang = SIMPLIFY_DEGREES(speeding_angle - bow_heading + 270)
+	var/overload_st = 10 * OVERLOAD_FACTOR * overload
+	var/disgust_amount = round(overload * OVERLOAD_FACTOR)
 
 	for(var/mob/living/M in GLOB.player_list)
 		if(!M.client)
@@ -24,36 +32,45 @@
 		if(M.virtual_z() != check.virtual_z())
 			continue
 
-		var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*OVERLOAD_FACTOR*10), round(((n_y)/acceleration_speed)*OVERLOAD_FACTOR*10), 0, 0)
-		var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
-		var/overload_st = 10*OVERLOAD_FACTOR*overload
-		M.client.pixel_x = round(overload_st*sin(ang))
-		M.client.pixel_y = round(overload_st*cos(ang))
+		M.client.pixel_x = round(overload_st * sin(ang))
+		M.client.pixel_y = round(overload_st * cos(ang))
 		animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
 
 		if(!iscarbon(M))
 			continue
 
 		var/mob/living/carbon/C = M
-		var/bezbab = 30
-		if(!C.resting)
-			bezbab += 30
-		if(!C.buckled)
-			bezbab += 30
+		var/is_protected = check_overload_protection(C)
 
-		var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
-		if(istype(boots) && boots.magpulse)
-			continue
+		if(!is_protected)
+			apply_overload_effects(C, overload_st, disgust_amount, ang, last_overload_throw)
 
+// MARK: Функции
+
+/proc/check_overload_protection(mob/living/carbon/C)
+	if(C.buckled)
 		if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
-			continue
+			return TRUE
+		return FALSE
 
-		if(prob(bezbab))
-			C.adjust_disgust(round(overload*OVERLOAD_FACTOR))
+	var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
+	if(istype(boots) && boots.magpulse)
+		return TRUE
 
-		if(round(overload*OVERLOAD_FACTOR) > 0)
-			if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
-				last_overload_throw = world.time
-				C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
+	return FALSE
+
+/proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, last_overload_throw)
+	var/chance_cyka = 30
+	if(!C.resting)
+		chance_cyka += 30
+	if(!C.buckled)
+		chance_cyka += 30
+
+	if(prob(chance_cyka))
+		C.adjust_disgust(disgust_amount)
+
+	if(disgust_amount > 0 && world.time - last_overload_throw > 20 && !C.anchored && !C.buckled)
+		last_overload_throw = world.time
+		C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
 
 #undef OVERLOAD_FACTOR

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -15,35 +15,45 @@
 		for(var/obj/i in helms)
 			if(i)
 				playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
+
 	for(var/mob/living/M in GLOB.player_list)
 		if(!M.client)
-			return
+			continue
+
 		var/obj/check = pick(helms)
-		if(M.virtual_z() == check.virtual_z())
-			var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*OVERLOAD_FACTOR*10), round(((n_y)/acceleration_speed)*OVERLOAD_FACTOR*10), 0, 0)
-			var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
-			var/overload_st = 10*OVERLOAD_FACTOR*overload
-			M.client.pixel_x = round(overload_st*sin(ang))
-			M.client.pixel_y = round(overload_st*cos(ang))
-			animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
-			if(!iscarbon(M))
-				return
-			var/mob/living/carbon/C = M
-			var/bezbab = 30
-			if(!C.resting)
-				bezbab = bezbab+30
-			if(!C.buckled)
-				bezbab = bezbab+30
-			var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
-			if(boots.magpulse)
-				return
-			if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
-				return
-			if(prob(bezbab))
-				C.adjust_disgust(round(overload*OVERLOAD_FACTOR))
-			if(round(overload*OVERLOAD_FACTOR) > 0)
-				if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
-					last_overload_throw = world.time
-					C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
+		if(M.virtual_z() != check.virtual_z())
+			continue
+
+		var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*OVERLOAD_FACTOR*10), round(((n_y)/acceleration_speed)*OVERLOAD_FACTOR*10), 0, 0)
+		var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
+		var/overload_st = 10*OVERLOAD_FACTOR*overload
+		M.client.pixel_x = round(overload_st*sin(ang))
+		M.client.pixel_y = round(overload_st*cos(ang))
+		animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
+
+		if(!iscarbon(M))
+			continue
+
+		var/mob/living/carbon/C = M
+		var/bezbab = 30
+		if(!C.resting)
+			bezbab += 30
+		if(!C.buckled)
+			bezbab += 30
+
+		var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
+		if(istype(boots) && boots.magpulse)
+			continue
+
+		if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
+			continue
+
+		if(prob(bezbab))
+			C.adjust_disgust(round(overload*OVERLOAD_FACTOR))
+
+		if(round(overload*OVERLOAD_FACTOR) > 0)
+			if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
+				last_overload_throw = world.time
+				C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
 
 #undef OVERLOAD_FACTOR

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -1,3 +1,6 @@
+//[CELADON-ADD] - перегрузка
+#define OVERLOAD_FACTOR 32
+
 /datum/overmap/ship/controlled
 	var/last_overload_alarm = 0
 	var/last_overload_throw = 0
@@ -17,9 +20,9 @@
 			return
 		var/obj/check = pick(helms)
 		if(M.virtual_z() == check.virtual_z())
-			var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*world.icon_size*10), round(((n_y)/acceleration_speed)*world.icon_size*10), 0, 0)
+			var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*OVERLOAD_FACTOR*10), round(((n_y)/acceleration_speed)*OVERLOAD_FACTOR*10), 0, 0)
 			var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
-			var/overload_st = 10*world.icon_size*overload
+			var/overload_st = 10*OVERLOAD_FACTOR*overload
 			M.client.pixel_x = round(overload_st*sin(ang))
 			M.client.pixel_y = round(overload_st*cos(ang))
 			animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
@@ -37,8 +40,10 @@
 			if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
 				return
 			if(prob(bezbab))
-				C.adjust_disgust(round(overload*world.icon_size))
-			if(round(overload*world.icon_size) > 0)
+				C.adjust_disgust(round(overload*OVERLOAD_FACTOR))
+			if(round(overload*OVERLOAD_FACTOR) > 0)
 				if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
 					last_overload_throw = world.time
 					C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
+
+#undef OVERLOAD_FACTOR

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -1,4 +1,3 @@
-//[CELADON-ADD] - перегрузка
 /datum/overmap/ship/controlled
 	var/last_overload_alarm = 0
 	var/last_overload_throw = 0
@@ -6,32 +5,40 @@
 /datum/overmap/ship/controlled/adjust_speed(n_x, n_y)
 	. = ..()
 	var/overload = ((abs(n_x) + abs(n_y))/acceleration_speed)
-	if(round(overload*world.icon_size) > 0)
-		if(world.time-last_overload_alarm > 20)
-			last_overload_alarm = world.time
-			for(var/obj/i in helms)
-				if(i)
-					playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
+	if(overload == 0)
+		return
+	if(world.time-last_overload_alarm > 20)
+		last_overload_alarm = world.time
+		for(var/obj/i in helms)
+			if(i)
+				playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
 	for(var/mob/living/M in GLOB.player_list)
-		if(M.client)
-			var/obj/check = pick(helms)
-			if(M.virtual_z() == check.virtual_z())
-				var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*world.icon_size*10), round(((n_y)/acceleration_speed)*world.icon_size*10), 0, 0)
-				var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
-				var/overload_st = 10*world.icon_size*overload
-				M.client.pixel_x = round(overload_st*sin(ang))
-				M.client.pixel_y = round(overload_st*cos(ang))
-				animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
-				if(iscarbon(M))
-					var/mob/living/carbon/C = M
-					var/bezbab = 30
-					if(!C.resting)
-						bezbab = bezbab+30
-					if(!C.buckled)
-						bezbab = bezbab+30
-					if(prob(bezbab))
-						C.adjust_disgust(round(overload*world.icon_size))
-					if(round(overload*world.icon_size) > 0)
-						if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
-							last_overload_throw = world.time
-							C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
+		if(!M.client)
+			return
+		var/obj/check = pick(helms)
+		if(M.virtual_z() == check.virtual_z())
+			var/speeding_angle = get_angle_raw(0, 0, 0, 0, round(((n_x)/acceleration_speed)*world.icon_size*10), round(((n_y)/acceleration_speed)*world.icon_size*10), 0, 0)
+			var/ang = SIMPLIFY_DEGREES(speeding_angle-bow_heading+270)
+			var/overload_st = 10*world.icon_size*overload
+			M.client.pixel_x = round(overload_st*sin(ang))
+			M.client.pixel_y = round(overload_st*cos(ang))
+			animate(M.client, pixel_x = 0, pixel_y = 0, 10, 1)
+			if(!iscarbon(M))
+				return
+			var/mob/living/carbon/C = M
+			var/bezbab = 30
+			if(!C.resting)
+				bezbab = bezbab+30
+			if(!C.buckled)
+				bezbab = bezbab+30
+			var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
+			if(boots.magpulse)
+				return
+			if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
+				return
+			if(prob(bezbab))
+				C.adjust_disgust(round(overload*world.icon_size))
+			if(round(overload*world.icon_size) > 0)
+				if(world.time-last_overload_throw > 20 && !M.anchored && !M.buckled)
+					last_overload_throw = world.time
+					C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -1,5 +1,7 @@
-//[CELADON-ADD] - перегрузка
 #define OVERLOAD_FACTOR 32
+#define OVERLOAD_CHANCE 30
+#define OVERLOAD_COOLDOWN 20
+#define OVERLOAD_THROW_RANGE_MAX 8
 
 // MARK: Эффект перегрузки
 
@@ -9,17 +11,19 @@
 
 /datum/overmap/ship/controlled/adjust_speed(n_x, n_y)
 	. = ..()
+	if(acceleration_speed <= 0)
+		return
 	var/overload = ((abs(n_x) + abs(n_y)) / acceleration_speed)
 	if(overload <= 0)
 		return
 
-	if(world.time - last_overload_alarm > 20)
+	if(world.time - last_overload_alarm > OVERLOAD_COOLDOWN)
 		last_overload_alarm = world.time
 		for(var/obj/i in helms)
 			if(i)
 				playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
 
-	var/speeding_angle = get_angle_raw(0, 0, 0, 0, round((n_x/acceleration_speed) * OVERLOAD_FACTOR * 10), round((n_y/acceleration_speed) * OVERLOAD_FACTOR * 10), 0, 0 )
+	var/speeding_angle = get_angle_raw(0, 0, 0, 0, round((n_x/acceleration_speed) * OVERLOAD_FACTOR * 10), round((n_y/acceleration_speed) * OVERLOAD_FACTOR * 10), 0, 0)
 	var/ang = SIMPLIFY_DEGREES(speeding_angle - bow_heading + 270)
 	var/overload_st = 10 * OVERLOAD_FACTOR * overload
 	var/disgust_amount = round(overload * OVERLOAD_FACTOR)
@@ -29,7 +33,7 @@
 			continue
 
 		var/obj/check = pick(helms)
-		if(M.virtual_z() != check.virtual_z())
+		if(!check || M.virtual_z() != check.virtual_z())
 			continue
 
 		M.client.pixel_x = round(overload_st * sin(ang))
@@ -43,34 +47,33 @@
 		var/is_protected = check_overload_protection(C)
 
 		if(!is_protected)
-			apply_overload_effects(C, overload_st, disgust_amount, ang, last_overload_throw)
+			apply_overload_effects(C, overload_st, disgust_amount, ang, src)
 
 // MARK: Функции
 
 /proc/check_overload_protection(mob/living/carbon/C)
-	if(C.buckled)
-		if(istype(C.buckled, /obj/structure/chair/comfy/shuttle))
-			return TRUE
-		return FALSE
-
 	var/obj/item/clothing/shoes/magboots/boots = C.get_item_by_slot(ITEM_SLOT_FEET)
 	if(istype(boots) && boots.magpulse)
 		return TRUE
 
-	return FALSE
+	if(C.buckled && istype(C.buckled, /obj/structure/chair/comfy/shuttle))
+		return TRUE
 
-/proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, last_overload_throw)
-	var/chance_overload = 30
+/proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, datum/overmap/ship/controlled/ship)
+	var/chance_overload = OVERLOAD_CHANCE
 	if(!C.resting)
-		chance_overload += 30
+		chance_overload += OVERLOAD_CHANCE
 	if(!C.buckled)
-		chance_overload += 30
+		chance_overload += OVERLOAD_CHANCE
 
 	if(prob(chance_overload))
 		C.adjust_disgust(disgust_amount)
 
-	if(disgust_amount > 0 && world.time - last_overload_throw > 20 && !C.anchored && !C.buckled)
-		last_overload_throw = world.time
+	if(disgust_amount > 0 && world.time - ship.last_overload_throw > OVERLOAD_COOLDOWN && !C.anchored && !C.buckled)
+		ship.last_overload_throw = world.time
 		C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
 
 #undef OVERLOAD_FACTOR
+#undef OVERLOAD_CHANCE
+#undef OVERLOAD_COOLDOWN
+#undef OVERLOAD_THROW_RANGE_MAX

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -23,10 +23,12 @@
 			if(i)
 				playsound(i, 'sound/effects/alert.ogg', 25, FALSE)
 
-	var/speeding_angle = get_angle_raw(0, 0, 0, 0, round((n_x/acceleration_speed) * OVERLOAD_FACTOR * 10), round((n_y/acceleration_speed) * OVERLOAD_FACTOR * 10), 0, 0)
+	var/speeding_angle = ATAN2(n_y, n_x)
 	var/ang = SIMPLIFY_DEGREES(speeding_angle - bow_heading + 270)
 	var/overload_st = 10 * OVERLOAD_FACTOR * overload
 	var/disgust_amount = round(overload * OVERLOAD_FACTOR)
+	var/throw_range = clamp(round(overload_st), 1, OVERLOAD_THROW_RANGE_MAX)
+	var/throw_speed = max(1, round(throw_range / 2))
 
 	for(var/mob/living/M in GLOB.player_list)
 		if(!M.client)
@@ -47,7 +49,7 @@
 		var/is_protected = check_overload_protection(C)
 
 		if(!is_protected)
-			apply_overload_effects(C, overload_st, disgust_amount, ang, src)
+			apply_overload_effects(C, overload_st, disgust_amount, ang, throw_range, throw_speed, src)
 
 // MARK: Функции
 
@@ -59,7 +61,7 @@
 	if(C.buckled && istype(C.buckled, /obj/structure/chair/comfy/shuttle))
 		return TRUE
 
-/proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, datum/overmap/ship/controlled/ship)
+/proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, throw_range, throw_speed, datum/overmap/ship/controlled/ship)
 	var/chance_overload = OVERLOAD_CHANCE
 	if(!C.resting)
 		chance_overload += OVERLOAD_CHANCE
@@ -71,7 +73,7 @@
 
 	if(disgust_amount > 0 && world.time - ship.last_overload_throw > OVERLOAD_COOLDOWN && !C.anchored && !C.buckled)
 		ship.last_overload_throw = world.time
-		C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = round(overload_st)), range = round(overload_st/2), speed = round(overload_st/2), thrower = C)
+		C.throw_at(get_ranged_target_turf(C, angle2dir(ang), range = throw_range), range = throw_range, speed = throw_speed, thrower = C)
 
 #undef OVERLOAD_FACTOR
 #undef OVERLOAD_CHANCE

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -60,13 +60,13 @@
 	return FALSE
 
 /proc/apply_overload_effects(mob/living/carbon/C, overload_st, disgust_amount, ang, last_overload_throw)
-	var/chance_cyka = 30
+	var/chance_overload = 30
 	if(!C.resting)
-		chance_cyka += 30
+		chance_overload += 30
 	if(!C.buckled)
-		chance_cyka += 30
+		chance_overload += 30
 
-	if(prob(chance_cyka))
+	if(prob(chance_overload))
 		C.adjust_disgust(disgust_amount)
 
 	if(disgust_amount > 0 && world.time - last_overload_throw > 20 && !C.anchored && !C.buckled)

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -14,8 +14,6 @@
 	if(acceleration_speed <= 0)
 		return
 	var/overload = ((abs(n_x) + abs(n_y)) / acceleration_speed)
-	if(overload <= 0)
-		return
 
 	if(world.time - last_overload_alarm > OVERLOAD_COOLDOWN)
 		last_overload_alarm = world.time

--- a/mod_celadon/overload/code/overload.dm
+++ b/mod_celadon/overload/code/overload.dm
@@ -1,7 +1,7 @@
 #define OVERLOAD_FACTOR 32
 #define OVERLOAD_CHANCE 30
 #define OVERLOAD_COOLDOWN 20
-#define OVERLOAD_THROW_RANGE_MAX 8
+#define OVERLOAD_THROW_RANGE_MAX 6
 
 // MARK: Эффект перегрузки
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Чутка меняет и улучшает текущую систему перегрузок, меняя внутреннюю логику.
Некоторые вещи получили способ противодействия перегрузкам:
- Магнитные ботинки, не действуют эффекты перегрузки во включенном состоянии.
- Сиденье пилота (Титановое кресло), получило амортизацию, и гасит эффекты перегрузки.

## Причина создания ПР / Почему это хорошо для игры
Удаляет фанатов кодинга Яндеро-Дев. Сколько я буду ломать колени тем кто писал это?
Переписывает код по человеческий в функции, и в целом делает код читабельнее.

## Список изменений

```yml
🆑
add: Меняет поведение перегрузок, при одетых магбутсах, и в кресле пилота
add: Переписано почти вся логика перегрузок, от вероятности до самих эффектов
balance: У сидящего в кресле _пилота_ теперь не вызываются эффекты перегрузки и рвоты.
balance: Включенные магбутсы магнитятся к поверхности намертво, игнорируя броски от перегрузок.
del: Yandero-developer fans - очень сильно упрощены формулы расчета перегрузок
/🆑
```
