### PR TITLE
FIX: Накладывание метки крашера на трупы мобов

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -256,6 +256,10 @@
 		hammer_synced = new_hammer_synced
 
 /datum/status_effect/crusher_mark/on_apply()
+	// [CELADON-ADD] — CRUSHER_MARK_ON_MOBS
+	if(owner.stat == DEAD)
+		return FALSE
+	// [/CELADON-ADD]
 	// [CELADON-EDIT] — CRUSHER_MARK_ON_MOBS
 	// if(owner.mob_size >= MOB_SIZE_LARGE)
 	if(owner.mob_size >= MOB_SIZE_HUMAN && !(ishuman(owner)))

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -166,6 +166,10 @@
 /obj/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/L = target
+		// [CELADON-ADD] — CRUSHER_MARK_ON_MOBS
+		if(L.stat == DEAD)
+			return FALSE
+		// [/CELADON-ADD]
 		// [CELADON-ADD] - RETURN_CONTENT_CRUSHER_TROPHY - Возвращаем легенду
 		var/had_effect = (L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)) //used as a boolean
 		var/datum/status_effect/crusher_mark/CM = L.apply_status_effect(STATUS_EFFECT_CRUSHERMARK, hammer_synced)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -211,6 +211,12 @@ CELADON_FIXES_DEBUG_ROOM
 - EDIT: `code/modules/awaymissions/super_secret_room.dm` - фиксит сообщения для чата
 - ADD: `code/modules/awaymissions/signpost.dm` - фиксит лестницу, тепешает на координаты 139, 31, 3
 
+CRUSHER_MARK_ON_MOBS
+- EDIT: `code/datums/status_effects/debuffs.dm` - изменения от Ганзы
+- ADD: `code/datums/status_effects/debuffs.dm` - добавляем проверку на труп дял метки крашера
+- REMOVE: `code/modules/mining/equipment/kinetic_crusher.dm` - изменения от Ганзы
+- ADD: `code/modules/mining/equipment/kinetic_crusher.dm` - добавляем проверку на труп дял метки крашера
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет проверку на то мертв моб или нет, перед навешиванием метки крашера

## Причина создания ПР / Почему это хорошо для игры
Убираем абуз с меткой крашера на мертвых мобах
Closed #2234 

## Список изменений

```yml
🆑
add: Проверка на статус моба перед навешиванием метки крашера
/🆑
```
