### PR TITLE
FIX: Чиним улет иконок за границу контейнеров

### DIFF
--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -112,6 +112,11 @@
 	thing.layer = initial(thing.layer)
 	thing.plane = initial(thing.plane)
 	thing.mouse_opacity = initial(thing.mouse_opacity)
+	// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Сбрасываем позицию элемента для предотвращения визуальных багов
+	thing.pixel_x = initial(thing.pixel_x)
+	thing.pixel_y = initial(thing.pixel_y)
+	thing.screen_loc = null
+	// [/CELADON-ADD]
 	if(thing.maptext)
 		thing.maptext = ""
 
@@ -177,6 +182,11 @@
 		return FALSE
 	I.on_enter_storage(master)
 	I.item_flags |= IN_STORAGE
+	// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Сбрасываем позицию элемента при помещении в хранилище
+	I.pixel_x = 0
+	I.pixel_y = 0
+	I.screen_loc = null
+	// [/CELADON-ADD]
 	refresh_mob_views()
 	I.mouse_opacity = MOUSE_OPACITY_OPAQUE //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	if(M)

--- a/code/datums/components/storage/ui.dm
+++ b/code/datums/components/storage/ui.dm
@@ -42,10 +42,18 @@
 		for(var/type in numbered_contents)
 			var/datum/numbered_display/ND = numbered_contents[type]
 			ND.sample_object.mouse_opacity = MOUSE_OPACITY_OPAQUE
-			ND.sample_object.screen_loc = "[cx]:[screen_pixel_x],[cy]:[screen_pixel_y]"
+			// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Убеждаемся, что координаты находятся в допустимых пределах
+			var/safe_cx = clamp(cx, screen_start_x, screen_start_x + columns - 1)
+			var/safe_cy = clamp(cy, screen_start_y, screen_start_y + rows - 1)
+			ND.sample_object.screen_loc = "[safe_cx]:[screen_pixel_x],[safe_cy]:[screen_pixel_y]"
 			ND.sample_object.maptext = "<font color='white'>[(ND.number > 1)? "[ND.number]" : ""]</font>"
 			ND.sample_object.layer = ABOVE_HUD_LAYER
 			ND.sample_object.plane = ABOVE_HUD_PLANE
+			// [/CELADON-ADD]
+			// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Сбрасываем позицию элемента для предотвращения смещения
+			ND.sample_object.pixel_x = 0
+			ND.sample_object.pixel_y = 0
+			// [/CELADON-ADD]
 			. += ND.sample_object
 			cx++
 			if(cx - screen_start_x >= columns)
@@ -59,10 +67,21 @@
 				continue
 			var/atom/movable/screen/storage/item_holder/D = new(null, src, O)
 			D.mouse_opacity = MOUSE_OPACITY_OPAQUE //This is here so storage items that spawn with contents correctly have the "click around item to equip"
-			D.screen_loc = "[cx]:[screen_pixel_x],[cy]:[screen_pixel_y]"
+			// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Убеждаемся, что координаты находятся в допустимых пределах
+			var/safe_cx = clamp(cx, screen_start_x, screen_start_x + columns - 1)
+			var/safe_cy = clamp(cy, screen_start_y, screen_start_y + rows - 1)
+			// [/CELADON-ADD]
+			// [CELADON-EDIT] - FIXES_ICON_OUT_OF_BORDER
+			// D.screen_loc = "[cx]:[screen_pixel_x],[cy]:[screen_pixel_y]"	// ORIGINAL
+			D.screen_loc = "[safe_cx]:[screen_pixel_x],[safe_cy]:[screen_pixel_y]"
+			// [/CELADON-EDIT]
 			O.maptext = ""
 			O.layer = ABOVE_HUD_LAYER
 			O.plane = ABOVE_HUD_PLANE
+			// [CELADON-ADD] - FIXES_ICON_OUT_OF_BORDER - Сбрасываем позицию элемента для предотвращения смещения
+			O.pixel_x = 0
+			O.pixel_y = 0
+			// [/CELADON-ADD]
 			. += D
 			cx++
 			if(cx - screen_start_x >= columns)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -220,6 +220,10 @@ CRUSHER_MARK_ON_MOBS
 FIXES_MOB_SPAWNER
 - REMOVE: `code/modules/mining/ore_veins.dm` - убраны селинги из спавнера Т3 бура в джунглях
 
+FIXES_ICON_OUT_OF_BORDER
+- ADD, EDIT: `code/datums/components/storage/ui.dm` - чиним позиционирование иснтрументов в контейнерах
+- ADD: `code/datums/components/storage/concrete/_concrete.dm`
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет позиционирование инструментам, точнее иконкам в контейнерах, что будет предотвращать их смещение и улетание в бесконечность

## Причина создания ПР / Почему это хорошо для игры
Closed #2178 

![Screenshot_41](https://github.com/user-attachments/assets/a0d6501b-0861-4ab8-beaa-631d512b6196)


## Список изменений

```yml
🆑
add: Позиционирование инструментам
/🆑
```
