### PR TITLE
MAP: Фиксим аиры и апц на аванпостах

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -33061,9 +33061,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/borderfloorwhite{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -33078,17 +33075,7 @@
 	id = "outpost_ghost_janitor";
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/dark,
 /area/outpost/vacant_rooms/shop)
 "vQk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1976,6 +1976,9 @@
 	pixel_y = 3;
 	pixel_x = 8
 	},
+/obj/machinery/airalarm/directional/west{
+	req_access_txt = "8100, 8111"
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/outpost/medical/morgue)
 "bpq" = (
@@ -2809,7 +2812,7 @@
 	dir = 1
 	},
 /obj/structure/curtain,
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/white,
@@ -3351,11 +3354,11 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
 "coh" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	req_access_txt = "8100, 8111";
-	dir = 4;
-	pixel_y = 0;
-	pixel_x = 29
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access_txt = "8100, 8111"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
@@ -9569,9 +9572,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/corner/transparent/mauve/three_quarters,
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_2)
 "grD" = (
@@ -10116,7 +10116,7 @@
 	pixel_y = 27
 	},
 /obj/structure/curtain,
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/white,
@@ -17012,12 +17012,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/light_switch{
 	pixel_y = 1;
 	pixel_x = -23;
@@ -18652,9 +18646,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/directional/south{
-	req_access_txt = "8100, 8111"
-	},
-/obj/machinery/airalarm/directional/west{
 	req_access_txt = "8100, 8111"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -21670,6 +21661,9 @@
 /obj/effect/turf_decal/corner/transparent/mauve/three_quarters{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west{
+	req_access_txt = "8100, 8111"
+	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_2)
 "oyg" = (
@@ -23594,6 +23588,9 @@
 /obj/effect/turf_decal/corner/transparent/nsorange/three_quarters{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west{
+	req_access_txt = "8100, 8111"
+	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/relax_room)
 "pED" = (
@@ -23941,9 +23938,6 @@
 /area/outpost/operations)
 "pQn" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "pQy" = (
@@ -27334,9 +27328,6 @@
 /obj/effect/turf_decal/corner/transparent/blue/three_quarters{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
 "sca" = (
@@ -28388,9 +28379,6 @@
 "sTl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
-	},
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/outpost/medical/morgue)
@@ -30096,9 +30084,6 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
 /obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
@@ -31679,14 +31664,11 @@
 	color = "#792f27";
 	dir = 6
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	req_access_txt = "8100, 8111";
-	dir = 4;
-	pixel_y = 2;
-	pixel_x = 28
-	},
 /obj/structure/cable{
 	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/carpet,
 /area/outpost/crew/library)
@@ -35286,6 +35268,12 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
 "xAk" = (
@@ -36146,9 +36134,6 @@
 	pixel_x = -4;
 	mouse_opacity = 0
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -36161,6 +36146,10 @@
 /obj/item/kirbyplants/random{
 	pixel_y = 7;
 	pixel_x = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north{
+	pixel_x = 6;
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -62272,8 +62261,8 @@ plM
 lSc
 mRY
 mQw
-plM
 coh
+plM
 sbP
 aFX
 lAb

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -19102,7 +19102,9 @@
 	pixel_x = 10;
 	pixel_y = -21;
 	name = "Door Bolt";
-	id = "waterbar_charge2"
+	id = "waterbar_charge2";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
@@ -23094,7 +23096,9 @@
 	pixel_x = 21;
 	pixel_y = 10;
 	name = "Door Bolt";
-	id = "waterbar_stall1"
+	id = "waterbar_stall1";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /obj/structure/toilet{
 	dir = 1
@@ -27483,7 +27487,9 @@
 	pixel_x = -21;
 	pixel_y = 10;
 	name = "Door Bolt";
-	id = "waterbar_stall2"
+	id = "waterbar_stall2";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /obj/structure/toilet{
 	dir = 1
@@ -32568,7 +32574,9 @@
 	pixel_x = 10;
 	pixel_y = -21;
 	name = "Door Bolt";
-	id = "waterbar_charge1"
+	id = "waterbar_charge1";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -3405,10 +3405,6 @@
 /obj/effect/turf_decal/corner/opaque/lime/three_quarters{
 	dir = 4
 	},
-/obj/machinery/medipen_refiller{
-	pixel_x = -8;
-	pixel_y = 11
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "bWp" = (
@@ -8816,6 +8812,16 @@
 /obj/effect/decal/cleanable/molten_object/large,
 /turf/open/floor/plating/asteroid/icerock/temperate,
 /area/outpost/external)
+"eSi" = (
+/obj/effect/turf_decal/corner/opaque/lime/half{
+	dir = 1
+	},
+/obj/machinery/medipen_refiller{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/outpost/medical/hall_1)
 "eSn" = (
 /obj/effect/turf_decal/trimline/opaque/white/corner,
 /obj/effect/turf_decal/trimline/opaque/white/corner{
@@ -10979,11 +10985,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/medical_kiosk{
-	pixel_y = 21;
-	density = 0;
-	pixel_x = -8
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "gas" = (
@@ -12027,11 +12028,11 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/medical/morgue)
 "gCu" = (
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /obj/effect/turf_decal/corner/opaque/red/half{
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/east{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
@@ -12830,9 +12831,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/button/door{
+	id = "ice_stool_2";
+	name = "Stool Lock";
 	pixel_y = 25;
-	name = "Door Bolt";
-	id = "waterbar_charge1"
+	pixel_x = -2;
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/crew/bathroom)
@@ -15019,8 +15023,8 @@
 /obj/machinery/button/door{
 	id = "ice_stool_1";
 	name = "Stool Lock";
-	pixel_y = 28;
-	pixel_x = -4;
+	pixel_y = 25;
+	pixel_x = -2;
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
@@ -15402,11 +15406,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /obj/effect/turf_decal/corner/opaque/red/half{
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/east{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
@@ -15971,10 +15975,7 @@
 /turf/open/floor/carpet/black,
 /area/outpost/fraction/nanotrasen)
 "iKP" = (
-/obj/machinery/medical_kiosk{
-	pixel_y = 15;
-	density = 0
-	},
+/obj/machinery/medical_kiosk,
 /obj/effect/turf_decal/corner/opaque/lime/half{
 	dir = 1
 	},
@@ -24181,7 +24182,7 @@
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations/outpost_command)
 "nrc" = (
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/tech,
@@ -24718,12 +24719,11 @@
 /turf/open/floor/plating,
 /area/outpost/medical/morgue)
 "nEH" = (
-/obj/machinery/power/apc/auto_name/directional/south{
-	use_static_power = 1;
-	req_access_txt = "8100, 8111"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/crew/bar/bar_zone)
@@ -25443,11 +25443,11 @@
 /obj/effect/turf_decal/trimline/opaque/vired/warning{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plating,
 /area/outpost/medical/hall_2)
@@ -29670,6 +29670,7 @@
 /obj/effect/turf_decal/corner/opaque/blue/three_quarters{
 	dir = 4
 	},
+/obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "qtK" = (
@@ -34813,7 +34814,6 @@
 /area/outpost/exterior)
 "tiT" = (
 /obj/effect/turf_decal/corner/opaque/blue/three_quarters,
-/obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
 "tjo" = (
@@ -38722,7 +38722,7 @@
 /obj/machinery/firealarm/directional/east{
 	pixel_y = -19
 	},
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/dark_2,
@@ -40270,8 +40270,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/door/airlock/maintenance/external{
-	id_tag = "waterbar_charge1";
-	name = "Recharge Station 1"
+	id_tag = "ice_stool_2";
+	name = "Recharge Station"
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/crew/bathroom)
@@ -42148,7 +42148,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 6
 	},
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/tech,
@@ -42650,6 +42650,7 @@
 /area/outpost/security/armory)
 "xEf" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/aug_manipulator,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
 "xEs" = (
@@ -72090,7 +72091,7 @@ rgY
 rgY
 rgY
 oUm
-pUw
+eSi
 jtM
 sjV
 sjV


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксит графические баги после обновы аванпостов:
- летающие в воздухе АПЦ и АИРЫ
- дубликаты аиров
- неработающие болтирование туалетов
- дублирующие трубы атмоса под шлюзом уборщика


