### PR TITLE
FIX: Объект миссии мог испариться

### DIFF
--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -158,7 +158,10 @@
 		return FALSE //Dont fuck over stranded people
 
 	for(var/datum/mission/ruin/dynamic_mission in dynamic_missions)
-		if(dynamic_mission.active && !dynamic_mission.bound_left_location)
+		// [CELADON-EDIT] - FIXES_DYNAMIC_MISSION - Исправляем диспавн предмета миссии
+		// if(dynamic_mission.active && !dynamic_mission.bound_left_location)	// ORIGINAL
+		if(dynamic_mission.active && (!dynamic_mission.bound_left_location || dynamic_mission.can_complete()))
+		// [/CELADON-EDIT]
 			return FALSE //Dont fuck over people trying to complete a mission.
 
 	return TRUE

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -220,6 +220,9 @@ CRUSHER_MARK_ON_MOBS
 FIXES_MOB_SPAWNER
 - REMOVE: `code/modules/mining/ore_veins.dm` - убраны селинги из спавнера Т3 бура в джунглях
 
+FIXES_DYNAMIC_MISSION
+- EDIT: `code/modules/overmap/objects/dynamic_datum.dm` - Изменена логика в функции can_reset_dynamic(). Теперь объект не будет диспавниться если миссия все еще может быть завершена
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Объект миссии мог задеспавниться, если игроки покинули планету или таймер истек
Теперь объект не будет диспавниться если:
1. На объекте есть связанные с миссией предметы И игрок не покинул объект
2. ИЛИ миссия все еще может быть завершена (например, игрок взял предмет и может его сдать)

## Причина создания ПР / Почему это хорошо для игры
Closed #2167 

## Список изменений

```yml
🆑
tweak: Логика обработки задания и объекта задания
/🆑
```
