### PR TITLE
FIX: Моды энергощита и хамеллеона модсьютов

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -143,8 +143,10 @@
 	var/charge_recovery = 1
 	/// Whether or not this shield can lose multiple charges.
 	var/lose_multiple_charges = FALSE
+	// [CELADON-REMOVE] - FIXES_MODSUITS - Удалено т.к. не используется
 	/// The item path to recharge this shielkd.
-	var/recharge_path = null
+	// var/recharge_path = null
+	// [/CELADON-REMOVE]
 	/// The icon file of the shield.
 	var/shield_icon_file = 'icons/effects/effects.dmi'
 	/// The icon_state of the shield.
@@ -157,8 +159,11 @@
 	charges = max_charges
 
 /obj/item/mod/module/energy_shield/on_suit_activation()
+	// [CELADON-EDIT] - FIXES_MODSUITS
+	// charge_recovery = charge_recovery, lose_multiple_charges = lose_multiple_charges, recharge_path = recharge_path, starting_charges = charges, shield_icon_file = shield_icon_file, shield_icon = shield_icon)	// ORIGINAL
 	mod.AddComponent(/datum/component/shielded, max_charges = max_charges, recharge_start_delay = recharge_start_delay, charge_increment_delay = charge_increment_delay, \
-	charge_recovery = charge_recovery, lose_multiple_charges = lose_multiple_charges, recharge_path = recharge_path, starting_charges = charges, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
+	charge_recovery = charge_recovery, lose_multiple_charges = lose_multiple_charges, starting_charges = charges, shield_icon_file = shield_icon_file, shield_icon = shield_icon)
+	// [/CELADON-EDIT]
 	RegisterSignal(mod.wearer, COMSIG_HUMAN_CHECK_SHIELDS, PROC_REF(shield_reaction))
 
 /obj/item/mod/module/energy_shield/on_suit_deactivation(deleting = FALSE)
@@ -394,7 +399,7 @@
 	//mod.mob_overlay_state = initial(current_disguise.mob_overlay_state)
 	mod.item_state = initial(current_disguise.item_state)
 	mod.wearer.update_inv_back(mod.slot_flags)
-	RegisterSignal(mod, COMSIG_MOD_ACTIVATE, PROC_REF(return_look))
+	RegisterSignal(mod, COMSIG_MOD_ACTIVATE, PROC_REF(return_look), override = TRUE)	// [CELADON-ADD] - FIXES_MODSUITS
 
 /obj/item/mod/module/chameleon/proc/return_look()
 	mod.name = "[mod.theme.name] [initial(mod.name)]"

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -220,6 +220,9 @@ CRUSHER_MARK_ON_MOBS
 FIXES_MOB_SPAWNER
 - REMOVE: `code/modules/mining/ore_veins.dm` - убраны селинги из спавнера Т3 бура в джунглях
 
+FIXES_MODSUITS
+- ADD, REMOVE, EDIT: `code/modules/mod/modules/modules_antag.dm` - Выпиливаем неиспользуемые и сломанные опции модов
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
1. Модуль энергетического щита
При активации модуля энергетического щита возникал рантайм с ошибкой "bad arg name 'recharge_path'". Проблема была в том, что в функцию `AddComponent` передавался несуществующий параметр `recharge_path`.

2. Модуль хамелеона
При активации модуля хамелеона возникал рантайм с предупреждением "mod_activate overridden. Use override = TRUE to suppress this warning". Проблема была в попытке зарегистрировать уже существующий сигнал без флага `override`.

## Причина создания ПР / Почему это хорошо для игры
Closed #2242 

## Список изменений

```yml
🆑
remove: Удален неправильный параметр из вызова AddComponent
remove: Удалена неиспользуемая переменная var/recharge_path = null
add: Добавлен флаг override при регистрации сигнала
/🆑
```
