### PR TITLE
FIX: Музыка в лобби - Доработка по отображению и функциях логики

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -212,13 +212,14 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
-
+// [CELADON-ADD] - MUSIC_CELADON
 		if(SSticker.login_music_name)
 			var/music_name = SSticker.login_music_name
 			var/dot_position = findlasttext(music_name, ".")
 			if(dot_position)
 				music_name = copytext(music_name, 1, dot_position)
 			to_chat(src, span_redteamradio("<B>Музыка в лобби: [music_name]</B>"))
+// [/CELADON-ADD]
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -213,7 +213,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
-		if(Sticker.login_music_name)
+		if(SSticker.login_music_name)
 			var/music_name = SSticker.login_music_name
 			var/dot_position = findlasttext(music_name, ".")
 			if(dot_position)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -213,12 +213,12 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
-	if(prefs && (prefs.toggles & SOUND_LOBBY) && SSticker.login_music_name)
-		var/music_name = SSticker.login_music_name
-		var/dot_position = findtext(music_name, ".")
-		if(dot_position)
-			music_name = copytext(music_name, 1, dot_position)
-		to_chat(src, span_redteamradio("<B>Проигрывается музыка в лобби: [music_name]</B>"))
+		if(Sticker.login_music_name)
+			var/music_name = SSticker.login_music_name
+			var/dot_position = findtext(music_name, ".")
+			if(dot_position)
+				music_name = copytext(music_name, 1, dot_position)
+			to_chat(src, span_redteamradio("<B>Проигрывается музыка в лобби: [music_name]</B>"))
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -218,7 +218,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 			var/dot_position = findlasttext(music_name, ".")
 			if(dot_position)
 				music_name = copytext(music_name, 1, dot_position)
-			to_chat(src, span_redteamradio("<B>Проигрывается музыка в лобби: [music_name]</B>"))
+			to_chat(src, span_redteamradio("<B>Музыка в лобби: [music_name]</B>"))
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -213,12 +213,12 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
 		SEND_SOUND(src, sound(SSticker.login_music, repeat = 0, wait = 0, volume = vol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
-	if(SSticker.login_music_name)
+	if(prefs && (prefs.toggles & SOUND_LOBBY) && SSticker.login_music_name)
 		var/music_name = SSticker.login_music_name
 		var/dot_position = findtext(music_name, ".")
 		if(dot_position)
 			music_name = copytext(music_name, 1, dot_position)
-		to_chat(src, span_redteamradio("<B>Playing lobby music: [music_name]</B>"))
+		to_chat(src, span_redteamradio("<B>Проигрывается музыка в лобби: [music_name]</B>"))
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -215,7 +215,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 		if(Sticker.login_music_name)
 			var/music_name = SSticker.login_music_name
-			var/dot_position = findtext(music_name, ".")
+			var/dot_position = findlasttext(music_name, ".")
 			if(dot_position)
 				music_name = copytext(music_name, 1, dot_position)
 			to_chat(src, span_redteamradio("<B>Проигрывается музыка в лобби: [music_name]</B>"))


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь музыка в лобби не показывается тем у кого она отключена в преференсах
Так же переводит на Русский что играет в лобби, но не сами треки.

## Причина создания ПР / Почему это хорошо для игры
Упущенные моменты из #1957

## Список изменений

```yml
🆑
fix: Отображение играющего трека в лобби учитывает пресеты в настройках
spellcheck: Отображение в формате "Музыка в лобби: [название]"
/🆑
```
