### PR TITLE
ADD: Уникальный сборщик молний для пиратов Юпитера

### DIFF
--- a/_maps/_mod_celadon/shuttles/pirate/pirate_jupiter.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_jupiter.dmm
@@ -698,7 +698,7 @@
 "kd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/box/red,
-/obj/machinery/power/tesla_coil/tesla_ground,
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "kn" = (
@@ -1927,7 +1927,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/box/red,
-/obj/machinery/power/tesla_coil/tesla_ground,
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "Cy" = (
@@ -2387,7 +2387,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/box/red,
-/obj/machinery/power/tesla_coil/tesla_ground,
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "JI" = (
@@ -2667,7 +2667,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/box/red,
-/obj/machinery/power/tesla_coil/tesla_ground,
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "Ne" = (
@@ -3081,7 +3081,7 @@
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "VC" = (
-/obj/machinery/power/tesla_coil/tesla_ground,
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced,
 /obj/effect/turf_decal/box/red,
 /obj/structure/cable{
 	icon_state = "0-8"

--- a/mod_celadon/structures/_structures.dme
+++ b/mod_celadon/structures/_structures.dme
@@ -6,6 +6,7 @@
 #include "code/obj/barricades.dm"
 #include "code/obj/decals_indestructible.dm"
 #include "code/obj/doors.dm"
+#include "code/obj/enhanced_grounding_rod.dm"
 #include "code/obj/floor.dm"
 #include "code/obj/flooring_decals.dm"
 #include "code/obj/flora.dm"

--- a/mod_celadon/structures/code/obj/enhanced_grounding_rod.dm
+++ b/mod_celadon/structures/code/obj/enhanced_grounding_rod.dm
@@ -1,7 +1,17 @@
+/obj/item/circuitboard/machine/tesla_ground/enhanced
+	name = "Jupiter-class storm harvester (Machine Board)"
+	desc = "Уникальная плата для системы сбора энергии электроштормов кораблей класса Jupiter."
+	build_path = /obj/machinery/power/tesla_coil/tesla_ground/enhanced
+	req_components = list(
+		/obj/item/stock_parts/capacitor/quadratic = 10,
+		/obj/item/stock_parts/matter_bin/bluespace = 5,
+		/obj/item/stack/cable_coil = 50)
+
 /obj/machinery/power/tesla_coil/tesla_ground/enhanced
 	name = "Jupiter-class storm harvester"
 	desc = "Уникальная система сбора энергии электроштормов, разработанная специально для кораблей класса 'Jupiter'. Способна эффективно преобразовывать энергию молний в электричество для корабельных систем."
 	power_loss = 1 // Half the power loss for 2x generation
+	circuit = /obj/item/circuitboard/machine/tesla_ground/enhanced
 
 /obj/machinery/power/tesla_coil/tesla_ground/enhanced/zap_act(power, zap_flags, shocked_targets)
 	if(anchored && !panel_open)

--- a/mod_celadon/structures/code/obj/enhanced_grounding_rod.dm
+++ b/mod_celadon/structures/code/obj/enhanced_grounding_rod.dm
@@ -1,0 +1,17 @@
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced
+	name = "Jupiter-class storm harvester"
+	desc = "Уникальная система сбора энергии электроштормов, разработанная специально для кораблей класса 'Jupiter'. Способна эффективно преобразовывать энергию молний в электричество для корабельных систем."
+	power_loss = 1 // Half the power loss for 2x generation
+
+/obj/machinery/power/tesla_coil/tesla_ground/enhanced/zap_act(power, zap_flags, shocked_targets)
+	if(anchored && !panel_open)
+		obj_flags |= BEING_SHOCKED
+		var/power_produced = powernet ? power / power_loss : power
+		add_avail(power_produced * input_power_multiplier * 2) // 2x power generation
+		flick("coilhit", src)
+		addtimer(CALLBACK(src, PROC_REF(reset_shocked)), 10)
+		zap_buckle_check(power)
+		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
+		return power_produced * 2
+	else
+		. = ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
С новой системой от офов, зарядка пиратского корабля Юпитера, стала невыносимой пыткой, из-за того что мало молний били по коилам, а те выдавали мало энергии что не хватало для корабля и его уникальная фишка была анюзлесс. Пофиксить это сложно, сделав сильными шторма, то и все шторма в игре станут сильными. Я решил пойти иначе, я создал подкласс от тесла коила, уникальная машинерия которая нигде не продается и не изучается, а доступна только Юпитеру. Особенность тесла коила "Jupiter-class storm harvester" в том что у этой машинерии идет пониженая потеря энергии при сборе в 2 раза, из-за чего, выработка энергии также увеличивается в 2 раза.

Но, т.к. это уникальная машинерия для Юпитера, то данная машинерия может быть украдена, разобрана. Так что, берегите свой корабль

## Причина создания ПР / Почему это хорошо для игры
Closed #1953 

## Список изменений

```yml
🆑
add: Новый подкласс тесла коилов специально для Юпитера
/🆑
```
