### PR TITLE
FIX: Удаление шипов после стыковки

### DIFF
--- a/code/modules/overmap/_overmap_datum.dm
+++ b/code/modules/overmap/_overmap_datum.dm
@@ -464,7 +464,7 @@
  *
  * * dock_target - The overmap datum to dock to. Cannot be null.
  */
-/datum/overmap/proc/Dock(datum/overmap/dock_target, obj/docking_port/stationary/override_dock, force = FALSE)
+/datum/overmap/proc/Dock(datum/overmap/dock_target, obj/docking_port/stationary/override_dock, force = FALSE)	// [OVERWRITE] - FIXES_DOCKING - mod_celadon/fixes/code/dock_empty_space_fix.dm
 	SHOULD_CALL_PARENT(TRUE)
 	if(!istype(dock_target))
 		CRASH("Overmap datum [src] tried to dock to an invalid overmap datum.")

--- a/code/modules/overmap/objects/dynamic_datum.dm
+++ b/code/modules/overmap/objects/dynamic_datum.dm
@@ -126,7 +126,7 @@
 				playsound(Mob, landing_sound, 50)
 
 
-/datum/overmap/dynamic/post_undocked(datum/overmap/dock_requester)
+/datum/overmap/dynamic/post_undocked(datum/overmap/dock_requester)	// [OVERWRITE] - FIXES_DOCKING - mod_celadon/fixes/code/dock_empty_space_fix.dm
 	start_countdown()
 
 /datum/overmap/dynamic/proc/start_countdown(_lifespan = 60 SECONDS, _color = null)

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -291,7 +291,7 @@
 /**
  * Docks to an empty dynamic encounter. Used for intership interaction, structural modifications, and such
  */
-/datum/overmap/ship/controlled/proc/dock_in_empty_space()
+/datum/overmap/ship/controlled/proc/dock_in_empty_space()	// [OVERWRITE] - FIXES_DOCKING -mod_celadon/fixes/code/dock_empty_space_fix.dm
 	var/datum/overmap/dynamic/empty/empty_space = locate() in current_overmap.overmap_container[x][y]
 	if(!empty_space)
 		empty_space = new(list("x" = x, "y" = y), current_overmap)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -257,6 +257,11 @@ FIXES_DYNAMIC_MISSION
 
 - `mod_celadon/fixes/code/research_mission.dm` - вроде перезаписывает
 
+dock_empty_space_fix.dm:
+- `Dock(datum/overmap/to_dock, datum/docking_ticket/ticket, force = FALSE)`
+- `dock_in_empty_space()`
+- `post_undocked(datum/overmap/dock_requester)`
+
 <!-- fax_name -->
 <!-- 
 - `code\controllers\subsystem\overmap.dm`: `proc/spawn_ship_at_start`,

--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -40,5 +40,6 @@
 #include "code/dynamic_datum.dm"
 #include "code/security_outfit.dm"
 #include "code/faction.dm"
+#include "code/dock_empty_space_fix.dm"
 
 #endif

--- a/mod_celadon/fixes/code/dock_empty_space_fix.dm
+++ b/mod_celadon/fixes/code/dock_empty_space_fix.dm
@@ -4,7 +4,7 @@
 		if((to_dock.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 30 секунд), блокируем стыковку
 			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
 
-	return ..(to_dock, ticket, force)
+	return ..(to_dock, ticket, force) // А вот это, вызовет родителя со всеми параметрами как обычно
 
 /datum/overmap/ship/controlled/dock_in_empty_space()
 	// Проверяем существующее пустое место на опасность

--- a/mod_celadon/fixes/code/dock_empty_space_fix.dm
+++ b/mod_celadon/fixes/code/dock_empty_space_fix.dm
@@ -1,7 +1,7 @@
 /datum/overmap/ship/controlled/Dock(datum/overmap/to_dock, datum/docking_ticket/ticket, force = FALSE)
 	// Проверяем все динамические объекты с активным таймером удаления - планеты тоже сюда попадают
 	if(istype(to_dock, /datum/overmap/dynamic) && to_dock.token?.countdown && to_dock.death_time)
-		if((to_dock.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 30 секунд), блокируем стыковку
+		if((to_dock.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 15 секунд), блокируем стыковку
 			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
 
 	return ..(to_dock, ticket, force) // А вот это, вызовет родителя со всеми параметрами как обычно

--- a/mod_celadon/fixes/code/dock_empty_space_fix.dm
+++ b/mod_celadon/fixes/code/dock_empty_space_fix.dm
@@ -5,13 +5,15 @@
 			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
 
 	return ..(to_dock, ticket, force) // А вот это, вызовет родителя со всеми параметрами как обычно
+/datum/overmap/proc/is_docking_safe()
+	if(!istype(src, /datum/overmap/dynamic) || !token?.countdown || !death_time)
+		return TRUE
+	return (death_time - world.time) >= 15 SECONDS // Осталось больше 15 секунд?
 
 /datum/overmap/ship/controlled/dock_in_empty_space()
-	// Проверяем существующее пустое место на опасность
 	var/datum/overmap/dynamic/empty/empty_space = locate() in current_overmap.overmap_container[x][y]
-	if(empty_space && empty_space.token?.countdown && empty_space.death_time)
-		if((empty_space.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 30 секунд), блокируем стыковку
-			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
+	if(empty_space && !empty_space.is_docking_safe())
+		return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
 
 	if(!empty_space)
 		empty_space = new(list("x" = x, "y" = y), current_overmap)

--- a/mod_celadon/fixes/code/dock_empty_space_fix.dm
+++ b/mod_celadon/fixes/code/dock_empty_space_fix.dm
@@ -1,0 +1,33 @@
+/datum/overmap/ship/controlled/Dock(datum/overmap/to_dock, datum/docking_ticket/ticket, force = FALSE)
+	// Проверяем все динамические объекты с активным таймером удаления - планеты тоже сюда попадают
+	if(istype(to_dock, /datum/overmap/dynamic) && to_dock.token?.countdown && to_dock.death_time)
+		if((to_dock.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 30 секунд), блокируем стыковку
+			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
+
+	return ..(to_dock, ticket, force)
+
+/datum/overmap/ship/controlled/dock_in_empty_space()
+	// Проверяем существующее пустое место на опасность
+	var/datum/overmap/dynamic/empty/empty_space = locate() in current_overmap.overmap_container[x][y]
+	if(empty_space && empty_space.token?.countdown && empty_space.death_time)
+		if((empty_space.death_time - world.time) < 15 SECONDS)	// Если таймер истек или скоро истечет (менее 30 секунд), блокируем стыковку
+			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
+
+	if(!empty_space)
+		empty_space = new(list("x" = x, "y" = y), current_overmap)
+
+	if(empty_space)
+		Dock(empty_space)
+
+/datum/overmap/dynamic/empty/post_undocked(datum/overmap/dock_requester)
+	// НЕ запускаем таймер удаления сразу после отстыковки
+	// Даем время на возможную повторную стыковку, на подумать игрокам. Даём 10 сек
+	addtimer(CALLBACK(src, PROC_REF(delayed_countdown)), 10 SECONDS)
+
+/datum/overmap/dynamic/empty/proc/delayed_countdown()
+	// Проверяем, не пристыковался ли кто-то за это время
+	if(length(mapzone?.get_mind_mobs()))
+		return // Кто-то есть, не удаляем
+
+	// Запускаем обычный таймер удаления - он равен 60 сек
+	start_countdown()

--- a/mod_celadon/fixes/code/dock_empty_space_fix.dm
+++ b/mod_celadon/fixes/code/dock_empty_space_fix.dm
@@ -5,6 +5,7 @@
 			return "Объект нестабилен и скоро исчезнет. Стыковка отменена."
 
 	return ..(to_dock, ticket, force) // А вот это, вызовет родителя со всеми параметрами как обычно
+
 /datum/overmap/proc/is_docking_safe()
 	if(!istype(src, /datum/overmap/dynamic) || !token?.countdown || !death_time)
 		return TRUE


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляем проверку и защиту от непредвиденного удаления корабля, если игрок решил нажать быстро кнопку докинга. 
Теперь есть двойная защита:
Задержка таймера на 10 секунд - предотвращает немедленное удаление после взлета
Блокировка опасной стыковки - если таймер все же запустился и осталось менее 15 секунд (пока что так)

`P.S. Таймер блокировки общий, то есть и на планеты тоже работает. Если планетам будет недостаточно его, то будет пересмотрено в новом ПРе данная проблема.`

## Причина создания ПР / Почему это хорошо для игры
Closed #1860 

## Список изменений

```yml
🆑
add: Задержка перед удалением 10 сек
add: Проверка на безопасную стыковку 15 сек
/🆑
```
