### PR TITLE
FIX: Исправляем размещение спавнеров на тайлах космоса

### DIFF
--- a/code/game/objects/effects/spawners/mobspawner.dm
+++ b/code/game/objects/effects/spawners/mobspawner.dm
@@ -2,6 +2,10 @@
 	var/static/mob_category = rand(1, 3)
 
 /obj/effect/spawner/random/randomthreat/Initialize(mapload)
+	// [CELADON-ADD] - FIXES_SPAWNERS_ON_SPACE - Проверка на космотурф
+	if(isspaceturf(get_turf(src)))
+		return INITIALIZE_HINT_QDEL
+	// [/CELADON-ADD]
 	switch(mob_category)
 		if(1)
 			loot = list(

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -361,6 +361,11 @@
 	var/mutativeness = 1
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
+	// [CELADON-ADD] - FIXES_SPAWNERS_ON_SPACE - Проверка на космотурф
+	if(isspaceturf(location))
+		qdel(src)
+		return
+	// [/CELADON-ADD]
 	vines = list()
 	growth_queue = list()
 	var/obj/structure/spacevine/SV = spawn_spacevine_piece(location, null, muts)
@@ -393,6 +398,10 @@
 	return ..()
 
 /datum/spacevine_controller/proc/spawn_spacevine_piece(turf/location, obj/structure/spacevine/parent, list/muts)
+	// [CELADON-ADD] - FIXES_SPAWNERS_ON_SPACE - Проверка на космотурф
+	if(isspaceturf(location))
+		return null
+	// [/CELADON-ADD]
 	var/obj/structure/spacevine/SV = new(location)
 	growth_queue += SV
 	vines += SV

--- a/mod_celadon/fixes/FIXES_OFFERING_EFFECTS.txt
+++ b/mod_celadon/fixes/FIXES_OFFERING_EFFECTS.txt
@@ -1,3 +1,0 @@
-FIXES_OFFERING_EFFECTS
-- ADD: `code/datums/status_effects/neutral.dm`
-- EDIT: `code/modules/mob/living/carbon/inventory.dm`

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -245,6 +245,13 @@ FIXES_MODSUITS
 FIXES_DYNAMIC_MISSION
 - EDIT: `code/modules/overmap/objects/dynamic_datum.dm` - Изменена логика в функции can_reset_dynamic(). Теперь объект не будет диспавниться если миссия все еще может быть завершена
 
+FIXES_OFFERING_EFFECTS
+- ADD: `code/datums/status_effects/neutral.dm`
+- EDIT: `code/modules/mob/living/carbon/inventory.dm`
+
+FIXES_SPAWNERS_ON_SPACE - Проверка на космотурф
+- ADD: `code/game/objects/effects/spawners/mobspawner.dm`
+- ADD: `code/modules/events/spacevine.dm`
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляем, дополняем логику выбора спавна для вейнов и карпов озер при осмотре астероидных руин. Убираем возможность им размещаться на тайлах космоса

## Причина создания ПР / Почему это хорошо для игры
Closed #2261 

## Список изменений

```yml
🆑
add: проверки на тайл космоса перед размещением спавнеров
/🆑
```
