### PR TITLE
MAP: Наслоение труб и слабая защита мостика на аванпосту

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -33198,26 +33198,20 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
 "vQf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /obj/machinery/door/airlock{
 	dir = 4;
@@ -33227,17 +33221,7 @@
 	id = "outpost_ghost_janitor";
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/opaque/grey/diagonal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned,
+/turf/open/floor/plasteel/dark,
 /area/outpost/vacant_rooms/shop)
 "vQk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -8876,6 +8876,9 @@
 /area/outpost/fraction/inteq)
 "fLC" = (
 /obj/effect/spawner/structure/window/reinforced/indestructible,
+/obj/machinery/door/poddoor/ert{
+	id = "outpost_bridge_lockdown_inners"
+	},
 /turf/open/floor/plating,
 /area/outpost/operations)
 "fMu" = (
@@ -16145,6 +16148,14 @@
 /obj/item/storage/fancy/cigarettes/cigars/havana,
 /obj/item/lighter/clockwork,
 /obj/effect/spawner/random/celadon_drink,
+/obj/machinery/button/door{
+	id = "outpost_bridge_lockdown_inners";
+	pixel_x = -8;
+	name = "Bridge Lockdown";
+	req_one_access_txt = "8100";
+	dir = 1;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
 "kCQ" = (
@@ -24343,6 +24354,9 @@
 	dir = 1;
 	req_one_access_txt = "8100"
 	},
+/obj/machinery/door/poddoor/ert{
+	id = "outpost_bridge_lockdown_inners"
+	},
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "qdS" = (
@@ -31424,6 +31438,10 @@
 	security_level = 6;
 	dir = 8;
 	req_one_access_txt = "8100"
+	},
+/obj/machinery/door/poddoor/ert{
+	id = "outpost_bridge_lockdown_inners";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)


### PR DESCRIPTION
## Описание / Что этот PR делает
Честно, я удалял этот баг, но он снова вылез т_т
А насчет мостика. Часто борги после емага умудряются попасть на мостик аванпоста и творить дичь потом. Исправляем. Ставим бласт доры и кнопку смотрителю аванпоста

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
del: лишние трубы
add: защиту для мостика аванпоста
/🆑
```
