### PR TITLE
MAP: some fixes outposts

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -36,7 +36,8 @@
 	pixel_x = -28;
 	pixel_y = 6;
 	id = "outpost_security_desk";
-	name = "Desk Shutter"
+	name = "Desk Shutter";
+	req_one_access_txt = "8100"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
@@ -547,9 +548,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
 "awC" = (
@@ -938,6 +936,13 @@
 	dir = 4;
 	mouse_opacity = 0;
 	pixel_x = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -1510,23 +1515,21 @@
 "bdA" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
+	dir = 8
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 8;
-	pixel_x = 26
 	},
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/machinery/camera/autoname{
 	pixel_y = 11;
 	network = list("outpostelysium")
 	},
+/obj/machinery/door/window/brigdoor/eastright{
+	req_one_access_txt = "8126"
+	},
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/carpet/red_gold,
 /area/outpost/fraction/syndi/donkco_shop)
 "bdG" = (
@@ -2811,9 +2814,6 @@
 	dir = 1
 	},
 /obj/structure/curtain,
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/surgery_1)
 "bXC" = (
@@ -3734,11 +3734,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/reinforced/tinted/shutters{
-	alpha = 0;
-	mouse_opacity = 0;
-	anchored = 1
-	},
+/obj/structure/grille/indestructible,
 /turf/open/floor/mineral/plastitanium,
 /area/outpost/fraction/syndi)
 "cAo" = (
@@ -4151,9 +4147,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/industrial/warning,
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium{
-	anchored = 1
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/mineral/plastitanium,
 /area/outpost/fraction/syndi)
 "cLN" = (
@@ -4184,19 +4178,17 @@
 "cOe" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
+	dir = 8
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 8;
-	pixel_x = 26
-	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_one_access_txt = "8126"
+	},
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/carpet/red_gold,
 /area/outpost/fraction/syndi/donkco_shop)
 "cOn" = (
@@ -6458,16 +6450,19 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "ejk" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/structure/railing/wood{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
 	},
-/obj/structure/railing/wood{
-	layer = 3.1;
-	pixel_y = 29
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
 	},
-/turf/open/floor/grass,
-/area/outpost/hallway/central)
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/canteen)
 "ejS" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
 /obj/structure/crate_shelf,
@@ -7898,6 +7893,10 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south{
+	req_access_txt = "8100, 8111";
+	layer = 3
+	},
 /turf/open/floor/wood,
 /area/outpost/crew/dorm)
 "ffy" = (
@@ -8094,8 +8093,7 @@
 	},
 /obj/machinery/door/window/brigdoor/security{
 	req_one_access_txt = "8123";
-	pixel_x = 26;
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_1)
@@ -9399,12 +9397,7 @@
 /turf/open/chasm,
 /area/outpost/fraction/inteq)
 "ghu" = (
-/obj/effect/portal/permanent/one_way{
-	id = "outpost_trash_portal";
-	alpha = 0;
-	mouse_opacity = 0
-	},
-/turf/open/floor/plating/asteroid/icerock/temperate,
+/turf/open/chasm,
 /area/outpost/fraction/syndi)
 "ghO" = (
 /obj/structure/chair/sofa/brown/corner/directional/north,
@@ -9645,7 +9638,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/corner/transparent/mauve/three_quarters,
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/white,
@@ -10049,7 +10042,8 @@
 	dir = 8
 	},
 /obj/structure/guncloset{
-	req_one_access_txt = "8125"
+	req_one_access_txt = "8125";
+	anchored = 1
 	},
 /obj/item/gun/ballistic/shotgun/doublebarrel/presawn,
 /turf/open/floor/wood/mahogany,
@@ -10192,9 +10186,6 @@
 	pixel_y = 27
 	},
 /obj/structure/curtain,
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/surgery_2)
 "gJw" = (
@@ -10500,9 +10491,6 @@
 /turf/open/floor/plasteel/sepia,
 /area/outpost/crew/canteen)
 "gRu" = (
-/obj/machinery/door/window{
-	pixel_y = -6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11013,9 +11001,6 @@
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/south{
-	req_access_txt = "8100, 8111"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
@@ -11154,6 +11139,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -12367,7 +12355,8 @@
 /area/outpost/operations)
 "ien" = (
 /obj/structure/filingcabinet/double{
-	pixel_y = 9
+	pixel_y = 9;
+	density = 0
 	},
 /obj/structure/sign/solgov_flag{
 	pixel_y = 32
@@ -12762,7 +12751,7 @@
 "isZ" = (
 /obj/machinery/computer/cargo/faction/inteq,
 /turf/open/floor/plasteel/tech/techmaint,
-/area/outpost/fraction/inteq)
+/area/outpost/cargo/faction/inteq)
 "itc" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/box/corners{
@@ -13241,6 +13230,7 @@
 	tag = null
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/outpost/cargo)
 "iJr" = (
@@ -13966,6 +13956,10 @@
 /obj/structure/mopbucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
+/obj/machinery/door/window{
+	req_one_access_txt = "8126";
+	mouse_opacity = 0
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/outpost/medical/relax_room)
 "jfz" = (
@@ -14308,9 +14302,6 @@
 /turf/open/floor/plating,
 /area/outpost/maintenance/aft)
 "jqG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -14772,6 +14763,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -15820,10 +15814,6 @@
 /obj/machinery/door/window/survival_pod{
 	dir = 8;
 	pixel_x = -8
-	},
-/obj/item/clothing/shoes/sandal{
-	pixel_x = -5;
-	pixel_y = 13
 	},
 /obj/machinery/light/small/directional/east{
 	pixel_y = 16
@@ -17280,9 +17270,13 @@
 	req_access_txt = "8100, 8111"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 1;
-	pixel_x = -23;
+	pixel_y = 13;
+	pixel_x = -22;
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/west{
+	req_access_txt = "8100, 8111";
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/surgery_2)
@@ -18100,9 +18094,6 @@
 	name = "Elysium Town"
 	})
 "lQd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -18110,6 +18101,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "lQs" = (
@@ -18413,6 +18407,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "lYn" = (
@@ -18573,6 +18570,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -18770,10 +18770,10 @@
 /obj/machinery/power/apc/auto_name/directional/south{
 	req_access_txt = "8100, 8111"
 	},
-/obj/machinery/airalarm/directional/west{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/relax_room)
 "miF" = (
@@ -20996,23 +20996,17 @@
 "nVz" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
+	dir = 8
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 8;
-	pixel_x = 26
-	},
+/obj/structure/window/reinforced/spawner,
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/carpet/red_gold,
 /area/outpost/fraction/syndi/donkco_shop)
 "nVF" = (
@@ -22092,7 +22086,7 @@
 	},
 /obj/item/clothing/shoes/sandal{
 	pixel_x = -5;
-	pixel_y = 13
+	pixel_y = 8
 	},
 /turf/open/floor/wood/birch{
 	planetary_atmos = 1
@@ -22862,6 +22856,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/east{
+	req_access_txt = "8100, 8111"
+	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo/office)
 "phq" = (
@@ -23630,7 +23627,6 @@
 "pCA" = (
 /obj/structure/chair{
 	dir = 4;
-	pixel_x = 20;
 	layer = 2.05
 	},
 /turf/open/floor/carpet/black,
@@ -24059,9 +24055,6 @@
 /area/outpost/operations)
 "pQn" = (
 /obj/structure/bookcase/random/fiction,
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "pQy" = (
@@ -24161,10 +24154,6 @@
 /area/outpost/fraction/syndi)
 "pVx" = (
 /obj/structure/table/wood,
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	name = "Syndicate Radio Intercom"
-	},
 /obj/item/folder/red{
 	pixel_x = 3
 	},
@@ -24997,9 +24986,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
-	},
-/obj/machinery/recharge_station{
-	pixel_y = 22
 	},
 /turf/open/floor/wood,
 /area/outpost/crew/dop_zone_3)
@@ -26224,9 +26210,13 @@
 	req_access_txt = "8100, 8111"
 	},
 /obj/machinery/light_switch{
-	pixel_y = 1;
-	pixel_x = -23;
+	pixel_y = 13;
+	pixel_x = -22;
 	dir = 4
+	},
+/obj/machinery/airalarm/directional/west{
+	req_access_txt = "8100, 8111";
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/surgery_1)
@@ -27485,7 +27475,8 @@
 "sdR" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 4;
-	pixel_x = -6
+	pixel_x = -6;
+	density = 0
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
@@ -27587,6 +27578,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	name = "Syndicate Radio Intercom"
+	},
 /turf/open/floor/plasteel/rockvault,
 /area/outpost/operations)
 "shK" = (
@@ -28108,7 +28103,8 @@
 	})
 "sCZ" = (
 /obj/machinery/vending/boozeomat/outpost_access{
-	pixel_y = -32
+	pixel_y = -32;
+	density = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -28132,16 +28128,6 @@
 /obj/item/chair/greyscale,
 /turf/open/floor/plasteel/rockvault,
 /area/outpost/hallway/central)
-"sEj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window{
-	dir = 1;
-	req_one_access_txt = "8126";
-	mouse_opacity = 0;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/outpost/medical/relax_room)
 "sEx" = (
 /obj/item/paper{
 	pixel_x = 3;
@@ -28517,7 +28503,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west{
+/obj/machinery/airalarm/directional/east{
 	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
@@ -28964,7 +28950,8 @@
 /area/outpost/crew/garden)
 "thV" = (
 /obj/machinery/coffeemaker/premium{
-	pixel_y = 13
+	pixel_y = 13;
+	density = 0
 	},
 /obj/structure/table/wood/reinforced/bar,
 /turf/open/floor/wood/mahogany,
@@ -29116,6 +29103,9 @@
 	},
 /obj/effect/turf_decal/trimline/opaque/nsorange/line{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -30230,9 +30220,6 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
 /obj/effect/landmark/ert_outpost_spawn,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/armory)
@@ -30634,16 +30621,12 @@
 "uok" = (
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/plasma,
-/obj/machinery/power/apc/auto_name/directional/east{
-	req_access_txt = "8100, 8111"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo/office)
@@ -34361,6 +34344,13 @@
 /area/outpost/fraction/syndi)
 "wGq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/east{
+	req_access_txt = "8100, 8111"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo/office)
 "wGx" = (
@@ -34537,10 +34527,6 @@
 /obj/structure/marker_beacon,
 /turf/open/space/basic,
 /area/space)
-"wLZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
-/area/outpost/fraction/syndi)
 "wMK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/industrial/warning{
@@ -34714,6 +34700,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/structure/railing/wood{
+	layer = 3.1;
+	pixel_y = -3
+	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
 "wUc" = (
@@ -34735,6 +34725,9 @@
 	dir = 4
 	},
 /obj/item/trash/popcorn,
+/obj/machinery/light/colored/white/directional/south{
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "wVg" = (
@@ -35490,6 +35483,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south{
+	req_access_txt = "8100, 8111"
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/vacant_rooms/shop)
 "xCz" = (
@@ -35910,6 +35906,10 @@
 /obj/item/clothing/gloves/color/latex/nitrile/evil,
 /obj/item/storage/box/maid,
 /obj/effect/spawner/random/trash/janitor_supplies,
+/obj/machinery/door/window{
+	mouse_opacity = 0;
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/outpost/vacant_rooms/shop)
 "xRn" = (
@@ -36295,13 +36295,6 @@
 	dir = 8;
 	pixel_x = -4;
 	mouse_opacity = 0
-	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	req_access_txt = "8100, 8111"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
 	},
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_y = 10;
@@ -44707,7 +44700,7 @@ cGD
 cGD
 cGD
 jff
-wLZ
+jff
 sxr
 osl
 lVV
@@ -50657,7 +50650,7 @@ qqR
 gEb
 mlt
 wTI
-ejk
+gns
 mDW
 xYy
 mDW
@@ -62288,7 +62281,7 @@ aIl
 eER
 wdO
 wdO
-wdO
+ejk
 aIl
 aIl
 aIl
@@ -63364,7 +63357,7 @@ cGD
 cGD
 jJe
 jfv
-sEj
+ilq
 oFB
 ilq
 dyQ

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1969,7 +1969,6 @@
 	pixel_y = 21;
 	pixel_x = 8
 	},
-/obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
@@ -1980,6 +1979,10 @@
 /obj/item/reagent_containers/glass/rag{
 	pixel_y = 3;
 	pixel_x = 8
+	},
+/obj/structure/closet/secure_closet/medical3{
+	req_access = null;
+	req_one_access_txt = "8118"
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/outpost/medical/morgue)
@@ -13957,8 +13960,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/machinery/door/window{
-	req_one_access_txt = "8126";
-	mouse_opacity = 0
+	req_one_access_txt = "8123"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/outpost/medical/relax_room)
@@ -25117,11 +25119,6 @@
 	pixel_y = 26
 	},
 /obj/structure/table/wood/reinforced/bar,
-/obj/machinery/reagentgrinder{
-	pixel_y = 12;
-	layer = 4.25;
-	pixel_x = 4
-	},
 /obj/item/reagent_containers/condiment/saltshaker{
 	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
 	pixel_x = -4;
@@ -25133,6 +25130,11 @@
 	pixel_y = 2
 	},
 /obj/machinery/light/colored/directional/east,
+/obj/machinery/reagentgrinder/constructed{
+	pixel_y = 10;
+	pixel_x = 5;
+	layer = 4.3
+	},
 /turf/open/floor/wood/mahogany,
 /area/outpost/crew/bar/bar_zone)
 "qFz" = (
@@ -28951,7 +28953,8 @@
 "thV" = (
 /obj/machinery/coffeemaker/premium{
 	pixel_y = 13;
-	density = 0
+	density = 0;
+	layer = 4
 	},
 /obj/structure/table/wood/reinforced/bar,
 /turf/open/floor/wood/mahogany,
@@ -35907,7 +35910,6 @@
 /obj/item/storage/box/maid,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /obj/machinery/door/window{
-	mouse_opacity = 0;
 	dir = 1
 	},
 /turf/open/floor/plasteel/tech/grid,

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -1170,16 +1170,17 @@
 /area/outpost/operations/outpost_command)
 "aHU" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 4;
-	pixel_x = -26
+/obj/item/toy/plush/celadon/separ,
+/obj/machinery/door/window/brigdoor/westright{
+	req_one_access_txt = "8126"
+	},
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 2
 	},
-/obj/item/toy/plush/celadon/separ,
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -1874,10 +1875,6 @@
 /obj/machinery/door/window{
 	dir = 8;
 	req_one_access_txt = "8126"
-	},
-/obj/structure/window{
-	dir = 1;
-	pixel_y = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -3373,9 +3370,11 @@
 	},
 /area/outpost/exterior)
 "bVy" = (
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/east{
+	pixel_y = 4
+	},
 /obj/machinery/button/door{
-	pixel_y = -15;
+	pixel_y = -13;
 	id = "ice_cabinka_bar_1";
 	name = "Bolt Door Cab 1";
 	pixel_x = 23;
@@ -4400,6 +4399,10 @@
 	planetary_atmos = 1
 	},
 /area/outpost/medical/cmo)
+"cAv" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/ebony,
+/area/outpost/crew/bar/bar_zone)
 "cAJ" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/flora/grass/jungle,
@@ -4837,18 +4840,20 @@
 /area/outpost/medical/morgue)
 "cOz" = (
 /obj/machinery/power/apc/auto_name/directional/east{
-	req_access_txt = "8100, 8111"
+	req_access_txt = "8100, 8111";
+	pixel_y = -3
 	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
 /obj/structure/guncloset{
-	req_one_access_txt = "8125"
+	req_one_access_txt = "8125";
+	anchored = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
 	pixel_x = 8;
-	pixel_y = 9;
+	pixel_y = 11;
 	network = list("outpostelysium")
 	},
 /obj/structure/curtain/cloth/fancy,
@@ -5021,20 +5026,17 @@
 /area/outpost/medical/chemestry)
 "cTe" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
 /obj/item/toy/plush/celadon/rimri/snow,
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -5066,7 +5068,8 @@
 	},
 /obj/effect/turf_decal/corner/opaque/blue/diagonal,
 /obj/item/storage/firstaid/medical,
-/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/case/surgery,
+/obj/item/clothing/glasses/hud/health/prescription,
 /turf/open/floor/plasteel/dark_2,
 /area/outpost/medical/surgery_2)
 "cUM" = (
@@ -5295,13 +5298,19 @@
 	id = "freeSyndicateFaction";
 	teleport_channel = "free"
 	},
-/obj/structure/platform/industrial_alt/indestructible{
-	dir = 4
-	},
-/obj/structure/platform/industrial_alt/indestructible{
-	dir = 8
-	},
 /obj/machinery/light/colored/red/directional/north,
+/obj/structure/platform/industrial_alt{
+	dir = 4;
+	density = 0;
+	max_integrity = 200000;
+	mouse_opacity = 0
+	},
+/obj/structure/platform/industrial_alt{
+	dir = 8;
+	density = 0;
+	max_integrity = 200000;
+	mouse_opacity = 0
+	},
 /turf/open/floor/glass/red_four,
 /area/outpost/fraction/syndi/donkco_shop)
 "daP" = (
@@ -8284,16 +8293,15 @@
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
 	pixel_x = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	pixel_y = 2
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "eEs" = (
@@ -8948,13 +8956,12 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
 	pixel_y = 2
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "eWm" = (
@@ -9209,8 +9216,11 @@
 	},
 /area/outpost/crew/canteen)
 "feB" = (
-/obj/structure/platform/industrial_alt/indestructible{
-	dir = 1
+/obj/structure/platform/industrial_alt{
+	dir = 1;
+	density = 0;
+	max_integrity = 200000;
+	mouse_opacity = 0
 	},
 /turf/open/floor/carpet/red_gold{
 	planetary_atmos = 1
@@ -9970,7 +9980,8 @@
 /area/outpost/exterior)
 "fyx" = (
 /obj/structure/guncloset{
-	req_one_access_txt = "8125"
+	req_one_access_txt = "8125";
+	anchored = 1
 	},
 /obj/item/gun/ballistic/shotgun/doublebarrel/presawn,
 /turf/open/floor/wood/ebony,
@@ -12013,7 +12024,10 @@
 /turf/open/floor/plasteel/white,
 /area/outpost/crew/canteen)
 "gBY" = (
-/obj/structure/closet/secure_closet/medical3,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = null;
+	req_one_access_txt = "8118"
+	},
 /obj/item/storage/case/surgery,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
@@ -13217,9 +13231,6 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "hmS" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -14517,6 +14528,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/item/storage/firstaid/medical,
+/obj/item/storage/case/surgery,
+/obj/item/clothing/glasses/hud/health/prescription,
 /turf/open/floor/plasteel/dark_2,
 /area/outpost/medical/surgery_2)
 "hYb" = (
@@ -14587,6 +14601,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/patterned,
 /area/outpost/security/reseption)
+"iat" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 2
+	},
+/obj/structure/window,
+/turf/open/floor/wood/walnut{
+	planetary_atmos = 1
+	},
+/area/outpost/fraction/syndi/donkco_shop)
 "iaF" = (
 /obj/effect/turf_decal/corner/opaque/grey/full,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -14670,20 +14694,17 @@
 /area/outpost/crew/lounge/cab_1)
 "icI" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
 /obj/item/toy/plush/celadon/rimri,
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -15358,10 +15379,15 @@
 /area/outpost/medical/hall_2)
 "irJ" = (
 /obj/machinery/computer/arcade/orion_trail{
-	pixel_y = 14
+	pixel_y = 14;
+	density = 0
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
+	},
+/obj/structure/chair/stool/bar{
+	dir = 1;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet/orange,
 /area/outpost/medical/relax_room)
@@ -15717,7 +15743,8 @@
 /obj/structure/filingcabinet/employment{
 	dir = 4;
 	pixel_x = -11;
-	pixel_y = 0
+	pixel_y = 0;
+	density = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
@@ -15773,6 +15800,9 @@
 	pixel_y = 2
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "iEa" = (
@@ -16378,6 +16408,11 @@
 "iVJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -5;
+	pixel_x = 22;
+	dir = 8
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/crew/bar/bar_zone)
@@ -18206,9 +18241,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -18395,7 +18427,7 @@
 	pixel_y = 14;
 	network = list("outpostelysium")
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/ebony,
 /area/outpost/crew/bar/theatre)
 "kea" = (
@@ -18498,10 +18530,6 @@
 "kfT" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
@@ -18509,6 +18537,9 @@
 	req_one_access_txt = "8126"
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "kgq" = (
@@ -19029,9 +19060,6 @@
 /obj/structure/chair/sofa/olive/directional{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west{
-	req_access_txt = "8100, 8111"
-	},
 /turf/open/floor/carpet/green,
 /area/outpost/fraction/separatist)
 "kxJ" = (
@@ -19452,6 +19480,7 @@
 /obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/turf_decal/corner/opaque/neutral/diagonal,
 /obj/item/kirbyplants/random,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plasteel/white,
 /area/outpost/crew/canteen)
 "kKK" = (
@@ -20990,8 +21019,8 @@
 	req_access_txt = "8100, 8111"
 	},
 /obj/machinery/light_switch{
-	pixel_y = -5;
-	pixel_x = 22;
+	pixel_y = 12;
+	pixel_x = 20;
 	dir = 8
 	},
 /obj/structure/cable{
@@ -21134,6 +21163,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/item/storage/firstaid/medical,
+/obj/item/storage/case/surgery,
+/obj/item/clothing/glasses/hud/health/prescription,
 /turf/open/floor/plasteel/dark_2,
 /area/outpost/medical/surgery_2)
 "lJa" = (
@@ -25452,9 +25484,7 @@
 /turf/open/floor/plating,
 /area/outpost/medical/hall_2)
 "och" = (
-/obj/machinery/firealarm/directional/west{
-	pixel_y = 18
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/corner/opaque/ntblue{
 	dir = 9
 	},
@@ -25514,20 +25544,17 @@
 /area/outpost/exterior)
 "ocv" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
 /obj/item/toy/plush/celadon/kira,
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -25550,11 +25577,15 @@
 /turf/open/floor/wood,
 /area/outpost/fraction/nanotrasen)
 "odl" = (
-/obj/structure/platform/industrial_alt/corner/indestructible{
-	dir = 8
+/obj/structure/platform/industrial_alt/corner{
+	dir = 4;
+	mouse_opacity = 0;
+	max_integrity = 200000
 	},
-/obj/structure/platform/industrial_alt/corner/indestructible{
-	dir = 4
+/obj/structure/platform/industrial_alt/corner{
+	dir = 8;
+	mouse_opacity = 0;
+	max_integrity = 200000
 	},
 /turf/open/floor/carpet/red_gold{
 	planetary_atmos = 1
@@ -26387,18 +26418,17 @@
 "ozs" = (
 /obj/structure/table/wood/fancy/red,
 /obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	pixel_y = 28
-	},
-/obj/structure/window/reinforced/spawner{
 	dir = 4;
 	pixel_x = 3
 	},
 /obj/item/passport/cobrastan,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_one_access_txt = "8126";
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
 /turf/open/floor/carpet/red_gold{
 	planetary_atmos = 1
 	},
@@ -27084,7 +27114,8 @@
 /obj/machinery/photocopier{
 	pixel_x = -3;
 	pixel_y = -11;
-	layer = 2.79
+	layer = 2.79;
+	density = 0
 	},
 /turf/open/floor/marble/black_white_border,
 /area/outpost/fraction/nanotrasen)
@@ -28329,7 +28360,8 @@
 	},
 /obj/structure/filingcabinet/employment{
 	dir = 1;
-	pixel_x = 11
+	pixel_x = 11;
+	density = 0
 	},
 /turf/open/floor/plasteel/tech/techmaint,
 /area/outpost/fraction/inteq)
@@ -29165,7 +29197,8 @@
 /area/outpost/exterior)
 "qgn" = (
 /obj/structure/guncloset{
-	req_one_access_txt = "8125"
+	req_one_access_txt = "8125";
+	anchored = 1
 	},
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/ebony,
@@ -29194,7 +29227,9 @@
 /obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/turf_decal/corner/opaque/neutral/diagonal,
 /obj/structure/closet/secure_closet/personal{
-	pixel_x = 10
+	pixel_x = 10;
+	req_one_access_txt = "8124";
+	req_access = null
 	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
@@ -29753,6 +29788,7 @@
 /obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/effect/turf_decal/corner/opaque/neutral/diagonal,
 /obj/item/kirbyplants/random,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -29803,10 +29839,6 @@
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
 	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
 	pixel_x = 3
 	},
 /obj/structure/window/reinforced/spawner{
@@ -29817,6 +29849,9 @@
 	req_one_access_txt = "8126"
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "qvM" = (
@@ -29922,10 +29957,6 @@
 /turf/open/floor/wood,
 /area/outpost/security/detective)
 "qyo" = (
-/obj/structure/chair/stool/bar{
-	dir = 1;
-	pixel_y = 23
-	},
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -30052,16 +30083,17 @@
 /area/outpost/engineering)
 "qBL" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 8;
-	pixel_x = 26
+/obj/item/toy/plush/celadon/rd,
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
 	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
-	pixel_y = -26
+	pixel_y = 2
 	},
-/obj/item/toy/plush/celadon/rd,
+/obj/machinery/door/window/brigdoor/eastright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -32249,20 +32281,17 @@
 /area/outpost/vacant_rooms/trash_factory)
 "rOW" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
 /obj/item/toy/plush/celadon/mira,
+/obj/machinery/door/window/brigdoor/westright{
+	req_one_access_txt = "8126"
+	},
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -36704,20 +36733,17 @@
 /area/outpost/cargo)
 "uow" = (
 /obj/structure/rack,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "8126";
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 1;
 	pixel_y = 2
 	},
 /obj/item/toy/plush/celadon/tora,
+/obj/structure/window/reinforced/spawner{
+	pixel_y = -2
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	req_one_access_txt = "8126"
+	},
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -39620,14 +39646,6 @@
 /area/outpost/cargo)
 "wbh" = (
 /obj/structure/rack,
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = 3
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
-	},
 /obj/machinery/door/window/brigdoor/southleft{
 	req_one_access_txt = "8126"
 	},
@@ -39636,6 +39654,9 @@
 	pixel_y = 2
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "wbj" = (
@@ -39907,10 +39928,6 @@
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner{
 	dir = 4;
-	pixel_x = -26
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
 	pixel_x = 3
 	},
 /obj/machinery/door/window/brigdoor/southleft{
@@ -39918,6 +39935,9 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "win" = (
@@ -43734,15 +43754,14 @@
 /area/outpost/vacant_rooms/trash_factory)
 "yhw" = (
 /obj/structure/rack,
-/obj/structure/window/reinforced/spawner{
-	dir = 4;
-	pixel_x = -26
-	},
 /obj/machinery/door/window/brigdoor/southleft{
 	req_one_access_txt = "8126";
 	dir = 1
 	},
 /obj/effect/spawner/random/entertainment/plushie_celadon_all,
+/obj/structure/window/reinforced/spawner/west{
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
 "yil" = (
@@ -58375,7 +58394,7 @@ nPD
 vys
 uJI
 jdA
-roS
+cAv
 fyx
 tEq
 vys
@@ -60480,7 +60499,7 @@ heV
 juA
 gok
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT
@@ -60667,7 +60686,7 @@ heV
 gok
 gok
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT
@@ -61236,7 +61255,7 @@ nTE
 fNi
 wbr
 dMX
-wbr
+iat
 aYp
 eVM
 eVM
@@ -61415,7 +61434,7 @@ ava
 bXl
 gok
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT
@@ -61602,7 +61621,7 @@ gJf
 kvi
 gok
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT
@@ -62350,7 +62369,7 @@ heV
 gok
 gok
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT
@@ -62537,7 +62556,7 @@ heV
 gok
 juA
 aUT
-iDZ
+wbh
 fNi
 yhw
 kfT


### PR DESCRIPTION
## Описание / Что этот PR делает
Различные фиксы аванпостов.
## Причина создания ПР / Почему это хорошо для игры
Правка ошибок.
## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
fix: Заказы интеков теперь приходят куда надо, а мусор в синди карго отправляется в чазм (астероид), забор более не блокирует возможность попасть в синди карго (зимний), замена плохо размещенных стекол, заборов и стеклянных дверей, коллизия некоторых объектов была убрана (мешают ходить и взаимодействовать где это должно быть возможно), перемещение некоторых апц в нормальные места, добавлен свет в слишком темные места, убран лишний зарядник из комнаты отдыха (он находился за забором в книжном шкафу), выдан корректный доступ к шкафам и дверям.
map: Убраны лишние и добавлены пропущенные аир алярмы.
/🆑
```
