### PR TITLE
UPDATE: Новое-старое меню лодаута

### DIFF
--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -1,26 +1,32 @@
 GLOBAL_LIST_EMPTY(loadout_categories)
 GLOBAL_LIST_EMPTY(gear_datums)
-GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские категории
+GLOBAL_LIST_EMPTY(loadout_parent_categories) // [CELADON-ADD] - CELADON_QOL_LOADOUT - Родительские категории
 
 /datum/loadout_category
 	var/category = ""
+	 // [CELADON-ADD] - CELADON_QOL_LOADOUT
 	var/parent_category = "" // Родительская категория
 	var/category_icon = "" // Иконка категории
 	var/category_order = 0 // Порядок сортировки
 	var/list/subcategories = list() // Подкатегории
+	 // [/CELADON-ADD]
 	var/list/gear = list()
 
+// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+// /datum/loadout_category/New(cat)	// ORIGINAL
 /datum/loadout_category/New(cat, parent = "", icon = "", order = 0)
+// [/CELADON-EDIT]
 	category = cat
+	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 	parent_category = parent
 	category_icon = icon
 	category_order = order
+	// [/CELADON-ADD]
 	..()
 
 ///Create a list of gear datums to sort
 /proc/populate_gear_list()
-	// Создаем родительские категории
-	create_parent_categories()
+	create_parent_categories()	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 
 	for(var/geartype in subtypesof(/datum/gear))
 		var/datum/gear/G = geartype
@@ -38,26 +44,36 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 			WARNING("Loadout gear [G] is missing path definition")
 			continue
 
-		// Получаем информацию о категории
+		// [CELADON-ADD] - CELADON_QOL_LOADOUT - Получаем информацию о категории
 		var/category_info = get_category_info(use_category)
 		var/parent_cat = category_info["parent"]
 		var/cat_icon = category_info["icon"]
 		var/cat_order = category_info["order"]
+		// [/CELADON-ADD]
 
 		if(!GLOB.loadout_categories[use_category])
+			// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+			// GLOB.loadout_categories[use_category] = new /datum/loadout_category(use_category)	// ORIGINAL
 			GLOB.loadout_categories[use_category] = new /datum/loadout_category(use_category, parent_cat, cat_icon, cat_order)
+			// [/CELADON-EDIT]
 
-			// Добавляем в родительскую категорию
+			// [CELADON-ADD] - CELADON_QOL_LOADOUT - Добавляем в родительскую категорию
 			if(parent_cat && GLOB.loadout_parent_categories[parent_cat])
 				var/datum/loadout_category/parent_LC = GLOB.loadout_parent_categories[parent_cat]
 				parent_LC.subcategories[use_category] = GLOB.loadout_categories[use_category]
+			// [/CELADON-ADD]
 
 		var/datum/loadout_category/LC = GLOB.loadout_categories[use_category]
 		GLOB.gear_datums[use_name] = new geartype
 		LC.gear[use_name] = GLOB.gear_datums[use_name]
 
-	// Сортируем категории
-	sort_categories()
+	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
+	// GLOB.loadout_categories = sortAssoc(GLOB.loadout_categories)
+	// for(var/loadout_category in GLOB.loadout_categories)
+	// 	var/datum/loadout_category/LC = GLOB.loadout_categories[loadout_category]
+	// 	LC.gear = sortAssoc(LC.gear)
+	// [/CELADON-REMOVE]
+	sort_categories()	// [CELADON-ADD] - CELADON_QOL_LOADOUT - Сортируем категории
 	return 1
 
 /datum/gear
@@ -152,6 +168,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 
 	return new gd.path(gd.location)
 
+// [CELADON-ADD] - CELADON_QOL_LOADOUT
 ///Создаем родительские категории
 /proc/create_parent_categories()
 	GLOB.loadout_parent_categories["Clothing"] = new /datum/loadout_category("Одежда", "", "icons/obj/clothing/suits.dmi", 1)
@@ -225,10 +242,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 ///Генерирует древовидную навигацию для loadout
 /proc/generate_loadout_tree_navigation(current_tab)
 	var/list/dat = list()
-	// [CELADON-EDIT] - CELADON_QOL_LOADOUT
-	// dat += "<center><b>"	// ORIGINAL
 	dat += "<div style='text-align: center; margin: 5px 0; padding: 5px; background: #2a2a2a; border-radius: 5px;'>"
-	// [/CELADON-EDIT]
 	var/firstcat = 1
 	for(var/category in GLOB.loadout_categories)
 		if(firstcat)
@@ -236,24 +250,16 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		else
 			dat += " | "
 		if(category == current_tab)
-		// [CELADON-EDIT] - CELADON_QOL_LOADOUT
-		// dat += "<font color='#90EE90'><b>[category]</b></font>"	// ORIGINAL
 			dat += "<span style='color: #90EE90; font-weight: bold; padding: 2px 6px; background: #3a3a3a; border-radius: 3px;'>[category]</span>"
 		else
-		// [/CELADON-EDIT]
-	// [CELADON-EDIT] - CELADON_QOL_LOADOUT
-	// 		dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]'>[category]</a>"
-	// dat += "</b></center>"	// ORIGINAL
 			dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]' style='color: #87CEEB; text-decoration: none; padding: 2px 6px; border-radius: 3px;'>[category]</a>"
 	dat += "</div>"
-	// [/CELADON-EDIT]
 	return dat.Join()
 
 ///Генерирует CSS стили для древовидной навигации
 /proc/generate_loadout_tree_styles()
 	return ""
 
-// [CELADON-ADD] - CELADON_QOL_LOADOUT - Пускай все в одном месте будет
 ///Автоматически генерирует теги для предмета
 /datum/gear/proc/generate_auto_tags()
 	// Добавляем тег категории

--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // [CELADON-ADD] - CELADON_QOL_LOAD
 	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 	///Factions that can spawn with this item.
 	var/list/allowed_factions
-	// Примеры 	allowed_factions = list("NanoTrasen", ...)
+	// Примеры 	allowed_factions = list("NanoTrasen", "Syndicate", "Independent", "SolFed", "Pirates", "Elysium")
 	// [/CELADON-ADD]
 	///Stop certain species from receiving this gear
 	var/list/species_blacklist

--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // [CELADON-ADD] - CELADON_QOL_LOAD
 	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 	///Factions that can spawn with this item.
 	var/list/allowed_factions
-	// Примеры 	allowed_factions = list("NanoTrasen", "Syndicate", "Independent", "SolFed", "Pirates", "Elysium")
+	// Примеры 	allowed_factions = list("NanoTrasen", "Syndicate", "Independent", "InteQ", "SolFed", "Pirates", "Elysium")
 	// [/CELADON-ADD]
 	///Stop certain species from receiving this gear
 	var/list/species_blacklist

--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 /proc/populate_gear_list()
 	// Создаем родительские категории
 	create_parent_categories()
-	
+
 	for(var/geartype in subtypesof(/datum/gear))
 		var/datum/gear/G = geartype
 
@@ -46,12 +46,12 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 
 		if(!GLOB.loadout_categories[use_category])
 			GLOB.loadout_categories[use_category] = new /datum/loadout_category(use_category, parent_cat, cat_icon, cat_order)
-			
+
 			// Добавляем в родительскую категорию
 			if(parent_cat && GLOB.loadout_parent_categories[parent_cat])
 				var/datum/loadout_category/parent_LC = GLOB.loadout_parent_categories[parent_cat]
 				parent_LC.subcategories[use_category] = GLOB.loadout_categories[use_category]
-			
+
 		var/datum/loadout_category/LC = GLOB.loadout_categories[use_category]
 		GLOB.gear_datums[use_name] = new geartype
 		LC.gear[use_name] = GLOB.gear_datums[use_name]
@@ -72,8 +72,15 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 	// [/CELADON-EDIT]
 	///Slot to equip to.
 	var/slot
+	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
 	///Roles that can spawn with this item.
 	var/list/allowed_roles
+	// [/CELADON-REMOVE]
+	// [CELADON-ADD] - CELADON_QOL_LOADOUT
+	///Factions that can spawn with this item.
+	var/list/allowed_factions
+	// Примеры 	allowed_factions = list("NanoTrasen", ...)
+	// [/CELADON-ADD]
 	///Stop certain species from receiving this gear
 	var/list/species_blacklist
 	///Only allow certain species to receive this gear
@@ -92,6 +99,14 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 	//Icon state of item
 	var/icon_state
 	// [/CELADON-ADD]
+	// [CELADON-ADD] - CELADON_QOL_LOADOUT
+	///Tags for search and filtering
+	var/list/tags = list()
+	///Cost in loadout points (if point system is used)
+	var/cost = 0
+	///Large preview icon for detailed view
+	var/preview_icon_large
+	// [/CELADON-ADD]
 
 /datum/gear/New()
 	..()
@@ -103,6 +118,14 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		icon_state = initial(path.icon_state)
 		icon = initial(path.icon)
 	base64icon = icon2base64(icon(icon, icon_state, SOUTH, 1, FALSE))
+	// [/CELADON-ADD]
+	// [CELADON-ADD] - CELADON_QOL_LOADOUT
+	// Генерируем большую иконку для превью
+	if(!preview_icon_large)
+		preview_icon_large = icon2base64(icon(icon, icon_state, SOUTH, 1, FALSE))
+	// Автоматически определяем теги на основе категории и слота
+	if(!tags.len)
+		generate_auto_tags()
 	// [/CELADON-ADD]
 
 ///Called when the gear is first purchased
@@ -146,15 +169,15 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		"Footwear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/shoes.dmi", "order" = 4),
 		"External Wear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/suits.dmi", "order" = 5),
 		"Eyewear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/glasses.dmi", "order" = 6),
-		
+
 		// Аксессуары
 		"Accessories" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/accessories.dmi", "order" = 1),
 		"Gloves" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/gloves.dmi", "order" = 2),
 		"Scarfs" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/neck.dmi", "order" = 3),
-		
+
 		// Снаряжение
 		"General" = list("parent" = "Equipment", "icon" = "icons/obj/items_and_weapons.dmi", "order" = 1),
-		
+
 		// Личное
 		"Plushes" = list("parent" = "Personal", "icon" = "icons/obj/plushes.dmi", "order" = 1),
 		"Cloaks" = list("parent" = "Personal", "icon" = "icons/obj/clothing/cloaks.dmi", "order" = 2),
@@ -163,7 +186,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		"Dress" = list("parent" = "Personal", "icon" = "icons/obj/clothing/under/dress.dmi", "order" = 5),
 		"OOC" = list("parent" = "Personal", "icon" = "icons/obj/toy.dmi", "order" = 6)
 	)
-	
+
 	return category_mapping[category] || list("parent" = "Equipment", "icon" = "", "order" = 99)
 
 ///Сортируем категории
@@ -174,11 +197,11 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		var/datum/loadout_category/LC = GLOB.loadout_parent_categories[cat_name]
 		sorted_parents += list(list(LC.category_order, cat_name, LC))
 	sorted_parents = sortTim(sorted_parents, /proc/cmp_loadout_category_order)
-	
+
 	GLOB.loadout_parent_categories = list()
 	for(var/list/entry in sorted_parents)
 		GLOB.loadout_parent_categories[entry[2]] = entry[3]
-	
+
 	// Сортируем подкатегории
 	for(var/parent_name in GLOB.loadout_parent_categories)
 		var/datum/loadout_category/parent_LC = GLOB.loadout_parent_categories[parent_name]
@@ -187,7 +210,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 			var/datum/loadout_category/sub_LC = parent_LC.subcategories[sub_name]
 			sorted_subs += list(list(sub_LC.category_order, sub_name, sub_LC))
 		sorted_subs = sortTim(sorted_subs, /proc/cmp_loadout_category_order)
-		
+
 		parent_LC.subcategories = list()
 		for(var/list/entry in sorted_subs)
 			parent_LC.subcategories[entry[2]] = entry[3]
@@ -202,8 +225,10 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 ///Генерирует древовидную навигацию для loadout
 /proc/generate_loadout_tree_navigation(current_tab)
 	var/list/dat = list()
-	
-	dat += "<center><b>"
+	// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+	// dat += "<center><b>"	// ORIGINAL
+	dat += "<div style='text-align: center; margin: 5px 0; padding: 5px; background: #2a2a2a; border-radius: 5px;'>"
+	// [/CELADON-EDIT]
 	var/firstcat = 1
 	for(var/category in GLOB.loadout_categories)
 		if(firstcat)
@@ -211,12 +236,68 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 		else
 			dat += " | "
 		if(category == current_tab)
-			dat += "<font color='#90EE90'><b>[category]</b></font>"
+		// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+		// dat += "<font color='#90EE90'><b>[category]</b></font>"	// ORIGINAL
+			dat += "<span style='color: #90EE90; font-weight: bold; padding: 2px 6px; background: #3a3a3a; border-radius: 3px;'>[category]</span>"
 		else
-			dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]'>[category]</a>"
-	dat += "</b></center>"
+		// [/CELADON-EDIT]
+	// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+	// 		dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]'>[category]</a>"
+	// dat += "</b></center>"	// ORIGINAL
+			dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]' style='color: #87CEEB; text-decoration: none; padding: 2px 6px; border-radius: 3px;'>[category]</a>"
+	dat += "</div>"
+	// [/CELADON-EDIT]
 	return dat.Join()
 
 ///Генерирует CSS стили для древовидной навигации
 /proc/generate_loadout_tree_styles()
 	return ""
+
+// [CELADON-ADD] - CELADON_QOL_LOADOUT - Пускай все в одном месте будет
+///Автоматически генерирует теги для предмета
+/datum/gear/proc/generate_auto_tags()
+	// Добавляем тег категории
+	if(sort_category)
+		tags += lowertext(sort_category)
+
+	// Добавляем тег слота
+	if(slot)
+		switch(slot)
+			if(ITEM_SLOT_HEAD)
+				tags += "head"
+			if(ITEM_SLOT_NECK)
+				tags += "neck"
+			if(ITEM_SLOT_GLOVES)
+				tags += "gloves"
+			if(ITEM_SLOT_FEET)
+				tags += "feet"
+
+	// Добавляем теги на основе названия
+	if(display_name)
+		var/list/name_words = splittext(lowertext(display_name), " ")
+		for(var/word in name_words)
+			if(length(word) > 2) // Игнорируем короткие слова
+				tags += word
+
+///Проверяет, соответствует ли предмет поисковому запросу
+/datum/gear/proc/matches_search(search_query)
+	if(!search_query || search_query == "")
+		return TRUE
+
+	search_query = lowertext(search_query)
+
+	// Поиск по названию
+	if(findtext(lowertext(display_name), search_query))
+		return TRUE
+
+	// Поиск по описанию
+	if(findtext(lowertext(description), search_query))
+		return TRUE
+
+	// Поиск по тегам
+	for(var/tag in tags)
+		if(findtext(lowertext(tag), search_query))
+			return TRUE
+
+	return FALSE
+// [/CELADON-ADD]

--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -1,16 +1,27 @@
 GLOBAL_LIST_EMPTY(loadout_categories)
 GLOBAL_LIST_EMPTY(gear_datums)
+GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские категории
 
 /datum/loadout_category
 	var/category = ""
+	var/parent_category = "" // Родительская категория
+	var/category_icon = "" // Иконка категории
+	var/category_order = 0 // Порядок сортировки
+	var/list/subcategories = list() // Подкатегории
 	var/list/gear = list()
 
-/datum/loadout_category/New(cat)
+/datum/loadout_category/New(cat, parent = "", icon = "", order = 0)
 	category = cat
+	parent_category = parent
+	category_icon = icon
+	category_order = order
 	..()
 
 ///Create a list of gear datums to sort
 /proc/populate_gear_list()
+	// Создаем родительские категории
+	create_parent_categories()
+	
 	for(var/geartype in subtypesof(/datum/gear))
 		var/datum/gear/G = geartype
 
@@ -27,16 +38,26 @@ GLOBAL_LIST_EMPTY(gear_datums)
 			WARNING("Loadout gear [G] is missing path definition")
 			continue
 
+		// Получаем информацию о категории
+		var/category_info = get_category_info(use_category)
+		var/parent_cat = category_info["parent"]
+		var/cat_icon = category_info["icon"]
+		var/cat_order = category_info["order"]
+
 		if(!GLOB.loadout_categories[use_category])
-			GLOB.loadout_categories[use_category] = new /datum/loadout_category(use_category)
+			GLOB.loadout_categories[use_category] = new /datum/loadout_category(use_category, parent_cat, cat_icon, cat_order)
+			
+			// Добавляем в родительскую категорию
+			if(parent_cat && GLOB.loadout_parent_categories[parent_cat])
+				var/datum/loadout_category/parent_LC = GLOB.loadout_parent_categories[parent_cat]
+				parent_LC.subcategories[use_category] = GLOB.loadout_categories[use_category]
+			
 		var/datum/loadout_category/LC = GLOB.loadout_categories[use_category]
 		GLOB.gear_datums[use_name] = new geartype
 		LC.gear[use_name] = GLOB.gear_datums[use_name]
 
-	GLOB.loadout_categories = sortAssoc(GLOB.loadout_categories)
-	for(var/loadout_category in GLOB.loadout_categories)
-		var/datum/loadout_category/LC = GLOB.loadout_categories[loadout_category]
-		LC.gear = sortAssoc(LC.gear)
+	// Сортируем категории
+	sort_categories()
 	return 1
 
 /datum/gear
@@ -107,3 +128,72 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	gd = new(path, location) //Else, just give them the item and be done with it
 
 	return new gd.path(gd.location)
+
+///Создаем родительские категории
+/proc/create_parent_categories()
+	GLOB.loadout_parent_categories["Clothing"] = new /datum/loadout_category("Одежда", "", "icons/obj/clothing/suits.dmi", 1)
+	GLOB.loadout_parent_categories["Accessories"] = new /datum/loadout_category("Аксессуары", "", "icons/obj/clothing/accessories.dmi", 2)
+	GLOB.loadout_parent_categories["Equipment"] = new /datum/loadout_category("Снаряжение", "", "icons/obj/tools.dmi", 3)
+	GLOB.loadout_parent_categories["Personal"] = new /datum/loadout_category("Личное", "", "icons/obj/toy.dmi", 4)
+///Получаем информацию о категории
+/proc/get_category_info(category)
+	var/list/category_mapping = list(
+		// Одежда
+		"Headwear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/hats.dmi", "order" = 1),
+		"Uniforms" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/uniforms.dmi", "order" = 2),
+		"Suits" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/suits.dmi", "order" = 3),
+		"Footwear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/shoes.dmi", "order" = 4),
+		"External Wear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/suits.dmi", "order" = 5),
+		"Eyewear" = list("parent" = "Clothing", "icon" = "icons/obj/clothing/glasses.dmi", "order" = 6),
+		
+		// Аксессуары
+		"Accessories" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/accessories.dmi", "order" = 1),
+		"Gloves" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/gloves.dmi", "order" = 2),
+		"Scarfs" = list("parent" = "Accessories", "icon" = "icons/obj/clothing/neck.dmi", "order" = 3),
+		
+		// Снаряжение
+		"General" = list("parent" = "Equipment", "icon" = "icons/obj/items_and_weapons.dmi", "order" = 1),
+		
+		// Личное
+		"Plushes" = list("parent" = "Personal", "icon" = "icons/obj/plushes.dmi", "order" = 1),
+		"Cloaks" = list("parent" = "Personal", "icon" = "icons/obj/clothing/cloaks.dmi", "order" = 2),
+		"Costumes" = list("parent" = "Personal", "icon" = "icons/obj/clothing/costumes.dmi", "order" = 3),
+		"Coats" = list("parent" = "Personal", "icon" = "icons/obj/clothing/suits.dmi", "order" = 4),
+		"Dress" = list("parent" = "Personal", "icon" = "icons/obj/clothing/under/dress.dmi", "order" = 5),
+		"OOC" = list("parent" = "Personal", "icon" = "icons/obj/toy.dmi", "order" = 6)
+	)
+	
+	return category_mapping[category] || list("parent" = "Equipment", "icon" = "", "order" = 99)
+
+///Сортируем категории
+/proc/sort_categories()
+	// Сортируем родительские категории
+	var/list/sorted_parents = list()
+	for(var/cat_name in GLOB.loadout_parent_categories)
+		var/datum/loadout_category/LC = GLOB.loadout_parent_categories[cat_name]
+		sorted_parents += list(list(LC.category_order, cat_name, LC))
+	sorted_parents = sortTim(sorted_parents, /proc/cmp_loadout_category_order)
+	
+	GLOB.loadout_parent_categories = list()
+	for(var/list/entry in sorted_parents)
+		GLOB.loadout_parent_categories[entry[2]] = entry[3]
+	
+	// Сортируем подкатегории
+	for(var/parent_name in GLOB.loadout_parent_categories)
+		var/datum/loadout_category/parent_LC = GLOB.loadout_parent_categories[parent_name]
+		var/list/sorted_subs = list()
+		for(var/sub_name in parent_LC.subcategories)
+			var/datum/loadout_category/sub_LC = parent_LC.subcategories[sub_name]
+			sorted_subs += list(list(sub_LC.category_order, sub_name, sub_LC))
+		sorted_subs = sortTim(sorted_subs, /proc/cmp_loadout_category_order)
+		
+		parent_LC.subcategories = list()
+		for(var/list/entry in sorted_subs)
+			parent_LC.subcategories[entry[2]] = entry[3]
+			// Сортируем предметы в подкатегории
+			var/datum/loadout_category/sub_LC = entry[3]
+			sub_LC.gear = sortAssoc(sub_LC.gear)
+
+///Компаратор для сортировки категорий
+/proc/cmp_loadout_category_order(list/a, list/b)
+	return a[1] - b[1]

--- a/code/modules/client/loadout/_loadout.dm
+++ b/code/modules/client/loadout/_loadout.dm
@@ -135,6 +135,7 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 	GLOB.loadout_parent_categories["Accessories"] = new /datum/loadout_category("Аксессуары", "", "icons/obj/clothing/accessories.dmi", 2)
 	GLOB.loadout_parent_categories["Equipment"] = new /datum/loadout_category("Снаряжение", "", "icons/obj/tools.dmi", 3)
 	GLOB.loadout_parent_categories["Personal"] = new /datum/loadout_category("Личное", "", "icons/obj/toy.dmi", 4)
+
 ///Получаем информацию о категории
 /proc/get_category_info(category)
 	var/list/category_mapping = list(
@@ -197,3 +198,25 @@ GLOBAL_LIST_EMPTY(loadout_parent_categories) // Родительские кат�
 ///Компаратор для сортировки категорий
 /proc/cmp_loadout_category_order(list/a, list/b)
 	return a[1] - b[1]
+
+///Генерирует древовидную навигацию для loadout
+/proc/generate_loadout_tree_navigation(current_tab)
+	var/list/dat = list()
+	
+	dat += "<center><b>"
+	var/firstcat = 1
+	for(var/category in GLOB.loadout_categories)
+		if(firstcat)
+			firstcat = 0
+		else
+			dat += " | "
+		if(category == current_tab)
+			dat += "<font color='#90EE90'><b>[category]</b></font>"
+		else
+			dat += "<a href='byond://?_src_=prefs;preference=gear;select_category=[category]'>[category]</a>"
+	dat += "</b></center>"
+	return dat.Join()
+
+///Генерирует CSS стили для древовидной навигации
+/proc/generate_loadout_tree_styles()
+	return ""

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -151,7 +151,7 @@
 	slot = null
 
 /datum/gear/accessory/stethoscope
- display_name = "stethoscope"
+  display_name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -151,7 +151,7 @@
 	slot = null
 
 /datum/gear/accessory/stethoscope
-  display_name = "stethoscope"
+      display_name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -150,12 +150,10 @@
 	path = /obj/item/clothing/accessory/waistcoat
 	slot = null
 
-// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
-// /datum/gear/accessory/stethoscope
-// 	display_name = "stethoscope"
-// 	path = /obj/item/clothing/neck/stethoscope
-// 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
-// [/CELADON-REMOVE]
+/datum/gear/accessory/stethoscope
+ display_name = "stethoscope"
+	path = /obj/item/clothing/neck/stethoscope
+	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 
 /datum/gear/accessory/headphones
 	display_name = "headphones"

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -151,7 +151,7 @@
 	slot = null
 
 /datum/gear/accessory/stethoscope
-        display_name = "stethoscope"
+	display_name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -150,10 +150,12 @@
 	path = /obj/item/clothing/accessory/waistcoat
 	slot = null
 
-/datum/gear/accessory/stethoscope
-	display_name = "stethoscope"
-	path = /obj/item/clothing/neck/stethoscope
-	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
+// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
+// /datum/gear/accessory/stethoscope
+// 	display_name = "stethoscope"
+// 	path = /obj/item/clothing/neck/stethoscope
+// 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
+// [/CELADON-REMOVE]
 
 /datum/gear/accessory/headphones
 	display_name = "headphones"

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -151,7 +151,7 @@
 	slot = null
 
 /datum/gear/accessory/stethoscope
-      display_name = "stethoscope"
+        display_name = "stethoscope"
 	path = /obj/item/clothing/neck/stethoscope
 	allowed_roles = list("Medical Doctor", "Chief Medical Officer")
 

--- a/code/modules/client/loadout/loadout_hat.dm
+++ b/code/modules/client/loadout/loadout_hat.dm
@@ -9,17 +9,17 @@
 /datum/gear/hat/hhat_yellow
 	display_name = "hardhat, yellow"
 	path = /obj/item/clothing/head/hardhat
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
+	// allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
 
 /datum/gear/hat/hhat_orange
 	display_name = "hardhat, orange"
 	path = /obj/item/clothing/head/hardhat/orange
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
+	// allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
 
 /datum/gear/hat/hhat_blue
 	display_name = "hardhat, blue"
 	path = /obj/item/clothing/head/hardhat/dblue
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")
+	// allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician")	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
 
 //Berets, AKA how I lost my will to live again
 
@@ -74,7 +74,7 @@
 /datum/gear/hat/beret/engineering/hazard
 	display_name = "beret, hazard"
 	path = /obj/item/clothing/head/beret/eng/hazard
-	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer")
+	// allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer")	// [CELADON-REMOVE] - CELADON_QOL_LOADOUT
 
 //Soft caps
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1300,12 +1300,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				// Фракция над картинкой
 				if(G.allowed_factions && G.allowed_factions.len)
 					var/list/faction_color_map = list(
-						"NanoTrasen" = "#0077ff",
-						"Syndicate" = "#ff1900",
-						"Independent" = "#a0a0a0",
-						"SolFed" = "#ff9d00",
+						"NanoTrasen" = "#283674",
+						"Syndicate" = "#9c0808",
+						"Independent" = "#7e6641",
+						"SolFed" = "#ffd700",
 						"Pirates" = "#000000",
-						"Elysium" = "#207a14"
+						"Elysium" = "#006400"
 					)
 					var/list/colored_roles = list()
 					for(var/role in G.allowed_factions)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1303,7 +1303,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						"NanoTrasen" = "#283674",
 						"Syndicate" = "#9c0808",
 						"Independent" = "#7e6641",
-						"SolFed" = "#ffd700",
+						"InteQ" = "#4d291F",
+						"SolFed" = "#191970",
 						"Pirates" = "#000000",
 						"Elysium" = "#006400"
 					)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1231,39 +1231,45 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			// dat += "<tr><td colspan=4><center><b>Current loadout usage: [length(equipped_gear)]/[CONFIG_GET(number/max_loadout_items)]</b> \[<a href='byond://?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\] | \[<a href='byond://?_src_=prefs;preference=gear;toggle_loadout=1'>Toggle Loadout</a>\]</center></td></tr>"
 			dat += "<tr><td colspan=4><center><b>Current loadout usage: [length(equipped_gear)]/[max_loadout_items]</b> \[<a href='byond://?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\] | \[<a href='byond://?_src_=prefs;preference=gear;toggle_loadout=1'>Toggle Loadout</a>\]</center></td></tr>"
 			// [/CELADON-EDIT]
-			dat += "<tr><td colspan=4><center><b>"
+			
 
-			var/firstcat = 1
-			for(var/category in GLOB.loadout_categories)
-				if(firstcat)
-					firstcat = 0
-				else
-					dat += " |"
-				if(category == gear_tab)
-					dat += " [span_linkoff("[category]")] "
-				else
-					dat += " <a href='byond://?_src_=prefs;preference=gear;select_category=[category]'>[category]</a> "
-			dat += "</b></center></td></tr>"
+			
+			// Древовидная навигация
+			dat += "<tr><td colspan=4>"
+			dat += generate_loadout_tree_navigation(gear_tab)
+			dat += "</td></tr>"
 
 			var/datum/loadout_category/LC = GLOB.loadout_categories[gear_tab]
+			if(!LC)
+				// Если категория не найдена, выбираем первую доступную
+				for(var/cat_name in GLOB.loadout_categories)
+					gear_tab = cat_name
+					LC = GLOB.loadout_categories[gear_tab]
+					break
+			
 			dat += "<tr><td colspan=3><hr></td></tr>"
 			dat += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
 			dat += "<tr><td colspan=3><hr></td></tr>"
 
 			dat += "<tr><td colspan=3><hr></td></tr>"
-			// [CELADON-EDIT] - CELADON_QOL
-			// dat += "<tr><td><b>Name</b></td>" // CELADON-EDIT - ORIGINAL
-			dat += "<tr><td align='middle'><b>Name</b></td>"
-			// [/CELADON-EDIT]
+			dat += "<tr><td><b>Name</b></td>"
 			dat += "<td><b>Restricted Jobs</b></td>"
-			dat += "<td><b>Description</b></td>"
+			dat += "<td><b>Description</b></td></tr>"
 			dat += "<tr><td colspan=3><hr></td></tr>"
 			for(var/gear_name in LC.gear)
 				var/datum/gear/G = LC.gear[gear_name]
-				// [CELADON-EDIT] - CELADON_QOL
-				// dat += "<tr style='vertical-align:top;'><td width=20%><a style='white-space:normal;' [(G.display_name in equipped_gear) ? "class='linkOn' " : ""]href='?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a></td><td>" // CELADON-EDIT - ORIGINAL
-				dat += "<tr style='vertical-align:top;'><td align='middle' width=20%><a style='white-space:normal;' [(G.display_name in equipped_gear) ? "class='linkOn' " : ""]href='byond://?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a><br/><img src=data:image/jpeg;base64,[G.base64icon] class='loadoutPreview'><hr></td><td>"
-				// [/CELADON-EDIT]
+				var/is_equipped = (G.display_name in equipped_gear)
+				
+				dat += "<tr style='vertical-align:top; [is_equipped ? "background: #2a4a2a;" : ""]'>"
+				
+				// Колонка с предметом
+				dat += "<td align='middle' width='20%'>"
+				dat += "<a style='white-space:normal;' [(G.display_name in equipped_gear) ? "class='linkOn' " : ""]href='byond://?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a><br/>"
+				dat += "<img src='data:image/jpeg;base64,[G.base64icon]' class='loadoutPreview'><hr>"
+				dat += "</td>"
+				
+				// Колонка с профессиями
+				dat += "<td>"
 				if(G.allowed_roles)
 					dat += "<font size=2>"
 					var/list/allowedroles = list()
@@ -1271,7 +1277,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						allowedroles += role
 					dat += english_list(allowedroles, null, ", ")
 					dat += "</font>"
-				dat += "</td><td><font size=2><i>[G.description]</i></font></td></tr>"
+				dat += "</td>"
+				
+				// Колонка с описанием
+				dat += "<td><font size=2><i>[G.description]</i></font></td>"
+				
+				dat += "</tr>"
+
 			dat += "</table>"
 
 		if (3) // Game Preferences

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -231,6 +231,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/equipped_gear = list()
 	///Gear tab currently being viewed
 	var/gear_tab = "General"
+	// [CELADON-ADD] - CELADON_QOL_LOADOUT
+	///Scroll position in gear menu
+	var/gear_scroll_pos = 0
+	// [/CELADON-ADD]
 
 	var/action_buttons_screen_locs = list()
 	///If we want to broadcast deadchat connect/disconnect messages
@@ -1227,14 +1231,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						equipped_gear.Cut(i,i+1)
 
 			dat += "<table align='center' width='100%'>"
-			// [CELADON-EDIT] - CELADON_DONATE
+			// [CELADON-EDIT] - CELADON_DONATE, CELADON_QOL_LOADOUT
 			// dat += "<tr><td colspan=4><center><b>Current loadout usage: [length(equipped_gear)]/[CONFIG_GET(number/max_loadout_items)]</b> \[<a href='byond://?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\] | \[<a href='byond://?_src_=prefs;preference=gear;toggle_loadout=1'>Toggle Loadout</a>\]</center></td></tr>"
-			dat += "<tr><td colspan=4><center><b>Current loadout usage: [length(equipped_gear)]/[max_loadout_items]</b> \[<a href='byond://?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\] | \[<a href='byond://?_src_=prefs;preference=gear;toggle_loadout=1'>Toggle Loadout</a>\]</center></td></tr>"
+			dat += "<tr><td colspan=4 style='padding: 5px;'><div style='text-align: center; background: #2a2a2a; padding: 8px; border-radius: 5px; margin: 5px 0;'><b style='color: #87CEEB;'>Использовано слотов: [length(equipped_gear)]/[max_loadout_items]</b> | <a href='byond://?_src_=prefs;preference=gear;clear_loadout=1' style='color: #FF6B6B; text-decoration: none;'>Очистить</a> | <a href='byond://?_src_=prefs;preference=gear;toggle_loadout=1' style='color: #4ECDC4; text-decoration: none;'>Переключить</a></div></td></tr>"
 			// [/CELADON-EDIT]
-			
 
-			
-			// Древовидная навигация
+
+
+			// Навигация
 			dat += "<tr><td colspan=4>"
 			dat += generate_loadout_tree_navigation(gear_tab)
 			dat += "</td></tr>"
@@ -1246,45 +1250,92 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					gear_tab = cat_name
 					LC = GLOB.loadout_categories[gear_tab]
 					break
-			
-			dat += "<tr><td colspan=3><hr></td></tr>"
-			dat += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
-			dat += "<tr><td colspan=3><hr></td></tr>"
 
-			dat += "<tr><td colspan=3><hr></td></tr>"
-			dat += "<tr><td><b>Name</b></td>"
-			dat += "<td><b>Restricted Jobs</b></td>"
-			dat += "<td><b>Description</b></td></tr>"
-			dat += "<tr><td colspan=3><hr></td></tr>"
+			// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+			// dat += "<tr><td colspan=3><hr></td></tr>"
+			// dat += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
+			// dat += "<tr><td colspan=3><hr></td></tr>"
+
+			// dat += "<tr><td colspan=3><hr></td></tr>"
+			// dat += "<tr><td><b>Name</b></td>"
+			// dat += "<td><b>Restricted Jobs</b></td>"
+			// dat += "<td><b>Description</b></td></tr>"
+			// dat += "<tr><td colspan=3><hr></td></tr>"	// ORIGINAL
+			dat += "<tr><td colspan=4 style='padding: 5px 0;'><div style='text-align: center; font-weight: bold; font-size: 14px; color: #87CEEB; border-bottom: 1px solid #555; padding-bottom: 3px;'>[LC.category]</div></td></tr>"
+
+			// Сетка предметов
+			dat += "<tr><td colspan=4 style='padding: 0;'>"
+			dat += "<div id='gear-container' style='text-align: left; padding: 10px; max-height: 500px; overflow-y: auto; background: #1a1a1a; border: 1px solid #333; border-radius: 5px;' onscroll='localStorage.setItem(\"gearScrollPos\", this.scrollTop);'>"
+			// [/CELADON-ADD]
 			for(var/gear_name in LC.gear)
 				var/datum/gear/G = LC.gear[gear_name]
 				var/is_equipped = (G.display_name in equipped_gear)
-				
-				dat += "<tr style='vertical-align:top; [is_equipped ? "background: #2a4a2a;" : ""]'>"
-				
-				// Колонка с предметом
-				dat += "<td align='middle' width='20%'>"
-				dat += "<a style='white-space:normal;' [(G.display_name in equipped_gear) ? "class='linkOn' " : ""]href='byond://?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a><br/>"
-				dat += "<img src='data:image/jpeg;base64,[G.base64icon]' class='loadoutPreview'><hr>"
-				dat += "</td>"
-				
-				// Колонка с профессиями
-				dat += "<td>"
-				if(G.allowed_roles)
-					dat += "<font size=2>"
-					var/list/allowedroles = list()
-					for(var/role in G.allowed_roles)
-						allowedroles += role
-					dat += english_list(allowedroles, null, ", ")
-					dat += "</font>"
-				dat += "</td>"
-				
-				// Колонка с описанием
-				dat += "<td><font size=2><i>[G.description]</i></font></td>"
-				
-				dat += "</tr>"
+				// [CELADON-EDIT] - CELADON_QOL_LOADOUT
+				// dat += "<tr style='vertical-align:top; [is_equipped ? "background: #2a4a2a;" : ""]'>"
+
+				// // Колонка с предметом
+				// dat += "<td align='middle' width='20%'>"
+				// dat += "<a style='white-space:normal;' [(G.display_name in equipped_gear) ? "class='linkOn' " : ""]href='byond://?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a><br/>"
+				// dat += "<img src='data:image/jpeg;base64,[G.base64icon]' class='loadoutPreview'><hr>"
+				// dat += "</td>"
+
+				// // Колонка с профессиями
+				// dat += "<td>"
+				// if(G.allowed_roles)
+				// 	dat += "<font size=2>"
+				// 	var/list/allowedroles = list()
+				// 	for(var/role in G.allowed_roles)
+				// 		allowedroles += role
+				// 	dat += english_list(allowedroles, null, ", ")
+				// 	dat += "</font>"
+				// dat += "</td>"
+
+				// // Колонка с описанием
+				// dat += "<td><font size=2><i>[G.description]</i></font></td>"
+
+				// dat += "</tr>"	// ORIGINAL
+				// Карточка предмета
+				dat += "<div style='width: 200px; height: 150px; border: 2px solid [is_equipped ? "#90EE90" : "#555"]; border-radius: 8px; padding: 8px; background: [is_equipped ? "#2a4a2a" : "#1a1a1a"]; text-align: center; position: relative; display: inline-block; vertical-align: top; margin: 5px; cursor: pointer;' onclick=\"window.location.href='byond://?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'\">"
+
+				// Фракция над картинкой
+				if(G.allowed_factions && G.allowed_factions.len)
+					var/list/faction_color_map = list(
+						"NanoTrasen" = "#0077ff",
+						"Syndicate" = "#ff1900",
+						"Independent" = "#a0a0a0",
+						"SolFed" = "#ff9d00",
+						"Pirates" = "#000000",
+						"Elysium" = "#207a14"
+					)
+					var/list/colored_roles = list()
+					for(var/role in G.allowed_factions)
+						var/color = faction_color_map[role] || "#FFD700"
+						colored_roles += "<span style='color: [color];'>[role]</span>"
+					dat += "<div style='margin: 2px 0 5px 0; font-size: 12px; font-weight: bold;'>[english_list(colored_roles, null, ", ")]</div>"
+
+				// Иконка предмета
+				dat += "<div style='margin: 5px 0;'>"
+				dat += "<img src='data:image/jpeg;base64,[G.base64icon]' style='width: 64px; height: 64px; border: 1px solid #333;'>"
+				dat += "</div>"
+
+				// Название предмета
+				dat += "<div style='margin: 3px 0; color: [is_equipped ? "#90EE90" : "#87CEEB"]; font-weight: bold; font-size: 12px;'>"
+				dat += "[is_equipped ? "✓ " : ""][G.display_name]"
+				dat += "</div>"
+
+				// Описание
+				dat += "<div style='margin: 2px 0; font-size: 12px; color: #CCC; text-align: left; height: 40px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;' title='[G.description]'>"
+				dat += "[G.description]"
+				dat += "</div>"
+
+				dat += "</div>"
+
+			dat += "</div>"
+			dat += "<script>setTimeout(function(){var container = document.getElementById('gear-container'); if(container) {var pos = localStorage.getItem('gearScrollPos'); if(pos) container.scrollTop = parseInt(pos);}}, 10);</script>"
+			dat += "</td></tr>"
 
 			dat += "</table>"
+			// [/CELADON-EDIT]
 
 		if (3) // Game Preferences
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
@@ -1905,13 +1956,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				else
 					alert(user, "Can't equip [TG.display_name]. It conflicts with an already-equipped item.")
 			save_preferences()
+			update_preview_icon(show_gear, show_loadout)	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 
 		else if(href_list["select_category"])
 			gear_tab = href_list["select_category"]
 		else if(href_list["clear_loadout"])
 			equipped_gear.Cut()
+			update_preview_icon(show_gear, show_loadout)	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 		else if(href_list["toggle_loadout"])
 			show_loadout = !show_loadout
+			update_preview_icon(show_gear, show_loadout)	// [CELADON-ADD] - CELADON_QOL_LOADOUT
 
 		ShowChoices(user)
 		return

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -21,6 +21,7 @@ UNFUCK_SPRAYCAN
 BLOOD_EXAMINE
 DONT_ALTCLICK_WALLET
 DEBUG_QUALITY
+CELADON_QOL_LOADOUT
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -157,6 +158,12 @@ DONT_ALTCLICK_WALLET - Убирает вытаскивание карты на �
 
 DEBUG_QUALITY
 - DEL `code/game/objects/items/storage/boxes.dm` -> `mod_celadon/qol/code/BluespaceTechnician.dm`
+
+CELADON_QOL_LOADOUT
+- ADD, EDIT: `code/modules/client/preferences.dm`
+- ADD, EDIT, REMOVE: `code/modules/client/loadout/_loadout.dm`
+- REMOVE: `code/modules/client/loadout/loadout_accessories.dm`
+- REMOVE: `code/modules/client/loadout/loadout_hat.dm`
 
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,


### PR DESCRIPTION
## Описание / Что этот PR делает
Обновляем меню лодаута, чистим от всякого мусора, приводим в удобный вид (хартстоун). Избавляемся от хаоса. Убираем таблицу и внедряем карточки предметов. Чиним баги с ползунком, тееперь можно выбрать предмет и не быть поднятым в начало списка, наконец-то пофикшено. 

## Причина создания ПР / Почему это хорошо для игры
Меню лодаута было неудобным. Теперь оно необычное, чем-то на тг похожее, но сделано не на базе ТГУИ

## Демонстрация изменений / Тестирование
<img width="1324" height="879" alt="image" src="https://github.com/user-attachments/assets/b96a3334-60a4-4440-9c17-338a3cafb95a" />
<img width="1650" height="1071" alt="image" src="https://github.com/user-attachments/assets/99f093a5-b462-488f-9044-d78e8ff89c8c" />
<img width="1646" height="1066" alt="image" src="https://github.com/user-attachments/assets/1c352a75-5e11-4120-9612-9345202fe9b6" />
<img width="694" height="274" alt="image" src="https://github.com/user-attachments/assets/aa4591be-774c-4957-bd7d-12f0d69d0531" />
<img width="811" height="325" alt="image" src="https://github.com/user-attachments/assets/1cc8a195-7d09-4eec-ae23-39e0b26e6346" />

## Список изменений

```yml
🆑
tweak: меню лодаута
/🆑
```
