### PR TITLE
RE-BALANCE: Мертвые щиты больше не 100% защищают

### DIFF
--- a/mod_celadon/balance/_balance.dme
+++ b/mod_celadon/balance/_balance.dme
@@ -14,6 +14,7 @@
 #include "code/backpack.dm"
 #include "code/cargo.dm"	// Механизм временный, по выводу субшатлов из ремонта, вернуть инфляцию назад.
 #include "code/cc_clothes.dm"
+#include "code/chair_bullet_redirect.dm"
 #include "code/chemestry.dm"	// От ганзы не включенный файл
 #include "code/overmap_event_speed_safe.dm"
 #include "code/sharplite_balance.dm"

--- a/mod_celadon/balance/code/chair_bullet_redirect.dm
+++ b/mod_celadon/balance/code/chair_bullet_redirect.dm
@@ -1,0 +1,8 @@
+/mob/living/carbon/human/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
+	if(stat == DEAD && buckled && istype(buckled, /obj/structure/chair))
+		if(prob(15))
+			var/obj/structure/chair/chair = buckled
+			visible_message(span_warning("[P] пробивает [src] насквозь и попадает в [chair]!"))
+			chair.bullet_act(P, def_zone, piercing_hit)
+			return BULLET_ACT_HIT
+	return ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
Пр вносит механику пере направления пуль с трупов сидящих на мебели на саму мебель
Теперь есть 15% шанс того что пуля может попасть не в труп, а в мебель, на чем сидит труп


## Причина создания ПР / Почему это хорошо для игры
Исправляет абьюз с использованием трупов как неубиваемых щитов

## Список изменений

```yml
🆑
add: Механика перенапрвления пуль с трупов на стулья
/🆑
```
