### PR TITLE
BALANCE: Щиты - Логика работы щитов

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -42,7 +42,11 @@
 	var/braking_alert = "cracks!"
 // [/CELADON-ADD]
 
-/obj/item/shield/proc/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
+/obj/item/shield/proc/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK, damage_type)
+// [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Щиты не должны ломаться лол
+	if(damage_type != BRUTE && damage_type != BURN)
+		return FALSE
+// [/CELADON-ADD]
 	take_damage(damage)
 
 /obj/item/shield/atom_break(damage_flag)
@@ -77,10 +81,6 @@
 			. += span_warning("It's falling apart!")
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
-// [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Дизейблеры могли ломать шит, лол
-	if(damage_type != BRUTE && damage_type != BURN)
-		return FALSE
-// [/CELADON-ADD]
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
 // [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Щиты не должны блокировать лежа

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -84,6 +84,12 @@
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
 // [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Щиты не должны блокировать лежа
+	if(isprojectile(hitby))
+		var/obj/projectile/bullet = hitby
+		if(!defense_check(get_turf(owner), get_turf(bullet?.fired_from), owner?.dir))
+			return FALSE
+	else if(!defense_check(get_turf(owner), get_turf(hitby), owner?.dir))
+		return FALSE
 	if(owner.body_position == LYING_DOWN)
 		final_block_chance -= 30
 // [/CELADON-ADD]
@@ -94,6 +100,28 @@
 	. = ..()
 	if(.)
 		on_block(owner, hitby, attack_text, damage, attack_type, damage_type)
+
+// [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance
+/obj/item/shield/proc/defense_check(turf/aloc, turf/bloc, mobdir)
+	. = TRUE
+	var/dx = aloc.x - bloc.x
+	var/dy = aloc.y - bloc.y
+
+	switch(mobdir)
+		if(NORTH)
+			if(abs(dx) <= dy * 2)
+				. = FALSE
+		if(SOUTH)
+			if(abs(dx) <= dy * -2)
+				. = FALSE
+		if(EAST)
+			if(abs(dy) <= dx * 2)
+				. = FALSE
+		if(WEST)
+			if(abs(dy) <= dx * -2)
+				. = FALSE
+	return
+// [/CELADON-ADD]
 
 /obj/item/shield/riot
 	name = "ballistic shield"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -77,6 +77,10 @@
 			. += span_warning("It's falling apart!")
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK, damage_type = BRUTE)
+// [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Дизейблеры могли ломать шит, лол
+	if(damage_type != BRUTE && damage_type != BURN)
+		return FALSE
+// [/CELADON-ADD]
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
 // [CELADON-ADD] - BALLISTIC_SHIELD - Rebalance - Щиты не должны блокировать лежа
@@ -132,17 +136,19 @@
 //	[CELADON-ADD] - BALLISTIC_SHIELD - Extended Edition
 			if(broken_shield)
 				if(istype(src, /obj/item/shield/riot/tele))
-					icon_state = "[src::icon_state]1"
+					icon_state = "teleriot1"
 				else
-					icon_state = "[src::icon_state]"
+					icon_state = initial(icon_state)
 //	[/CELADON-ADD]
 			atom_integrity = max_integrity
 			to_chat(user, span_notice("You repair [src] with [T]."))
 			name = src::name
 			broken = FALSE
-			block_chance = 60
-			slowdown = 0.5			//slowdown = 1.25 [CELADON-EDIT] - BALLISTIC_SHIELD - Rebalance
-			//drag_slowdown = 1.25	// [/CELADON-REMOVE]
+// [CELADON-EDIT] - BALLISTIC_SHIELD - Extended Edition
+			block_chance = initial(block_chance)	//block_chance = 60
+			slowdown = initial(slowdown)			//slowdown = 1.25
+			//drag_slowdown = initial(drag_slowdown) // drag_slowdown = 1.25
+// [/CELADON-EDIT]
 
 /obj/item/shield/riot/spike
 	name = "spike shield"
@@ -174,14 +180,15 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	max_integrity = 30
 	recoil_bonus = 0 //it's PLASTIC
+	slowdown = 0		// [CELADON-REMOVE] - BALLISTIC_SHIELD - Rebalance
 
 /obj/item/shield/riot/buckler
 	name = "wooden buckler"
 	desc = "A medieval wooden buckler."
 	icon_state = "buckler"
 	item_state = "buckler"
-	//slowdown = 0			// [CELADON-REMOVE] - BALLISTIC_SHIELD - Rebalance
-	//drag_slowdown = 0		// [CELADON-REMOVE]
+	slowdown = 0
+	//drag_slowdown = 0		// [CELADON-REMOVE] - BALLISTIC_SHIELD - Rebalance
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	custom_materials = list(/datum/material/wood = MINERAL_MATERIAL_AMOUNT * 10)
@@ -394,5 +401,6 @@
 	block_chance = 25
 	max_integrity = 70
 	w_class = WEIGHT_CLASS_BULKY
+	slowdown = 0		// [CELADON-REMOVE] - BALLISTIC_SHIELD - Rebalance
 
 #undef BATON_BASH_COOLDOWN

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -92,7 +92,7 @@
 
 				return BULLET_ACT_FORCE_PIERCE // complete projectile permutation
 
-		if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
+		if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration, P.damage_type))	// [CELADON-EDIT] - Вы сейчас серьезно не проверяете что за тип урона?
 			P.on_hit(src, 100, def_zone, piercing_hit)
 			return BULLET_ACT_HIT
 
@@ -115,13 +115,13 @@
 		return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/check_shields(atom/AM, damage, attack_text = "the attack", attack_type = MELEE_ATTACK, armour_penetration = 0)
+/mob/living/carbon/human/proc/check_shields(atom/AM, damage, attack_text = "the attack", attack_type = MELEE_ATTACK, armour_penetration = 0, damage_type = BRUTE)	// [CELADON-EDIT] - Вы сейчас серьезно не проверяете что за тип урона?
 	var/block_chance_modifier = round(damage / -3)
 
 	var/obj/item/shield = get_best_shield()
 	if(shield)
 		var/final_block_chance = shield.block_chance - (clamp((armour_penetration - shield.armour_penetration)/2,0,100)) + block_chance_modifier
-		var/shield_result = shield.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type)
+		var/shield_result = shield.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type, damage_type)	// [CELADON-EDIT] - Вы сейчас серьезно не проверяете что за тип урона?
 		if(shield_result >= 1)
 			return TRUE
 		if(shield_result == -1)


### PR DESCRIPTION
## Описание / Что этот PR делает
Кратко:
- Щиты больше не могут ломаться от дизейблеров или арбалетов с токсинами. **Проще:** Не ломаются от любого другого типа урона кроме как от ТРАВМ и ОЖОГОВ;
- Телескопический щит больше не становится по характеристикам баллистическим после его починки;
- Телескопический щит больше не исчезает при починке;
- Добавлены углы защиты для щитов, щиты больше не защищают со спины.

## Причина создания ПР / Почему это хорошо для игры
Добавляет проверку на тип урона щитам;
Чинит отображение;
Убирает за-хардкоженные значения что давали потенциально всем щитам статы баллистического щита.

## Список изменений

```yml
🆑
fix: Логика работы щитов, и прочие мелочи с ними
balance: Ребаланс углов защиты у щитов
/🆑
```
