### PR TITLE
MAP: Заменяет флаги на фракционные на корабликах

### DIFF
--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_delta.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_delta.dmm
@@ -45,7 +45,7 @@
 "ar" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/border,
 /obj/machinery/light/directional/south,
-/obj/item/banner/command/mundane,
+/obj/item/banner/nanotrasen/mundane,
 /obj/effect/turf_decal/road/line/opaque/white{
 	dir = 1
 	},
@@ -56,7 +56,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/item/banner/command/mundane,
+/obj/item/banner/nanotrasen/mundane,
 /obj/effect/turf_decal/road/line/opaque/white,
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
@@ -800,7 +800,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/window/reinforced/spawner/west,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "Nanotrasen banner"
 	},
@@ -1382,7 +1382,7 @@
 /obj/effect/turf_decal/trimline/opaque/ntblue/line{
 	dir = 5
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "Nanotrasen banner"
 	},
@@ -8590,7 +8590,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "Nanotrasen banner"
 	},
@@ -9316,7 +9316,7 @@
 /obj/effect/turf_decal/trimline/opaque/ntblue/line{
 	dir = 1
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "Nanotrasen banner"
 	},
@@ -11226,7 +11226,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/opaque/ntblue/line,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "Nanotrasen banner"
 	},

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_ranger.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_ranger.dmm
@@ -610,7 +610,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor/hole/right,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	layer = 3.09
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skipper.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skipper.dmm
@@ -3177,7 +3177,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	layer = 3.09
 	},
@@ -3565,7 +3565,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	layer = 3.09
 	},
@@ -4443,7 +4443,7 @@
 	dir = 1
 	},
 /obj/machinery/light/dim/directional/west,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	layer = 3.09
 	},
@@ -5223,7 +5223,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	layer = 3.09
 	},
@@ -6584,7 +6584,7 @@
 "Ve" = (
 /obj/structure/railing,
 /obj/machinery/light/dim/directional/west,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	layer = 3.09
 	},

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -695,7 +695,7 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/north,
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "nanotrasen banner"
 	},
@@ -1382,7 +1382,7 @@
 	pixel_x = 20;
 	pixel_y = 11
 	},
-/obj/item/banner/command/mundane{
+/obj/item/banner/nanotrasen/mundane{
 	anchored = 1;
 	name = "nanotrasen banner"
 	},

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_kau_delta.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_kau_delta.dmm
@@ -954,7 +954,7 @@
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/item/banner/red{
+/obj/item/banner/syndie/mundane{
 	job_loyalties = list("Captain","Lieutenant","Operative")
 	},
 /obj/effect/turf_decal/spline/plain/opaque/syndiered{


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняет флаги CTF на фракционные

## Причина создания ПР / Почему это хорошо для игры
Более логичнее что на кораблях их же знамя, а не старый флаг CTF?

## Список изменений

```yml
🆑
map: Фракционные флаги на корабли
/🆑
```
