### PR TITLE
MAP: Обновляем туалеты на астероидном аванпосту

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -650,6 +650,18 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/starboard)
+"azO" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "azT" = (
 /turf/open/floor/wood{
 	light_range = 2
@@ -19640,28 +19652,6 @@
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
-"mRZ" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "mSb" = (
 /obj/machinery/conveyor/auto{
 	dir = 1;
@@ -28468,14 +28458,6 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/vacant_rooms)
-"sRz" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
 "sRB" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -32114,6 +32096,12 @@
 	planetary_atmos = 1
 	},
 /area/outpost/hallway/central)
+"vix" = (
+/obj/structure/falsewall/reinforced{
+	req_one_access_txt = "8131"
+	},
+/turf/open/floor/fakepit,
+/area/outpost/crew/canteen)
 "viF" = (
 /obj/structure/toilet/secret{
 	secret_type = /obj/item/storage/box/donkpockets;
@@ -32954,6 +32942,14 @@
 /obj/structure/chair/bench/red/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/outpost/hallway/central)
+"vIT" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/canteen)
 "vJv" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -33275,15 +33271,25 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "vSg" = (
@@ -34457,20 +34463,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
-"wJd" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "wJh" = (
 /obj/structure/sign/moniq{
 	pixel_y = 28;
@@ -36557,6 +36549,20 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/outpost/fraction/syndi)
+"ylI" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "yme" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -61364,7 +61370,7 @@ mCh
 gWG
 pkB
 vyZ
-wJd
+ylI
 aIl
 cGD
 cGD
@@ -61921,7 +61927,7 @@ aIl
 hMo
 eVx
 aIl
-vRZ
+azO
 pkB
 pkB
 aIl
@@ -62112,7 +62118,7 @@ prV
 pkB
 pkB
 skl
-mRZ
+vRZ
 aIl
 cGD
 cGD
@@ -62299,7 +62305,7 @@ prV
 pkB
 eJq
 aIl
-aIl
+vix
 aIl
 cGD
 cGD
@@ -62482,7 +62488,7 @@ maA
 iNo
 oel
 aIl
-sRz
+vIT
 pkB
 pkB
 aIl

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -650,18 +650,6 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/starboard)
-"azO" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "azT" = (
 /turf/open/floor/wood{
 	light_range = 2
@@ -12548,13 +12536,11 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "ilg" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
 	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "ilq" = (
@@ -20416,6 +20402,16 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
+"nuY" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/canteen)
 "nvv" = (
 /obj/effect/turf_decal/corner/transparent/blue/half{
 	dir = 1
@@ -31010,6 +31006,10 @@
 /obj/effect/spawner/random/celadon_drink,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/relax_room)
+"uAo" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/fakepit,
+/area/outpost/crew/canteen)
 "uAT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31650,6 +31650,28 @@
 "uXL" = (
 /turf/open/floor/plating/asteroid/icerock,
 /area/outpost/external)
+"uXW" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "uYn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32096,12 +32118,6 @@
 	planetary_atmos = 1
 	},
 /area/outpost/hallway/central)
-"vix" = (
-/obj/structure/falsewall/reinforced{
-	req_one_access_txt = "8131"
-	},
-/turf/open/floor/fakepit,
-/area/outpost/crew/canteen)
 "viF" = (
 /obj/structure/toilet/secret{
 	secret_type = /obj/item/storage/box/donkpockets;
@@ -32942,14 +32958,6 @@
 /obj/structure/chair/bench/red/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/outpost/hallway/central)
-"vIT" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
 "vJv" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
@@ -33271,25 +33279,17 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "vSg" = (
@@ -34547,6 +34547,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
+"wMR" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "wNg" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -36549,20 +36561,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/outpost/fraction/syndi)
-"ylI" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "yme" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -61370,7 +61368,7 @@ mCh
 gWG
 pkB
 vyZ
-ylI
+vRZ
 aIl
 cGD
 cGD
@@ -61927,7 +61925,7 @@ aIl
 hMo
 eVx
 aIl
-azO
+wMR
 pkB
 pkB
 aIl
@@ -62118,7 +62116,7 @@ prV
 pkB
 pkB
 skl
-vRZ
+uXW
 aIl
 cGD
 cGD
@@ -62305,7 +62303,7 @@ prV
 pkB
 eJq
 aIl
-vix
+uAo
 aIl
 cGD
 cGD
@@ -62488,7 +62486,7 @@ maA
 iNo
 oel
 aIl
-vIT
+ilg
 pkB
 pkB
 aIl
@@ -62864,7 +62862,7 @@ aIl
 aIl
 mod
 fTx
-ilg
+nuY
 aIl
 cGD
 cGD

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -12536,19 +12536,14 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "ilg" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall2"
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/mono/dark,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "ilq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16214,7 +16209,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 31
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "kDX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -19645,6 +19640,28 @@
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_2)
+"mRZ" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "mSb" = (
 /obj/machinery/conveyor/auto{
 	dir = 1;
@@ -23203,10 +23220,11 @@
 /turf/open/floor/grass,
 /area/outpost/hallway/aft)
 "prV" = (
-/obj/structure/extinguisher_cabinet/directional/north{
-	pixel_x = -6
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "psd" = (
 /obj/structure/rack,
@@ -27421,30 +27439,18 @@
 	},
 /area/outpost/hallway/central)
 "sax" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
+	},
 /obj/machinery/button/door{
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 10;
 	name = "Door Bolt";
-	id = "aster_bar_stall1"
+	id = "aster_bar_stall2"
 	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "saI" = (
@@ -28462,6 +28468,14 @@
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/vacant_rooms)
+"sRz" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/canteen)
 "sRB" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -33261,16 +33275,14 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
 	},
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
@@ -34445,6 +34457,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
+"wJd" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "wJh" = (
 /obj/structure/sign/moniq{
 	pixel_y = 28;
@@ -61336,10 +61362,10 @@ lre
 aIl
 mCh
 gWG
+pkB
 vyZ
-vRZ
+wJd
 aIl
-cGD
 cGD
 cGD
 pdc
@@ -61522,11 +61548,11 @@ aaJ
 vNo
 aIl
 kDP
+pkB
 eJq
 aIl
 aIl
 aIl
-cGD
 cGD
 cGD
 pdc
@@ -61710,10 +61736,10 @@ vOi
 aIl
 ckd
 pkB
+pkB
 ejk
-ilg
+sax
 aIl
-cGD
 cGD
 cGD
 cGD
@@ -61895,12 +61921,12 @@ aIl
 hMo
 eVx
 aIl
-kDP
+vRZ
+pkB
 pkB
 aIl
 aIl
 aIl
-cGD
 cGD
 cGD
 cGD
@@ -62082,12 +62108,12 @@ aIl
 uxa
 fmV
 aIl
-ckd
+prV
+pkB
 pkB
 skl
-sax
+mRZ
 aIl
-cGD
 cGD
 cGD
 pdc
@@ -62270,11 +62296,11 @@ hMo
 eVx
 aIl
 prV
+pkB
 eJq
 aIl
 aIl
 aIl
-cGD
 cGD
 cGD
 pdc
@@ -62455,10 +62481,10 @@ rey
 maA
 iNo
 oel
-blm
-twd
-egU
-aSl
+aIl
+sRz
+pkB
+pkB
 aIl
 cGD
 cGD
@@ -62642,10 +62668,10 @@ wEw
 wEw
 awn
 uyb
-aIl
-mod
-fTx
-fTx
+blm
+twd
+egU
+aSl
 aIl
 cGD
 cGD
@@ -62830,9 +62856,9 @@ aIl
 aIl
 aIl
 aIl
-eER
-wdO
-wdO
+mod
+fTx
+ilg
 aIl
 cGD
 cGD
@@ -63017,9 +63043,9 @@ cGD
 cGD
 cGD
 aIl
-aIl
-aIl
-aIl
+eER
+wdO
+wdO
 aIl
 cGD
 pdc
@@ -63203,11 +63229,11 @@ cGD
 cGD
 cGD
 cGD
-cGD
-cGD
-cGD
-cGD
-cGD
+aIl
+aIl
+aIl
+aIl
+aIl
 cGD
 pdc
 pdc
@@ -63389,13 +63415,13 @@ vuq
 vuq
 cGD
 cGD
-pdc
 cGD
-pdc
-pdc
-pdc
-pdc
-pdc
+cGD
+cGD
+cGD
+cGD
+cGD
+cGD
 pdc
 pdc
 pdc
@@ -63575,13 +63601,13 @@ tSq
 tSq
 vuq
 cGD
+cGD
 pdc
 pdc
-pdc
-pdc
-pdc
-pdc
-pdc
+cGD
+cGD
+cGD
+cGD
 pdc
 pdc
 pdc
@@ -63766,7 +63792,7 @@ pdc
 pdc
 pdc
 pdc
-pdc
+cGD
 pdc
 pdc
 pdc

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1222,11 +1222,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
-"aSl" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "aSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1426,9 +1421,11 @@
 	},
 /area/outpost/vacant_rooms/trash_factory)
 "bbe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/obj/machinery/airalarm/directional/south{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -7293,26 +7290,14 @@
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "eJq" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -9
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "eJu" = (
 /obj/effect/turf_decal/industrial/traffic{
@@ -9084,12 +9069,7 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
 "fTx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south{
-	req_access_txt = "8100, 8111"
-	},
+/obj/effect/turf_decal/corner/transparent/blue/full,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "fTF" = (
@@ -14252,8 +14232,26 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
 "jox" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/dark,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/leaper_sludge{
+	layer = 2.07
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping{
+	layer = 2.07
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "jpg" = (
 /obj/effect/turf_decal/corner/transparent/blue/three_quarters{
@@ -19020,10 +19018,12 @@
 /turf/open/floor/plasteel,
 /area/outpost/vacant_rooms)
 "mod" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -23282,6 +23282,11 @@
 	pixel_y = 27
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 4;
+	mouse_opacity = 0
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "psd" = (
@@ -29378,14 +29383,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/starboard)
-"twd" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "twR" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
@@ -33642,7 +33639,6 @@
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "wdZ" = (
@@ -61406,10 +61402,10 @@ lre
 blm
 mCh
 egU
-egU
 vRZ
 skl
 blm
+cGD
 cGD
 cGD
 pdc
@@ -61593,10 +61589,10 @@ vNo
 blm
 kDP
 pkB
-jox
 blm
 blm
 blm
+cGD
 cGD
 cGD
 pdc
@@ -61780,10 +61776,10 @@ vOi
 blm
 ckd
 pkB
-egU
 ilg
 gWG
 blm
+cGD
 cGD
 cGD
 cGD
@@ -61967,10 +61963,10 @@ eVx
 blm
 kmM
 pkB
-pkB
 blm
 blm
 blm
+cGD
 cGD
 cGD
 cGD
@@ -62154,10 +62150,10 @@ fmV
 blm
 jFK
 egU
-pkB
 sax
-eJq
+jox
 blm
+cGD
 cGD
 cGD
 pdc
@@ -62341,10 +62337,10 @@ eVx
 blm
 prV
 pkB
-jox
 blm
 qWv
 blm
+cGD
 cGD
 cGD
 pdc
@@ -62526,10 +62522,10 @@ maA
 iNo
 oel
 blm
-twd
-egU
-aSl
+pkB
+eJq
 blm
+cGD
 cGD
 cGD
 cGD
@@ -62715,7 +62711,7 @@ uyb
 nsB
 mod
 bbe
-fTx
+blm
 blm
 cGD
 cGD
@@ -63089,7 +63085,7 @@ cGD
 blm
 vyZ
 ejk
-ejk
+fTx
 blm
 cGD
 pdc

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -3227,8 +3227,9 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "ckd" = (
-/obj/machinery/recharge_station{
-	pixel_y = 22
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -6366,13 +6367,17 @@
 /turf/open/floor/plating,
 /area/outpost/fraction/syndi)
 "egU" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
+/obj/machinery/light/small/directional/north,
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/corner/transparent/blue/full,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "ehl" = (
@@ -6443,7 +6448,8 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "ejk" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/fakepit,
 /area/outpost/crew/lounge/cab_1)
 "ejS" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
@@ -7159,6 +7165,9 @@
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "eFk" = (
@@ -7272,13 +7281,19 @@
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "eJq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock{
-	name = "Lounge"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall2"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "eJu" = (
 /obj/effect/turf_decal/industrial/traffic{
@@ -8396,28 +8411,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
-"fvU" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/lounge/cab_1)
 "fwd" = (
 /turf/closed/wall/mineral/wood,
 /area/outpost/hallway/central)
@@ -9072,9 +9065,11 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
 "fTx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/machinery/airalarm/directional/south{
+	req_access_txt = "8100, 8111"
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -9637,15 +9632,6 @@
 	color = "#A47449"
 	},
 /area/outpost/hallway/central)
-"gqw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south{
-	req_access_txt = "8100, 8111"
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "gqT" = (
 /obj/effect/mob_spawn/human/elysium_outpost/medic{
 	dir = 1
@@ -15539,6 +15525,19 @@
 /area/ruin/beach/complex{
 	name = "Elysium Town"
 	})
+"khI" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "khQ" = (
 /obj/structure/table/wood/fancy/orange,
 /turf/open/floor/wood/ebony,
@@ -15895,6 +15894,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/outpost/crew/bar/bar_zone)
+"ksZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "kts" = (
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18972,6 +18978,9 @@
 "mod" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "moq" = (
@@ -21788,6 +21797,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_2)
+"oxD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock{
+	name = "Lounge"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "oyg" = (
 /obj/item/banner/nanotrasen/mundane,
 /obj/effect/turf_decal/siding/wood{
@@ -22982,8 +23003,16 @@
 /turf/open/floor/mineral/plastitanium,
 /area/outpost/fraction/syndi)
 "pkB" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/fakepit,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "pla" = (
 /obj/structure/chair/bench/olive/directional/west,
@@ -23213,9 +23242,8 @@
 /turf/open/floor/grass,
 /area/outpost/hallway/aft)
 "prV" = (
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
+/obj/machinery/recharge_station{
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -26992,18 +27020,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
-"rNq" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/lounge/cab_1)
 "rNO" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -27437,20 +27453,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
-"rZY" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "saf" = (
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plating/asteroid/sand/lit{
@@ -27634,7 +27636,6 @@
 /turf/closed/indestructible/reinforced,
 /area/outpost/fraction/nanotrasen)
 "skl" = (
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "sks" = (
@@ -29102,19 +29103,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/outpost/crew/garden)
-"tmK" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "tnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -30955,6 +30943,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access_txt = "8100, 8111";
+	dir = 1;
+	pixel_y = -36;
+	pixel_x = 33
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
 "uyh" = (
@@ -31908,6 +31908,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/outpost/cargo)
+"vew" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "veF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -32733,16 +32742,15 @@
 	name = "Elysium Town"
 	})
 "vyZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	dir = 4;
 	pixel_x = -21;
 	pixel_y = 10;
 	name = "Door Bolt";
-	id = "aster_bar_stall2"
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/mono/dark,
@@ -33011,6 +33019,32 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/concrete/tiles,
 /area/outpost/hallway/aft)
+"vLs" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
+"vLJ" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "vLM" = (
 /obj/structure/statue_ships/isv_box/ne,
 /turf/open/floor/carpet/red_gold{
@@ -33597,6 +33631,7 @@
 /obj/effect/turf_decal/trimline/transparent/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "wdZ" = (
@@ -35426,20 +35461,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
-"xzG" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/lounge/cab_1)
 "xzT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -61374,9 +61395,9 @@ lre
 blm
 mCh
 gWG
-ejk
+skl
 vRZ
-xzG
+vyZ
 blm
 cGD
 cGD
@@ -61560,8 +61581,8 @@ aaJ
 vNo
 blm
 kDP
-ejk
 skl
+vLJ
 blm
 blm
 blm
@@ -61746,11 +61767,11 @@ aIl
 qSD
 vOi
 blm
-ckd
-ejk
-ejk
+prV
+skl
+skl
 ilg
-vyZ
+eJq
 blm
 cGD
 cGD
@@ -61933,9 +61954,9 @@ aIl
 hMo
 eVx
 blm
-rNq
-ejk
-ejk
+pkB
+skl
+skl
 blm
 blm
 blm
@@ -62120,11 +62141,11 @@ aIl
 uxa
 fmV
 blm
-prV
-ejk
-ejk
+ckd
+skl
+skl
 sax
-fvU
+vLs
 blm
 cGD
 cGD
@@ -62307,11 +62328,11 @@ aIl
 hMo
 eVx
 blm
-prV
-ejk
+ckd
 skl
+vLJ
 blm
-pkB
+ejk
 blm
 cGD
 cGD
@@ -62495,7 +62516,7 @@ iNo
 oel
 blm
 twd
-ejk
+skl
 aSl
 blm
 cGD
@@ -62680,10 +62701,10 @@ wEw
 wEw
 awn
 uyb
-eJq
+oxD
 mod
+ksZ
 fTx
-gqw
 blm
 cGD
 cGD
@@ -62869,8 +62890,8 @@ aIl
 aIl
 blm
 eER
+vew
 wdO
-egU
 blm
 cGD
 cGD
@@ -63055,9 +63076,9 @@ cGD
 cGD
 cGD
 blm
-rZY
-tmK
-tmK
+egU
+khI
+khI
 blm
 cGD
 pdc

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -3237,13 +3237,10 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "ckd" = (
-/obj/structure/extinguisher_cabinet/directional/north{
-	pixel_x = -6
+/obj/machinery/recharge_station{
+	pixel_y = 22
 	},
-/obj/machinery/firealarm/directional/north{
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "ckm" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -6453,17 +6450,10 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "ejk" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 2";
+	id_tag = "aster_bar_stall2"
 	},
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "ejS" = (
@@ -7293,10 +7283,7 @@
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "eJq" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom Stall 2";
-	id_tag = "waterbar_stall2"
-	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "eJu" = (
@@ -8110,9 +8097,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/departments/restroom{
-	pixel_y = -32
-	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
 "fnK" = (
@@ -10628,10 +10612,7 @@
 /turf/open/floor/plating/rust,
 /area/outpost/fraction/syndi)
 "gWG" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -24;
-	pixel_y = 6
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "gWO" = (
@@ -12555,8 +12536,19 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "ilg" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall2"
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "ilq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16219,10 +16211,8 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "kDP" = (
-/obj/machinery/door/airlock/maintenance/external{
-	dir = 4;
-	id_tag = "waterbar_charge2";
-	name = "Recharge Station 2"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 31
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
@@ -19234,14 +19224,6 @@
 	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_x = 10;
-	pixel_y = -21;
-	name = "Door Bolt";
-	id = "waterbar_charge2"
-	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "mCp" = (
@@ -23221,19 +23203,10 @@
 /turf/open/floor/grass,
 /area/outpost/hallway/aft)
 "prV" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	dir = 8;
-	pixel_x = 21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "waterbar_stall1"
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -6
 	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "psd" = (
 /obj/structure/rack,
@@ -27448,12 +27421,31 @@
 	},
 /area/outpost/hallway/central)
 "sax" = (
-/obj/machinery/door/airlock/maintenance/external{
+/obj/machinery/button/door{
 	dir = 4;
-	id_tag = "waterbar_charge1";
-	name = "Recharge Station 1"
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall1"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "saI" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -27625,16 +27617,9 @@
 /turf/closed/indestructible/reinforced,
 /area/outpost/fraction/nanotrasen)
 "skl" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "waterbar_stall2"
-	},
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 1";
+	id_tag = "aster_bar_stall1"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
@@ -30940,6 +30925,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
 "uyh" = (
@@ -32718,19 +32706,11 @@
 	name = "Elysium Town"
 	})
 "vyZ" = (
-/obj/machinery/recharge_station{
-	pixel_y = 22
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 3";
+	id_tag = "aster_bar_stall3"
 	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	dir = 1;
-	pixel_x = 10;
-	pixel_y = -21;
-	name = "Door Bolt";
-	id = "waterbar_charge1"
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "vzF" = (
 /obj/effect/turf_decal/box/red/corners{
@@ -33281,11 +33261,18 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom Stall 1";
-	id_tag = "waterbar_stall1"
+/obj/machinery/light/small/directional/west,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "vSg" = (
 /obj/structure/flora/herb/g,
@@ -61348,10 +61335,10 @@ lFl
 lre
 aIl
 mCh
-aIl
+gWG
 vyZ
+vRZ
 aIl
-cGD
 cGD
 cGD
 cGD
@@ -61535,12 +61522,12 @@ aaJ
 vNo
 aIl
 kDP
-aIl
-sax
-aIl
+eJq
 aIl
 aIl
 aIl
+cGD
+cGD
 cGD
 pdc
 pdc
@@ -61722,12 +61709,12 @@ qSD
 vOi
 aIl
 ckd
-gWG
 pkB
+ejk
 ilg
-eJq
-skl
 aIl
+cGD
+cGD
 cGD
 cGD
 pdc
@@ -61906,15 +61893,15 @@ rWC
 oAb
 aIl
 hMo
-oel
-blm
-twd
-twd
-egU
-aSl
+eVx
+aIl
+kDP
+pkB
 aIl
 aIl
 aIl
+cGD
+cGD
 cGD
 cGD
 pdc
@@ -62095,13 +62082,13 @@ aIl
 uxa
 fmV
 aIl
-mod
-fTx
-fTx
-fTx
-vRZ
-prV
+ckd
+pkB
+skl
+sax
 aIl
+cGD
+cGD
 cGD
 pdc
 pdc
@@ -62282,13 +62269,13 @@ aIl
 hMo
 eVx
 aIl
-eER
-wdO
-wdO
-ejk
+prV
+eJq
 aIl
 aIl
 aIl
+cGD
+cGD
 cGD
 pdc
 pdc
@@ -62467,13 +62454,13 @@ fcl
 rey
 maA
 iNo
-eVx
+oel
+blm
+twd
+egU
+aSl
 aIl
-aIl
-aIl
-aIl
-aIl
-aIl
+cGD
 cGD
 cGD
 cGD
@@ -62656,10 +62643,10 @@ wEw
 awn
 uyb
 aIl
-cGD
-cGD
-cGD
-cGD
+mod
+fTx
+fTx
+aIl
 cGD
 cGD
 cGD
@@ -62843,12 +62830,12 @@ aIl
 aIl
 aIl
 aIl
+eER
+wdO
+wdO
+aIl
 cGD
 cGD
-cGD
-cGD
-cGD
-pdc
 pdc
 pdc
 pdc
@@ -63029,11 +63016,11 @@ cGD
 cGD
 cGD
 cGD
-cGD
-cGD
-cGD
-cGD
-cGD
+aIl
+aIl
+aIl
+aIl
+aIl
 cGD
 pdc
 pdc
@@ -63221,7 +63208,7 @@ cGD
 cGD
 cGD
 cGD
-pdc
+cGD
 pdc
 pdc
 pdc
@@ -63404,10 +63391,10 @@ cGD
 cGD
 pdc
 cGD
-cGD
 pdc
 pdc
-cGD
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -63591,7 +63578,7 @@ cGD
 pdc
 pdc
 pdc
-cGD
+pdc
 pdc
 pdc
 pdc
@@ -63783,8 +63770,8 @@ pdc
 pdc
 pdc
 pdc
-pdc
-pdc
+cGD
+cGD
 pdc
 pdc
 pdc

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1224,6 +1224,7 @@
 /area/outpost/fraction/nanotrasen)
 "aSl" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "aSr" = (
@@ -1424,6 +1425,13 @@
 	light_range = 2
 	},
 /area/outpost/vacant_rooms/trash_factory)
+"bbe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "bbj" = (
 /turf/closed/indestructible/reinforced,
 /area/outpost/crew/cryo)
@@ -3227,9 +3235,8 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "ckd" = (
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
+/obj/machinery/recharge_station{
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
@@ -6367,17 +6374,7 @@
 /turf/open/floor/plating,
 /area/outpost/fraction/syndi)
 "egU" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "ehl" = (
@@ -6448,8 +6445,17 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "ejk" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/fakepit,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "ejS" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
@@ -7168,8 +7174,14 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/auto_name/directional/south{
+	req_access_txt = "8100, 8111";
+	dir = 1;
+	pixel_y = 29;
+	pixel_x = -1
+	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
+/area/outpost/crew/canteen)
 "eFk" = (
 /obj/structure/railing/wood{
 	layer = 3.1;
@@ -7281,18 +7293,25 @@
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "eJq" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall2"
-	},
-/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "eJu" = (
@@ -9086,6 +9105,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/hallway/central)
+"fTQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "fTZ" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/dark_2,
@@ -10622,7 +10651,18 @@
 /area/outpost/fraction/syndi)
 "gWG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall2"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "gWO" = (
 /obj/structure/flora/ausbushes/sunnybush,
@@ -14211,6 +14251,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
+"jox" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "jpg" = (
 /obj/effect/turf_decal/corner/transparent/blue/three_quarters{
 	dir = 1
@@ -14720,6 +14764,13 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
 /area/outpost/hallway/fore)
+"jFK" = (
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "jGj" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -15525,19 +15576,6 @@
 /area/ruin/beach/complex{
 	name = "Elysium Town"
 	})
-"khI" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "khQ" = (
 /obj/structure/table/wood/fancy/orange,
 /turf/open/floor/wood/ebony,
@@ -15720,6 +15758,19 @@
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
+"kmM" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "kmS" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -15894,13 +15945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/outpost/crew/bar/bar_zone)
-"ksZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "kts" = (
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20362,6 +20406,18 @@
 /obj/structure/flora/ausbushes/sparsegrass/hell,
 /turf/open/floor/plating/moss,
 /area/outpost/hallway/central)
+"nsB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock{
+	name = "Lounge"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "nsT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -21797,18 +21853,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_2)
-"oxD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock{
-	name = "Lounge"
-	},
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "oyg" = (
 /obj/item/banner/nanotrasen/mundane,
 /obj/effect/turf_decal/siding/wood{
@@ -23003,16 +23047,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/outpost/fraction/syndi)
 "pkB" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "pla" = (
 /obj/structure/chair/bench/olive/directional/west,
@@ -23242,9 +23277,11 @@
 /turf/open/floor/grass,
 /area/outpost/hallway/aft)
 "prV" = (
-/obj/machinery/recharge_station{
-	pixel_y = 22
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "psd" = (
@@ -25802,6 +25839,10 @@
 	color = "#55391A"
 	},
 /area/outpost/fraction/solfed)
+"qWv" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/fakepit,
+/area/outpost/crew/lounge/cab_1)
 "qWC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -27636,7 +27677,18 @@
 /turf/closed/indestructible/reinforced,
 /area/outpost/fraction/nanotrasen)
 "skl" = (
-/turf/open/floor/plasteel/dark,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
 "sks" = (
 /obj/structure/table/wood/fancy/blue,
@@ -30943,12 +30995,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/south{
-	req_access_txt = "8100, 8111";
-	dir = 1;
-	pixel_y = -36;
-	pixel_x = 33
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31908,15 +31954,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/grimy,
 /area/outpost/cargo)
-"vew" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "veF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -32742,18 +32779,18 @@
 	name = "Elysium Town"
 	})
 "vyZ" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
 	},
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/light/small/directional/north,
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "vzF" = (
 /obj/effect/turf_decal/box/red/corners{
@@ -33019,32 +33056,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/concrete/tiles,
 /area/outpost/hallway/aft)
-"vLs" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/lounge/cab_1)
-"vLJ" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/lounge/cab_1)
 "vLM" = (
 /obj/structure/statue_ships/isv_box/ne,
 /turf/open/floor/carpet/red_gold{
@@ -61394,10 +61405,10 @@ lFl
 lre
 blm
 mCh
-gWG
-skl
+egU
+egU
 vRZ
-vyZ
+skl
 blm
 cGD
 cGD
@@ -61581,8 +61592,8 @@ aaJ
 vNo
 blm
 kDP
-skl
-vLJ
+pkB
+jox
 blm
 blm
 blm
@@ -61767,11 +61778,11 @@ aIl
 qSD
 vOi
 blm
-prV
-skl
-skl
+ckd
+pkB
+egU
 ilg
-eJq
+gWG
 blm
 cGD
 cGD
@@ -61954,9 +61965,9 @@ aIl
 hMo
 eVx
 blm
+kmM
 pkB
-skl
-skl
+pkB
 blm
 blm
 blm
@@ -62141,11 +62152,11 @@ aIl
 uxa
 fmV
 blm
-ckd
-skl
-skl
+jFK
+egU
+pkB
 sax
-vLs
+eJq
 blm
 cGD
 cGD
@@ -62328,11 +62339,11 @@ aIl
 hMo
 eVx
 blm
-ckd
-skl
-vLJ
+prV
+pkB
+jox
 blm
-ejk
+qWv
 blm
 cGD
 cGD
@@ -62516,7 +62527,7 @@ iNo
 oel
 blm
 twd
-skl
+egU
 aSl
 blm
 cGD
@@ -62701,9 +62712,9 @@ wEw
 wEw
 awn
 uyb
-oxD
+nsB
 mod
-ksZ
+bbe
 fTx
 blm
 cGD
@@ -62890,7 +62901,7 @@ aIl
 aIl
 blm
 eER
-vew
+fTQ
 wdO
 blm
 cGD
@@ -63076,9 +63087,9 @@ cGD
 cGD
 cGD
 blm
-egU
-khI
-khI
+vyZ
+ejk
+ejk
 blm
 cGD
 pdc

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -5117,6 +5117,14 @@
 /obj/machinery/mission_pad,
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
+"dsg" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/canteen)
 "dsN" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/full,
 /obj/effect/turf_decal/trimline/opaque/neutral/filled/warning,
@@ -9875,6 +9883,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
+"gyR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall2"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "gzj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -12536,12 +12559,26 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "ilg" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
+/obj/structure/toilet{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/canteen)
 "ilq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20402,16 +20439,6 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/hall_1)
-"nuY" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
 "nvv" = (
 /obj/effect/turf_decal/corner/transparent/blue/half{
 	dir = 1
@@ -21231,11 +21258,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
@@ -21872,6 +21902,20 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
+"oBD" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "oCc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -27425,19 +27469,14 @@
 	},
 /area/outpost/hallway/central)
 "sax" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall2"
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/dark,
 /area/outpost/crew/canteen)
 "saI" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -30721,6 +30760,18 @@
 /obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo)
+"usd" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/canteen)
 "use" = (
 /turf/open/floor/grass/fairy/beach,
 /area/outpost/hallway/central)
@@ -30908,17 +30959,14 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/sign/departments/restroom{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/outpost/crew/canteen)
@@ -31006,10 +31054,6 @@
 /obj/effect/spawner/random/celadon_drink,
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/relax_room)
-"uAo" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/fakepit,
-/area/outpost/crew/canteen)
 "uAT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31650,28 +31694,6 @@
 "uXL" = (
 /turf/open/floor/plating/asteroid/icerock,
 /area/outpost/external)
-"uXW" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "uYn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -33279,18 +33301,8 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/fakepit,
 /area/outpost/crew/canteen)
 "vSg" = (
 /obj/structure/flora/herb/g,
@@ -34547,18 +34559,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
-"wMR" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "wNg" = (
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
@@ -61368,7 +61368,7 @@ mCh
 gWG
 pkB
 vyZ
-vRZ
+oBD
 aIl
 cGD
 cGD
@@ -61742,7 +61742,7 @@ ckd
 pkB
 pkB
 ejk
-sax
+gyR
 aIl
 cGD
 cGD
@@ -61925,7 +61925,7 @@ aIl
 hMo
 eVx
 aIl
-wMR
+usd
 pkB
 pkB
 aIl
@@ -62116,7 +62116,7 @@ prV
 pkB
 pkB
 skl
-uXW
+ilg
 aIl
 cGD
 cGD
@@ -62303,7 +62303,7 @@ prV
 pkB
 eJq
 aIl
-uAo
+vRZ
 aIl
 cGD
 cGD
@@ -62486,7 +62486,7 @@ maA
 iNo
 oel
 aIl
-ilg
+dsg
 pkB
 pkB
 aIl
@@ -62862,7 +62862,7 @@ aIl
 aIl
 mod
 fTx
-nuY
+sax
 aIl
 cGD
 cGD

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1223,14 +1223,9 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
 "aSl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south{
-	req_access_txt = "8100, 8111"
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "aSr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -1815,13 +1810,8 @@
 /turf/open/floor/plasteel/white,
 /area/outpost/medical/palata_2)
 "blm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock{
-	name = "Lounge"
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/turf/closed/indestructible/reinforced,
+/area/outpost/crew/lounge/cab_1)
 "bln" = (
 /obj/structure/table/wood/poker,
 /obj/item/flashlight/lamp/green{
@@ -3241,7 +3231,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "ckm" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
@@ -5117,14 +5107,6 @@
 /obj/machinery/mission_pad,
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
-"dsg" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
 "dsN" = (
 /obj/effect/turf_decal/corner/opaque/ntblue/full,
 /obj/effect/turf_decal/trimline/opaque/neutral/filled/warning,
@@ -6384,12 +6366,15 @@
 /turf/open/floor/plating,
 /area/outpost/fraction/syndi)
 "egU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "ehl" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -6458,12 +6443,8 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
 "ejk" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom Stall 2";
-	id_tag = "aster_bar_stall2"
-	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "ejS" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
 /obj/structure/crate_shelf,
@@ -7167,19 +7148,19 @@
 /turf/open/floor/carpet/blue,
 /area/outpost/fraction/solfed)
 "eER" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 12;
+	pixel_y = 15
 	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "eFk" = (
 /obj/structure/railing/wood{
 	layer = 3.1;
@@ -7291,9 +7272,14 @@
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
 "eJq" = (
-/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock{
+	name = "Lounge"
+	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "eJu" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 4
@@ -8410,6 +8396,28 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
+"fvU" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/insectguts,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/leaper_sludge,
+/obj/effect/decal/cleanable/glitter,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/built/directional/south,
+/obj/effect/decal/cleanable/wrapping,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "fwd" = (
 /turf/closed/wall/mineral/wood,
 /area/outpost/hallway/central)
@@ -9064,14 +9072,12 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
 "fTx" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "fTF" = (
 /obj/item/stack/sheet/mineral/uranium/five,
 /turf/open/floor/plating/asteroid/wasteplanet,
@@ -9631,6 +9637,15 @@
 	color = "#A47449"
 	},
 /area/outpost/hallway/central)
+"gqw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south{
+	req_access_txt = "8100, 8111"
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "gqT" = (
 /obj/effect/mob_spawn/human/elysium_outpost/medic{
 	dir = 1
@@ -9883,21 +9898,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
-"gyR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall2"
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "gzj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -10637,7 +10637,7 @@
 "gWG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "gWO" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
@@ -12559,27 +12559,12 @@
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
 "ilg" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 2";
+	id_tag = "aster_bar_stall2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/insectguts,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/leaper_sludge,
-/obj/effect/decal/cleanable/glitter,
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/built/directional/south,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "ilq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
@@ -16245,7 +16230,7 @@
 	pixel_y = 31
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "kDX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -18985,19 +18970,10 @@
 /turf/open/floor/plasteel,
 /area/outpost/vacant_rooms)
 "mod" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-12";
-	pixel_x = 12;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "moq" = (
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
@@ -19255,7 +19231,7 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "mCp" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/plate{
@@ -21902,20 +21878,6 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
-"oBD" = (
-/obj/machinery/button/door{
-	dir = 4;
-	pixel_x = -21;
-	pixel_y = 10;
-	name = "Door Bolt";
-	id = "aster_bar_stall3"
-	},
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "oCc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -23020,8 +22982,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/outpost/fraction/syndi)
 "pkB" = (
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/obj/structure/falsewall/reinforced,
+/turf/open/floor/fakepit,
+/area/outpost/crew/lounge/cab_1)
 "pla" = (
 /obj/structure/chair/bench/olive/directional/west,
 /turf/open/floor/plasteel,
@@ -23255,7 +23218,7 @@
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "psd" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/techfloor{
@@ -27029,6 +26992,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
+"rNq" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
+/obj/structure/urinal{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "rNO" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -27462,6 +27437,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/operations)
+"rZY" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "saf" = (
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plating/asteroid/sand/lit{
@@ -27469,15 +27458,12 @@
 	},
 /area/outpost/hallway/central)
 "sax" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 1";
+	id_tag = "aster_bar_stall1"
 	},
-/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "saI" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/outpost/hallway/central)
@@ -27648,12 +27634,9 @@
 /turf/closed/indestructible/reinforced,
 /area/outpost/fraction/nanotrasen)
 "skl" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom Stall 1";
-	id_tag = "aster_bar_stall1"
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "sks" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/desk_flag{
@@ -29119,6 +29102,19 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/outpost/crew/garden)
+"tmK" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/structure/mirror{
+	pixel_y = 6;
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/corner/transparent/blue/full,
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "tnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -29343,10 +29339,13 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/starboard)
 "twd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3;
+	mouse_opacity = 0
+	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "twR" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
@@ -30760,18 +30759,6 @@
 /obj/machinery/door/poddoor/shutters/preopen,
 /turf/open/floor/plasteel/tech,
 /area/outpost/cargo)
-"usd" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3;
-	mouse_opacity = 0
-	},
-/obj/structure/urinal{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/mono/dark,
-/area/outpost/crew/canteen)
 "use" = (
 /turf/open/floor/grass/fairy/beach,
 /area/outpost/hallway/central)
@@ -32746,12 +32733,20 @@
 	name = "Elysium Town"
 	})
 "vyZ" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom Stall 3";
-	id_tag = "aster_bar_stall3"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/toilet{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall2"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "vzF" = (
 /obj/effect/turf_decal/box/red/corners{
 	dir = 8
@@ -33301,9 +33296,12 @@
 /turf/open/floor/plasteel,
 /area/outpost/operations)
 "vRZ" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/fakepit,
-/area/outpost/crew/canteen)
+/obj/machinery/door/airlock{
+	name = "Bathroom Stall 3";
+	id_tag = "aster_bar_stall3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/outpost/crew/lounge/cab_1)
 "vSg" = (
 /obj/structure/flora/herb/g,
 /turf/open/floor/grass/fairy,
@@ -33593,18 +33591,14 @@
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
 "wdO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 14;
-	pixel_y = 5
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_y = 6;
-	pixel_x = 27
+/obj/effect/turf_decal/trimline/transparent/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/corner/transparent/blue/full,
 /turf/open/floor/plasteel/dark,
-/area/outpost/crew/canteen)
+/area/outpost/crew/lounge/cab_1)
 "wdZ" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -35432,6 +35426,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
+"xzG" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 10;
+	name = "Door Bolt";
+	id = "aster_bar_stall3"
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/outpost/crew/lounge/cab_1)
 "xzT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -61363,13 +61371,13 @@ ndE
 wPF
 lFl
 lre
-aIl
+blm
 mCh
 gWG
-pkB
-vyZ
-oBD
-aIl
+ejk
+vRZ
+xzG
+blm
 cGD
 cGD
 pdc
@@ -61550,13 +61558,13 @@ ndE
 rVD
 aaJ
 vNo
-aIl
+blm
 kDP
-pkB
-eJq
-aIl
-aIl
-aIl
+ejk
+skl
+blm
+blm
+blm
 cGD
 cGD
 pdc
@@ -61737,13 +61745,13 @@ aIl
 aIl
 qSD
 vOi
-aIl
+blm
 ckd
-pkB
-pkB
 ejk
-gyR
-aIl
+ejk
+ilg
+vyZ
+blm
 cGD
 cGD
 cGD
@@ -61924,13 +61932,13 @@ oAb
 aIl
 hMo
 eVx
-aIl
-usd
-pkB
-pkB
-aIl
-aIl
-aIl
+blm
+rNq
+ejk
+ejk
+blm
+blm
+blm
 cGD
 cGD
 cGD
@@ -62111,13 +62119,13 @@ oZi
 aIl
 uxa
 fmV
-aIl
+blm
 prV
-pkB
-pkB
-skl
-ilg
-aIl
+ejk
+ejk
+sax
+fvU
+blm
 cGD
 cGD
 pdc
@@ -62298,13 +62306,13 @@ aIl
 aIl
 hMo
 eVx
-aIl
+blm
 prV
+ejk
+skl
+blm
 pkB
-eJq
-aIl
-vRZ
-aIl
+blm
 cGD
 cGD
 pdc
@@ -62485,11 +62493,11 @@ rey
 maA
 iNo
 oel
-aIl
-dsg
-pkB
-pkB
-aIl
+blm
+twd
+ejk
+aSl
+blm
 cGD
 cGD
 cGD
@@ -62672,11 +62680,11 @@ wEw
 wEw
 awn
 uyb
+eJq
+mod
+fTx
+gqw
 blm
-twd
-egU
-aSl
-aIl
 cGD
 cGD
 cGD
@@ -62859,11 +62867,11 @@ aIl
 aIl
 aIl
 aIl
-aIl
-mod
-fTx
-sax
-aIl
+blm
+eER
+wdO
+egU
+blm
 cGD
 cGD
 pdc
@@ -63046,11 +63054,11 @@ cGD
 cGD
 cGD
 cGD
-aIl
-eER
-wdO
-wdO
-aIl
+blm
+rZY
+tmK
+tmK
+blm
 cGD
 pdc
 pdc
@@ -63233,11 +63241,11 @@ cGD
 cGD
 cGD
 cGD
-aIl
-aIl
-aIl
-aIl
-aIl
+blm
+blm
+blm
+blm
+blm
 cGD
 pdc
 pdc


### PR DESCRIPTION
## Описание / Что этот PR делает
Изменяет вид и кол-во туалетов. Избавляемся от кабинок для ИПС

## Причина создания ПР / Почему это хорошо для игры
Общественное мнение одного-нескольких людей победило со счетом 5:1, логика против эстетики. Теперь все будет грамотно смотреться

## Демонстрация изменений

<img width="1313" height="818" alt="изображение" src="https://github.com/user-attachments/assets/47ab8526-8355-4735-bf71-193dfe1948dc" />

## Список изменений

```yml
🆑
tweak: Карта астероидного аванпоста 
/🆑
```
