### PR TITLE
TWEAK: Закатывание рукавов у одежды

### DIFF
--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -38,7 +38,7 @@
 #include "code/vending.dm"
 #include "code/weebstick.dm"
 #include "code/dynamic_datum.dm"
-#include "code/security_outfit.dm"
+#include "code/alternative_clothing.dm"
 #include "code/faction.dm"
 #include "code/dock_empty_space_fix.dm"
 

--- a/mod_celadon/fixes/code/alternative_clothing.dm
+++ b/mod_celadon/fixes/code/alternative_clothing.dm
@@ -1,6 +1,11 @@
-//Модуль для фикса сломанных оффовских security одежд.
+//Модуль для фикса сломанных одежд. Закатывание рукавов или же самой одежды.
+
 //Путь до файла - code/modules/clothing/under/jobs/security.dm
-//Путь до атласа оффов - /icons/mob/clothing/under/security.dmi
+//Путь до атласа - /icons/mob/clothing/under/security.dmi
+
+//Два предмета, что не удалось починить, но они сломаны:
+//	/obj/item/clothing/under/rank/security/brig_phys/nt
+//	/obj/item/clothing/under/rank/security/brig_phys/nt/skirt
 
 /obj/item/clothing/under/rank/security/officer/skirt
 	roll_sleeves = FALSE
@@ -13,19 +18,6 @@
 
 /obj/item/clothing/under/rank/security/detective/grey/skirt
 	roll_sleeves = FALSE
-
-//Эта вещь сломана полностью и абсолютно и не фиксится никак
-/obj/item/clothing/under/rank/security/brig_phys/nt
-	icon_state = "security_medic"
-	item_state = "rbrig_phys"
-	mob_overlay_state = "security_medic"
-
-//Тоже самое, что и выше
-/obj/item/clothing/under/rank/security/brig_phys/nt/skirt
-	icon_state = "security_medic_skirt"
-	item_state = "rbrig_phys_skirt"
-	roll_sleeves = FALSE
-	mob_overlay_state = "security_medic_skirt"
 
 /obj/item/clothing/under/rank/security/warden/skirt
 	roll_sleeves = FALSE
@@ -63,8 +55,14 @@
 /obj/item/clothing/under/rank/security/officer/camo
 	roll_sleeves = FALSE
 
-
-//Отдельный фикс конкретного предмета
+//Путь до файла - code/modules/clothing/under/miscellaneous.dm
+//Путь до спрайта - icons/mob/clothing/under/misc.dmi
 
 /obj/item/clothing/under/utility/skirt
 	roll_down = FALSE
+
+//Путь до файла - code/modules/clothing/under/syndicate.dm
+//Путь до атласа - icons/mob/clothing/under/syndicate.dmi
+
+/obj/item/clothing/under/syndicate/cybersun/officer
+	roll_sleeves = FALSE


### PR DESCRIPTION
## Описание / Что этот PR делает
Меняем наименование файла и логику названия, переделывая файл из фикса секурити одежд в принципе под файл для фикса подобного рода проблем с одеждой

## Причина создания ПР / Почему это хорошо для игры
Логичнее было бы наспрайтить закатанные рукава для одежд, но да... Поэтому, что бы в игре было чуть меньше сломанностей, просто убираем возможность закатать рукава и молимся на то, что когда-нибудь можно бует вновь закатать рукава!

## Демонстрация изменений / Тестирование

## Список изменений
obj/item/clothing/under/syndicate/cybersun/officer - больше нельзя закатать рукава
```yml
🆑
tweak: Логика названия файла с одеждой
fix: Забираем возможность закатывать рукава
/🆑
```
