### PR TITLE
FIX: Исправляем ошибки после принятия двух PR`ов

### DIFF
--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -171,33 +171,34 @@ Contents:
 	H.gloves.item_state = "s-ninjan"
 
 // [CELADON-REMOVE] - FIXES_ANTAG_NINJA - Вынесено в модуль
-// //This proc allows the suit to be taken off.
-// /obj/item/clothing/suit/space/space_ninja/proc/unlock_suit()
-// 	affecting = null
-// 	REMOVE_TRAIT(src, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-// 	slowdown = 1
-// 	icon_state = "s-ninja"
-// 	if(n_hood)//Should be attached, might not be attached.
-// 		REMOVE_TRAIT(n_hood, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-// 	if(n_shoes)
-// 		REMOVE_TRAIT(n_shoes, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-// 		n_shoes.slowdown++
-// 	if(n_gloves)
-// 		n_gloves.icon_state = "s-ninja"
-// 		n_gloves.item_state = "s-ninja"
-// 		REMOVE_TRAIT(n_gloves, TRAIT_NODROP, NINJA_SUIT_TRAIT)
-// 		n_gloves.candrain = FALSE
-// 		n_gloves.draining = FALSE
+/* //This proc allows the suit to be taken off.
+/obj/item/clothing/suit/space/space_ninja/proc/unlock_suit()
+	affecting = null
+	REMOVE_TRAIT(src, TRAIT_NODROP, NINJA_SUIT_TRAIT)
+	slowdown = 1
+	icon_state = "s-ninja"
+	if(n_hood)//Should be attached, might not be attached.
+		REMOVE_TRAIT(n_hood, TRAIT_NODROP, NINJA_SUIT_TRAIT)
+	if(n_shoes)
+		REMOVE_TRAIT(n_shoes, TRAIT_NODROP, NINJA_SUIT_TRAIT)
+		n_shoes.slowdown++
+	if(n_gloves)
+		n_gloves.icon_state = "s-ninja"
+		n_gloves.item_state = "s-ninja"
+		REMOVE_TRAIT(n_gloves, TRAIT_NODROP, NINJA_SUIT_TRAIT)
+		n_gloves.candrain = FALSE
+		n_gloves.draining = FALSE
 
 
-// /obj/item/clothing/suit/space/space_ninja/examine(mob/user)
-// 	. = ..()
-// 	if(s_initialized)
-// 		if(user == affecting)
-// 			. += "All systems operational. Current energy capacity: <B>[DisplayEnergy(cell.charge)]</B>.\n"+\
-// 			"The CLOAK-tech device is <B>[stealth?"active":"inactive"]</B>.\n"+\
-// 			"There are <B>[s_bombs]</B> smoke bomb\s remaining.\n"+\
-// 			"There are <B>[a_boost]</B> adrenaline booster\s remaining."
+/obj/item/clothing/suit/space/space_ninja/examine(mob/user)
+	. = ..()
+	if(s_initialized)
+		if(user == affecting)
+			. += "All systems operational. Current energy capacity: <B>[DisplayEnergy(cell.charge)]</B>.\n"+\
+			"The CLOAK-tech device is <B>[stealth?"active":"inactive"]</B>.\n"+\
+			"There are <B>[s_bombs]</B> smoke bomb\s remaining.\n"+\
+			"There are <B>[a_boost]</B> adrenaline booster\s remaining."
+*/
 // [/CELADON-REMOVE]
 
 /obj/item/clothing/suit/space/space_ninja/ui_action_click(mob/user, action)

--- a/mod_celadon/_master_files/__master_files.dme
+++ b/mod_celadon/_master_files/__master_files.dme
@@ -5,5 +5,6 @@
 
 #include "code/_paths.dm"
 #include "code/modules/mob/dead/new_player/ship_select.dm"
+#include "code/modules/tgui/states/portable_device.dm"
 
 #endif

--- a/mod_celadon/_master_files/code/modules/tgui/states/portable_device.dm
+++ b/mod_celadon/_master_files/code/modules/tgui/states/portable_device.dm
@@ -1,5 +1,6 @@
 /**
  * tgui state: portable_device_state
+ * Основано на примере кода из "code\modules\tgui\states\inventory.dm"
  *
  * Checks that the src_object is in the user's inventory
  * and that the user is conscious. Allows UI interaction


### PR DESCRIPTION
## Описание / Что этот PR делает

Иссправляем Warnings, после этого: https://github.com/CeladonSS13/Shiptest/pull/2315

_Проблема была в том, что код был закомментирован неверным образом._

<img width="669" height="95" alt="image" src="https://github.com/user-attachments/assets/99f7844d-b95f-4ebf-989c-86e0948e6839" />

Исправляем ошибку билда, после PR`a: https://github.com/CeladonSS13/Shiptest/pull/2315

_Проблема была в отсутствии инициализиации файла .dm._

`code\game\objects\items\devices\radio\radio.dm:147:error: returnGLOB.portable_device_state: undefined var`
<img width="572" height="258" alt="image" src="https://github.com/user-attachments/assets/d06d4058-aa5d-4419-a91c-1201adfe10d5" />

## Список изменений

```yml
🆑
fix: Исправлены ошибки, вызванные плохо проверенными PR`ами.
/🆑
```
