### PR TITLE
MAP: Трубы транспорта на аванпосте

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -18365,8 +18365,8 @@
 	density = 0;
 	dir = 4
 	},
-/obj/structure/transit_tube/station/dispenser/reverse{
-	dir = 4;
+/obj/structure/transit_tube/station/dispenser/flipped{
+	dir = 8;
 	layer = 4
 	},
 /turf/open/floor/plasteel/elevatorshaft,
@@ -24043,7 +24043,7 @@
 /obj/structure/platform/industrial{
 	dir = 8
 	},
-/obj/structure/transit_tube/junction/flipped{
+/obj/structure/transit_tube/junction{
 	layer = 5
 	},
 /turf/open/floor/plating/asteroid/snow/temperatre/snow{
@@ -31085,7 +31085,7 @@
 	pixel_y = 9;
 	layer = 5.2
 	},
-/obj/structure/transit_tube/junction/flipped{
+/obj/structure/transit_tube/junction{
 	layer = 5;
 	dir = 1
 	},
@@ -36843,9 +36843,9 @@
 /obj/structure/sign/poster/bay/random{
 	pixel_x = 32
 	},
-/obj/structure/transit_tube/station/dispenser/reverse{
-	dir = 8;
-	layer = 4
+/obj/structure/transit_tube/station/dispenser{
+	layer = 4;
+	dir = 4
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/outpost/exterior)


### PR DESCRIPTION
## Описание / Что этот PR делает
Фикс транзитных труб

## Причина создания ПР / Почему это хорошо для игры
Да, теперь всякие коты там не застревают
> И нет, в этот раз не ты Барсик

## Список изменений

```yml
🆑
map: Починка транзитных труб на ледяном аванпосте
/🆑
```
