### PR TITLE
MAP: Убираем Админский ньюкастер с ангаров и ставим обычные

### DIFF
--- a/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_40x20.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_40x20.dmm
@@ -1972,6 +1972,15 @@
 	planetary_atmos = 1
 	},
 /area/hangar)
+"NE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/concrete/slab_1{
+	planetary_atmos = 1
+	},
+/area/hangar)
 "NK" = (
 /obj/structure/catwalk/over/plated_catwalk,
 /obj/effect/decal/cleanable/dirt,
@@ -3771,7 +3780,7 @@ Mt
 Mt
 FC
 sP
-eP
+NE
 HI
 Tu
 gE

--- a/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_40x40.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_40x40.dmm
@@ -1311,6 +1311,7 @@
 	pixel_y = 4;
 	pixel_x = -7
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/concrete/reinforced{
 	planetary_atmos = 1
 	},

--- a/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_56x20.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_56x20.dmm
@@ -1533,6 +1533,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/concrete/reinforced{
 	planetary_atmos = 1
 	},

--- a/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_56x40.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_asteroid_56x40.dmm
@@ -1027,6 +1027,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/concrete/reinforced{
 	planetary_atmos = 1
 	},

--- a/_maps/_mod_celadon/outpost/hangar/elysium_ice_20x20.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_ice_20x20.dmm
@@ -715,9 +715,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/east{
-	pixel_y = -6
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hangar)
 "tL" = (

--- a/_maps/_mod_celadon/outpost/hangar/elysium_ice_40x20.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_ice_40x20.dmm
@@ -1462,13 +1462,11 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/east{
-	pixel_y = -6
-	},
 /obj/machinery/light/small/directional/east{
 	light_color = "#FF0000";
 	pixel_y = 10
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hangar)
 "Md" = (

--- a/_maps/_mod_celadon/outpost/hangar/elysium_ice_40x40.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_ice_40x40.dmm
@@ -855,9 +855,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/east{
-	pixel_y = -6
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hangar)
 "ti" = (

--- a/_maps/_mod_celadon/outpost/hangar/elysium_ice_56x20.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_ice_56x20.dmm
@@ -1028,9 +1028,7 @@
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/east{
-	pixel_y = -6
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hangar)
 "CN" = (

--- a/_maps/_mod_celadon/outpost/hangar/elysium_ice_56x40.dmm
+++ b/_maps/_mod_celadon/outpost/hangar/elysium_ice_56x40.dmm
@@ -1373,15 +1373,13 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/east{
-	pixel_y = -6
-	},
 /obj/machinery/light/small/directional/south{
 	light_color = "#FF0000";
 	dir = 4;
 	pixel_y = 10;
 	pixel_x = 28
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/hangar)
 "FS" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Заменяет секьюрити ньюкастер с ангаров зимнего аванпоста на обычный. Также добавляем обычные в астероидные ангары.

## Причина создания ПР / Почему это хорошо для игры
Любой игрок на зимнем аванпосту может объявить в розыск кого угодно и удалить что угодно в новостной ленте

## Список изменений

```yml
🆑
add: Ньюкастеры в ангары астероидного аванпоста
tweak: Замена админского ньюкастера на ледяном аванпосту на обычные
/🆑
```
