### PR TITLE
MAP: Фикс и обновление Лагуны

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
@@ -104,7 +104,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "at" = (
 /obj/docking_port/mobile{
@@ -180,7 +180,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "aL" = (
 /obj/item/kirbyplants/random,
@@ -188,7 +188,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "aN" = (
 /obj/machinery/light/directional/east,
@@ -272,14 +272,13 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "bk" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/chair/pew/right{
+/obj/structure/chair/pew/left{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -377,7 +376,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "bQ" = (
 /obj/structure/disposalpipe/segment{
@@ -429,7 +430,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "cc" = (
 /obj/structure/window,
@@ -449,7 +450,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "cj" = (
 /obj/machinery/vending/coffee{
@@ -468,7 +469,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "ct" = (
 /obj/structure/table/reinforced/glass,
@@ -590,7 +591,9 @@
 	dir = 9
 	},
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "df" = (
 /obj/effect/turf_decal/corner/opaque/white/bordercorner{
@@ -620,7 +623,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "dr" = (
 /obj/machinery/reagentgrinder{
@@ -658,7 +661,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "dL" = (
 /obj/machinery/door/poddoor/preopen{
@@ -708,7 +711,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "dV" = (
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "dZ" = (
 /obj/structure/table/wood/poker,
@@ -804,10 +809,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sign/picture_frame{
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "eR" = (
 /obj/structure/table/reinforced,
@@ -980,7 +987,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "fG" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -1019,7 +1026,7 @@
 /area/ship/external)
 "fV" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "fX" = (
 /obj/machinery/door/airlock{
@@ -1320,7 +1327,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "hZ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1329,7 +1336,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "ib" = (
 /obj/structure/railing,
@@ -1536,7 +1543,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "jf" = (
 /obj/structure/cable{
@@ -1581,7 +1590,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1658,7 +1669,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "jV" = (
 /obj/machinery/airalarm/directional/west,
@@ -1764,14 +1775,16 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "ku" = (
 /obj/structure/bookcase/random/religion,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "kv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -1795,11 +1808,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "ky" = (
-/obj/structure/closet/athletic_mixed{
-	pixel_x = 17;
-	pixel_y = 24;
-	density = 0
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -1844,7 +1852,9 @@
 "ll" = (
 /obj/structure/chair/comfy/grey/directional/west,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "lm" = (
 /obj/vehicle/ridden/janicart,
@@ -1943,7 +1953,7 @@
 /obj/machinery/newscaster/directional/west{
 	pixel_y = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "lI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2020,7 +2030,7 @@
 /obj/item/seeds/wheat,
 /obj/item/seeds/watermelon,
 /obj/item/seeds/carrot,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "mh" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -2086,7 +2096,7 @@
 	pixel_y = -12;
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "mz" = (
 /obj/machinery/door/airlock/external{
@@ -2145,7 +2155,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "mM" = (
 /obj/item/healthanalyzer,
@@ -2188,7 +2198,7 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "mO" = (
-/turf/open/floor/carpet/black,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "mT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2199,7 +2209,7 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "mV" = (
 /obj/structure/chair/sofa/brown/directional/south,
@@ -2274,7 +2284,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "nE" = (
 /obj/machinery/computer/helm{
@@ -2314,7 +2324,7 @@
 	pixel_x = 0;
 	pixel_y = -30
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "nX" = (
 /obj/structure/closet/wall/directional/west,
@@ -2354,6 +2364,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/toilet)
+"ok" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
 "on" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -2404,7 +2420,7 @@
 	},
 /obj/machinery/door/airlock/silver,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "oM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -2571,7 +2587,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "pp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2650,7 +2666,7 @@
 	pixel_x = -25;
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "pN" = (
 /obj/structure/cable{
@@ -2952,7 +2968,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "rC" = (
 /obj/structure/window/reinforced/spawner/west{
@@ -3238,7 +3254,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "tt" = (
 /obj/structure/disposalpipe/segment{
@@ -3447,7 +3463,7 @@
 /obj/structure/closet/wardrobe/mixed,
 /obj/machinery/airalarm/directional/north,
 /obj/item/spacecash/bundle/c1000,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "uO" = (
 /obj/structure/cable{
@@ -3642,7 +3658,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "vP" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3653,7 +3669,7 @@
 /obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "vU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3662,7 +3678,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "vV" = (
 /obj/effect/turf_decal/corner/opaque/white/border,
@@ -3696,7 +3712,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "wi" = (
 /obj/docking_port/stationary{
@@ -3872,7 +3888,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "xr" = (
 /obj/machinery/door/airlock/external{
@@ -4429,7 +4447,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Ax" = (
 /obj/structure/closet/crate/miningcar,
@@ -4442,7 +4460,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing,
 /obj/structure/chair/sofa/grey/left/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "AD" = (
 /obj/item/towel{
@@ -4621,10 +4639,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/structure/chair/pew/left{
+/obj/structure/chair/pew/right{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "Bz" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -4712,10 +4730,10 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/office)
 "BX" = (
-/obj/structure/sign/picture_frame{
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/black,
 /area/ship/crew/library)
 "BY" = (
@@ -4752,13 +4770,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/canteen/kitchen)
 "Ck" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "Co" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -4809,7 +4827,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "CE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4893,9 +4911,6 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/fore)
 "Dg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
 /obj/item/kirbyplants/random{
 	pixel_y = 6
 	},
@@ -4941,8 +4956,11 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Ds" = (
-/obj/structure/chair/sofa/grey/right/directional/east,
-/turf/open/floor/wood,
+/obj/structure/chair/sofa/grey/right/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "Dv" = (
 /obj/structure/janitorialcart,
@@ -4970,8 +4988,8 @@
 	dir = 10
 	},
 /obj/structure/railing,
-/obj/structure/chair/sofa/grey/right/directional/west,
-/turf/open/floor/wood,
+/obj/structure/chair/sofa/grey/right/directional/east,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5058,10 +5076,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/sign/picture_frame{
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Eg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5095,7 +5115,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/siding/wood/end,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "Er" = (
 /obj/item/table_bell,
@@ -5231,7 +5251,7 @@
 	dir = 4
 	},
 /obj/machinery/light/dim/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5500,7 +5520,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "GO" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -5571,11 +5591,11 @@
 /area/ship/engineering)
 "He" = (
 /obj/machinery/newscaster/directional/east,
-/obj/structure/chair/pew/right{
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/pew/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "Hg" = (
 /obj/structure/railing/corner,
@@ -5651,7 +5671,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "HN" = (
 /obj/structure/disposalpipe/segment{
@@ -5680,7 +5700,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "HW" = (
 /obj/structure/chair/comfy/grey/directional/south,
@@ -5785,7 +5805,7 @@
 	dir = 1
 	},
 /obj/structure/chair/sofa/grey/left/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "IX" = (
 /obj/structure/disposalpipe/segment{
@@ -5814,7 +5834,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "Jj" = (
 /obj/structure/bed,
@@ -5823,7 +5843,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "Jo" = (
 /obj/structure/chair,
@@ -5845,13 +5865,10 @@
 /turf/open/floor/carpet/black,
 /area/ship/crew/office)
 "Jr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/chair/pew/left{
+/obj/structure/chair/pew/right{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "Js" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -5897,7 +5914,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Jy" = (
 /obj/structure/mineral_door/paperframe,
@@ -5926,12 +5943,18 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/grey/left/directional/east,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "JD" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -5994,6 +6017,9 @@
 "Kh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
@@ -6175,7 +6201,7 @@
 /area/ship/security)
 "Lu" = (
 /obj/structure/chair/sofa/brown/right/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "LA" = (
 /obj/machinery/atmospherics/components/binary/circulator,
@@ -6290,7 +6316,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Mm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -6307,7 +6333,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Mr" = (
 /obj/machinery/computer/atmos_control/incinerator{
@@ -6339,16 +6367,13 @@
 /area/ship/hallway/fore)
 "ML" = (
 /obj/machinery/light/directional/west,
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/structure/chair/pew/right{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "MM" = (
 /obj/effect/turf_decal/siding/wood{
@@ -6389,7 +6414,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "Np" = (
 /obj/item/radio/intercom/directional/south,
@@ -6405,6 +6430,10 @@
 /obj/effect/turf_decal/industrial/radiation/full,
 /turf/open/floor/plating,
 /area/ship/external)
+"Ns" = (
+/obj/structure/chair/sofa/grey/right/directional/west,
+/turf/open/floor/suns/hatch/walnut,
+/area/ship/crew/canteen)
 "Ny" = (
 /obj/machinery/button/door{
 	id = "cruise_entrance1";
@@ -6436,7 +6465,7 @@
 /obj/structure/table/wood,
 /obj/item/binoculars,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "NB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -6510,7 +6539,7 @@
 /obj/machinery/disposal/bin{
 	pixel_x = -7
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Oj" = (
 /obj/structure/chair/office{
@@ -6624,10 +6653,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sign/picture_frame{
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Pg" = (
 /obj/structure/cable{
@@ -6711,14 +6742,18 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "PC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "PD" = (
 /turf/open/floor/carpet,
@@ -6797,7 +6832,7 @@
 	specialfunctions = 4;
 	normaldoorcontrol = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "PX" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe{
@@ -6832,7 +6867,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "Qg" = (
 /obj/structure/chair/stool/bar{
@@ -6942,7 +6977,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "QJ" = (
 /obj/machinery/door/airlock/external{
@@ -6984,7 +7019,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "QU" = (
 /obj/structure/closet/firecloset/wall/directional/west,
@@ -7037,7 +7072,7 @@
 	specialfunctions = 4;
 	normaldoorcontrol = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "QZ" = (
 /obj/structure/railing{
@@ -7060,7 +7095,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Rd" = (
 /obj/structure/cable{
@@ -7090,7 +7127,7 @@
 /area/ship/engineering)
 "Rg" = (
 /obj/structure/chair/sofa/grey/left/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "Ri" = (
 /obj/structure/cable{
@@ -7119,8 +7156,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/chair/sofa/grey/right/directional/west,
-/turf/open/floor/wood,
+/obj/structure/chair/sofa/grey/right/directional/east,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "Ro" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -7148,7 +7185,7 @@
 /area/ship/crew)
 "Rr" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "Rw" = (
 /obj/structure/chair/comfy/grey/directional/south,
@@ -7190,7 +7227,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew)
 "RJ" = (
 /obj/structure/closet/crate/engineering,
@@ -7214,7 +7251,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "RO" = (
 /obj/item/kirbyplants/random{
@@ -7260,6 +7297,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/hallway/fore)
+"RY" = (
+/turf/open/floor/suns/hatch/walnut,
+/area/ship/crew/canteen)
 "RZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -7315,7 +7355,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Sq" = (
 /obj/structure/closet/crate/internals,
@@ -7344,13 +7386,13 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing,
 /obj/structure/table/wood/fancy/royalblack,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "SK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "SL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -7434,17 +7476,21 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Tx" = (
 /obj/structure/chair/comfy/grey/directional/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sign/picture_frame{
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/diagonal{
+	color = "#543C30"
+	},
 /area/ship/crew/library)
 "Ty" = (
 /obj/structure/disposalpipe/segment{
@@ -7476,7 +7522,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/maple,
 /area/ship/crew/hydroponics)
 "TI" = (
 /obj/machinery/door/airlock/public/glass,
@@ -7490,16 +7536,16 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "TK" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "TL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7516,13 +7562,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "TO" = (
 /obj/structure/railing{
@@ -7564,14 +7610,12 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "TX" = (
-/obj/structure/chair/pew/left{
+/obj/structure/table/wood/fancy/royalblack,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ship/crew/chapel)
+/turf/open/floor/suns/hatch/walnut,
+/area/ship/crew/canteen)
 "Ua" = (
 /obj/structure/window/plasma/reinforced/spawner,
 /obj/structure/window/plasma/reinforced/spawner/east,
@@ -7844,7 +7888,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "VS" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -7968,7 +8012,7 @@
 "WB" = (
 /obj/structure/chair/sofa/brown/left/directional/west,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "WC" = (
 /obj/machinery/door/airlock/wood/glass{
@@ -8003,7 +8047,7 @@
 /area/ship/hallway/aft)
 "WL" = (
 /obj/structure/table/wood/fancy/royalblack,
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/walnut,
 /area/ship/crew/canteen)
 "WR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -8135,13 +8179,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/suns/hatch/mahogany,
 /area/ship/crew/chapel)
 "XC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8337,7 +8381,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "YO" = (
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "YV" = (
 /obj/structure/chair/comfy/shuttle{
@@ -8426,7 +8470,7 @@
 	pixel_y = -12;
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "Zx" = (
 /obj/structure/flora/tree/palm{
@@ -8486,9 +8530,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/flora/herb,
 /turf/open/floor/grass/fairy,
 /area/ship/crew)
 "ZS" = (
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/toilet)
 "ZU" = (
@@ -8510,7 +8556,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/suns/hatch/ebony,
 /area/ship/crew/dorm)
 "ZZ" = (
 /obj/machinery/door/firedoor/border_only{
@@ -9277,9 +9323,9 @@ pq
 qA
 qA
 rb
+TX
 WL
-WL
-rb
+RY
 WL
 SH
 cc
@@ -9320,8 +9366,8 @@ qA
 rb
 Ds
 Rg
-rb
-Ds
+RY
+Ns
 AB
 hS
 Ir
@@ -9360,9 +9406,9 @@ qA
 qA
 rb
 Kh
-rb
+ok
 Kh
-rb
+ok
 JD
 Qt
 YH
@@ -10223,7 +10269,7 @@ Or
 td
 Fv
 ML
-TX
+Jr
 Jr
 kL
 BT


### PR DESCRIPTION
## Описание / Что этот PR делает

- Фиксит развернутые офами диваны и скамейки
- Обновляет картинную галерею, заменяя болванки на конкретные арты игроков с библиотеки
- Обновляет полы на всем шипе
- Убирает не проходимый ящик в туалетах

## Причина создания ПР / Почему это хорошо для игры
Сломанные карты не круто

## Список изменений

```yml
🆑
map: Карта Лагуны
/🆑
```
