### PR TITLE
MAP: Замена сек-ньюкастерво на обычные

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_budgetcuts.dmm
+++ b/_maps/_mod_celadon/RandomRuins/RockRuins/rockplanet_budgetcuts.dmm
@@ -1564,7 +1564,7 @@
 /obj/item/flashlight/lamp{
 	pixel_y = 4
 	},
-/obj/machinery/newscaster/security_unit{
+/obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/item/radio/intercom/directional/west,

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/spacemall.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/spacemall.dmm
@@ -8500,7 +8500,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/spacemall/dorms)
 "FJ" = (
-/obj/machinery/newscaster/security_unit{
+/obj/machinery/newscaster{
 	pixel_x = 32
 	},
 /obj/structure/cable{

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -4873,6 +4873,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/carpet/green,
 /area/outpost/operations/outpost_command)
 "cOL" = (
@@ -15042,8 +15043,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/newscaster/security_unit/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood/walnut{
 	planetary_atmos = 1
 	},
@@ -22677,7 +22678,7 @@
 	pixel_y = 6;
 	pixel_x = -1
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
 "mAg" = (
@@ -25705,11 +25706,11 @@
 	pixel_y = 6;
 	pixel_x = -1
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1;
 	color = "#808080"
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/outpost/security)
 "ofR" = (
@@ -34229,10 +34230,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
 /obj/machinery/firealarm/directional/south{
 	pixel_x = 12
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/tech,
 /area/outpost/security/checkpoint)
 "sSO" = (
@@ -34835,6 +34836,10 @@
 /obj/item/spacecash/bundle/c10,
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo/faction/all/zone_3)
+"thf" = (
+/obj/machinery/newscaster/security_unit/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/outpost/operations/outpost_command)
 "thl" = (
 /obj/effect/turf_decal/borderfloor{
 	layer = 2.030
@@ -57594,7 +57599,7 @@ wMX
 wMX
 wMX
 wMX
-oII
+thf
 oII
 oII
 oII

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -22206,6 +22206,11 @@
 	},
 /area/outpost/crew/bar)
 "mmO" = (
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "outpost3";
+	use_static_power = 1
+	},
 /obj/machinery/light/floor{
 	color = "#FF0000";
 	light_color = "#FF0000"
@@ -74765,8 +74770,8 @@ rgY
 rgY
 rgY
 jtk
-dri
 mmO
+jtk
 jtk
 rgY
 rgY

--- a/_maps/_mod_celadon/shuttles/independent/independent_caravan.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_caravan.dmm
@@ -341,7 +341,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/red_gold,
 /area/ship/bridge)
 "fT" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
@@ -41,7 +41,7 @@
 /area/ship/maintenance/starboard)
 "ax" = (
 /obj/structure/filingcabinet/employment,
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/blue,
 /area/ship/bridge)
 "aC" = (
@@ -4027,7 +4027,7 @@
 /area/ship/maintenance/starboard)
 "Vq" = (
 /obj/structure/filingcabinet/security,
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "Vs" = (

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm
@@ -1007,7 +1007,7 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/newscaster/directional/north,
 /obj/machinery/rnd/server,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/office)

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
@@ -3762,7 +3762,7 @@
 /obj/item/gun/ballistic/shotgun/automatic/bulldog/inteq{
 	pixel_x = -8;
 	pixel_y = 8;
-	
+
 	},
 /obj/structure/sign/poster/retro/lasergun_new{
 	pixel_x = -32
@@ -6441,7 +6441,7 @@
 	pixel_x = 31;
 	pixel_y = 13
 	},
-/obj/machinery/newscaster/security_unit/directional/east{
+/obj/machinery/newscaster/directional/east{
 	pixel_y = -3
 	},
 /turf/open/floor/plasteel/telecomms_floor,

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
@@ -1168,7 +1168,7 @@
 	pixel_y = -2;
 	pixel_x = -8
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
@@ -2324,7 +2324,7 @@
 	pixel_y = 11;
 	pixel_x = 12
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/techfloor,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew)
@@ -2482,7 +2482,7 @@
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
 	dir = 4
 	},

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
@@ -1218,7 +1218,7 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
 "ij" = (
@@ -1714,7 +1714,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/cargo/office)
 "lh" = (
@@ -1836,7 +1836,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/birch,
 /area/ship/crew/canteen)
@@ -2375,7 +2375,7 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 10
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/cryo)
@@ -3210,7 +3210,7 @@
 /obj/item/gun/ballistic/automatic/pistol/solgov{
 	pixel_x = -2
 	},
-/obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 10
 	},
@@ -3834,7 +3834,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/solgov,
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/blue,
 /area/ship/crew/office)
 "yw" = (
@@ -4167,7 +4167,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew/toilet)
 "AU" = (
@@ -5206,7 +5206,7 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 1
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "HG" = (
@@ -5435,7 +5435,7 @@
 /area/ship/crew/cryo)
 "Js" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/library)
 "Jt" = (
@@ -7078,7 +7078,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 10
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -872,7 +872,7 @@
 	},
 /obj/structure/table/syndi,
 /obj/machinery/fax/syndicate,
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/marble/black,
 /area/ship/bridge)
 "mY" = (
@@ -1107,7 +1107,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "sj" = (
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /obj/structure/chair/comfy/beige/directional/west,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
@@ -1414,7 +1414,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/line{
 	dir = 1
 	},
-/obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/marble/black,
 /area/ship/hallway/central)
 "yT" = (
@@ -3120,7 +3120,7 @@
 	pixel_x = 2;
 	pixel_y = 25
 	},
-/obj/machinery/newscaster/security_unit/directional/east{
+/obj/machinery/newscaster/directional/east{
 	pixel_y = 11
 	},
 /obj/item/radio/intercom/directional/east{

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
@@ -411,7 +411,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /obj/item/toy/cards/deck/syndicate{
 	pixel_y = -8
 	},
@@ -1648,7 +1648,7 @@
 	pixel_y = 11;
 	pixel_x = 10
 	},
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /obj/item/megaphone/sec{
 	name = "syndicate megaphone";
 	pixel_y = 6;
@@ -2981,7 +2981,7 @@
 	pixel_x = 9;
 	pixel_y = 6
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/bridge)
@@ -3260,7 +3260,7 @@
 	dir = 6
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/newscaster/security_unit/directional/east,
+/obj/machinery/newscaster/directional/east,
 /obj/item/radio/intercom/directional/south{
 	frequency = 1667
 	},
@@ -3457,7 +3457,7 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/newscaster/directional/west,
 /obj/item/radio/intercom/directional/north{
 	frequency = 1667
 	},
@@ -3924,7 +3924,7 @@
 	pixel_x = -11;
 	pixel_y = 10
 	},
-/obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/newscaster/directional/north,
 /obj/item/chair/plastic{
 	pixel_x = -1;
 	pixel_y = 8
@@ -4031,7 +4031,7 @@
 	pixel_y = 0;
 	pixel_x = -32
 	},
-/obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "Nx" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Заменяет на картах аванпоста, руинах, кораблях игроков ньюкастеры админские на обычные
Добавляем парочку админских в админ зону аванпоста

## Причина создания ПР / Почему это хорошо для игры
Власть над тем чтобы по кд спаминть новости и розыск подавать на всех - не надо нам такого

## Список изменений

```yml
🆑
tweak: Секньюкастеры меняем на обычные
/🆑
```
