### PR TITLE
MAP: Фиксим дыру в туалете аванпоста

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -18386,7 +18386,8 @@
 /area/outpost/hallway/central)
 "lXF" = (
 /obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/fakepit,
 /area/outpost/crew/lounge/cab_1)
 "lXT" = (
 /obj/effect/turf_decal/siding/wood{
@@ -18989,6 +18990,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/lounge/cab_1)
 "moq" = (
@@ -27464,7 +27466,7 @@
 	name = "Bathroom Stall 1";
 	id_tag = "aster_bar_stall1"
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/closed/indestructible/reinforced,
 /area/outpost/crew/lounge/cab_1)
 "saI" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -61908,7 +61910,7 @@ blm
 kmM
 pkB
 blm
-lXF
+blm
 blm
 cGD
 cGD
@@ -62282,7 +62284,7 @@ blm
 prV
 pkB
 blm
-blm
+lXF
 blm
 cGD
 cGD

--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -25804,10 +25804,6 @@
 	color = "#55391A"
 	},
 /area/outpost/fraction/solfed)
-"qWv" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/floor/fakepit,
-/area/outpost/crew/lounge/cab_1)
 "qWC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -62286,7 +62282,7 @@ blm
 prV
 pkB
 blm
-qWv
+blm
 blm
 cGD
 cGD


### PR DESCRIPTION
## Описание / Что этот PR делает
Срочно чиним секретную дыру в первой кабинке туалета

## Причина создания ПР / Почему это хорошо для игры
При открытии данной стены, разгерметизировался целый аванпост

## Список изменений

```yml
🆑
tweak: Фальш стена и дыра заменена на стенку
/🆑
```
