### PR TITLE
FIX: Капюшон нельзя теперь вытащить из толстовок

### DIFF
--- a/mod_celadon/fixes/code/icons.dm
+++ b/mod_celadon/fixes/code/icons.dm
@@ -17,3 +17,16 @@
 
 /obj/item/gun/energy/pulse/carbine
 	mob_overlay_icon = 'mod_celadon/_storage_icons/icons/items/weapons/overlay/onmob.dmi'
+
+// Чинит капюшоны, путем запрета взятия капюшона из карманов толстовки
+//TODO: Чтобы починилось все на свете с худями, надо называть и капюшоны и одежду одним именем
+/obj/item/clothing/head/hooded/attack_hand(mob/user)
+	if(loc == suit && suit)
+		to_chat(user, span_warning("The hood is attached to [suit]!"))
+		return
+	return ..()
+
+/obj/item/clothing/head/hooded/MouseDrop(atom/over_object)
+	if(loc == suit && suit)
+		return
+	return ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
При попытке взаимодействовать с капюшоном из карманов курток, ничего не будет происходить, а в чат будет писаться что это нельзя сделать, а именно вытащить капюшон. Для этого есть спец кнопка

## Причина создания ПР / Почему это хорошо для игры
При попытках вытащить капюшон, заставляло игру циклично спавнить ошибочный спрайт. Над игроком появлялось слово - YOU ERROR


## Список изменений

```yml
🆑
add: проверка на съёмность капюшона от курток
/🆑
```
