### PR TITLE
RE-BALANCE: Возвращение HARM интента, или то как стало легко стрелять по лежачим

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -532,12 +532,16 @@
 		var/mob/living/L = target
 		// [CELADON-EDIT] - BALANCE_CAN_HIT_TARGET - Делаем шансы на попадания
 		if(iscarbon(L))
-			if(direct_target && !L.density && firer.density && prob(90)) // 85% что пуля попадет в лежащую цель от стоящего стрелка
+			if(direct_target && !L.density && firer.density && prob(80)) // 80% что пуля попадет в лежащую цель от стоящего стрелка
 				return TRUE
-			if(direct_target && !L.density && !firer.density && prob(75)) // 75% что пуля попадет в лежащую цель от лежащего стрелка
+			if(direct_target && !L.density && !firer.density && prob(70)) // 70% что пуля попадет в лежащую цель от лежащего стрелка
 				return TRUE
-			if(direct_target && L.density && !firer.density && prob(60)) // 60% пуля попадет в стоящую цель от лежачего стрелка
+			if(direct_target && L.density && !firer.density && prob(75)) // 75% пуля попадет в стоящую цель от лежачего стрелка
 				return TRUE
+			if(!L.density && ismob(firer)) // Проверяем HARM интент для лежачих целей
+				var/mob/M = firer
+				if(M.a_intent == INTENT_HARM && prob(75)) // 75% что пуля попадет в лежащую цель в HARM интенте
+					return TRUE
 		else if(direct_target)
 			return TRUE
 		// [/CELADON-EDIT]
@@ -546,7 +550,7 @@
 			return FALSE
 	// [CELADON-EDIT] - BALANCE_CAN_HIT_TARGET - Делаем шансы на попадания
 	// return TRUE 	// CELADON-EDIT - ORIGINAL
-	if(prob(50))	// С вероятность 50% шальная пуля зацепит лежащего
+	if(prob(75))	// С вероятность 75% шальная пуля зацепит лежащего
 		return TRUE
 	return FALSE
 	// [/CELADON-EDIT]

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -530,7 +530,7 @@
 			return FALSE
 	else
 		var/mob/living/L = target
-		// [CELADON-EDIT] - CELADON_BALANCE - Делаем шансы на попадания
+		// [CELADON-EDIT] - BALANCE_CAN_HIT_TARGET - Делаем шансы на попадания
 		if(iscarbon(L))
 			if(direct_target && !L.density && firer.density && prob(90)) // 85% что пуля попадет в лежащую цель от стоящего стрелка
 				return TRUE
@@ -544,7 +544,7 @@
 		// If target not able to use items, move and stand - or if they're just dead, pass over.
 		if(L.stat || (!hit_stunned_targets && HAS_TRAIT(L, TRAIT_IMMOBILIZED) && HAS_TRAIT(L, TRAIT_FLOORED) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED)))
 			return FALSE
-	// [CELADON-EDIT] - CELADON_BALANCE - Делаем шансы на попадания
+	// [CELADON-EDIT] - BALANCE_CAN_HIT_TARGET - Делаем шансы на попадания
 	// return TRUE 	// CELADON-EDIT - ORIGINAL
 	if(prob(50))	// С вероятность 50% шальная пуля зацепит лежащего
 		return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -532,11 +532,11 @@
 		var/mob/living/L = target
 		// [CELADON-EDIT] - CELADON_BALANCE - Делаем шансы на попадания
 		if(iscarbon(L))
-			if(direct_target && !L.density && firer.density && prob(85)) // 85% что пуля попадет в лежащую цель от стоящего стрелка
+			if(direct_target && !L.density && firer.density && prob(90)) // 85% что пуля попадет в лежащую цель от стоящего стрелка
 				return TRUE
-			if(direct_target && !L.density && !firer.density && prob(70)) // 70% что пуля попадет в лежащую цель от лежащего стрелка
+			if(direct_target && !L.density && !firer.density && prob(75)) // 75% что пуля попадет в лежащую цель от лежащего стрелка
 				return TRUE
-			if(direct_target && L.density && !firer.density && prob(90)) // 90% пуля попадет в стоящую цель от лежачего стрелка
+			if(direct_target && L.density && !firer.density && prob(60)) // 60% пуля попадет в стоящую цель от лежачего стрелка
 				return TRUE
 		else if(direct_target)
 			return TRUE
@@ -546,7 +546,7 @@
 			return FALSE
 	// [CELADON-EDIT] - CELADON_BALANCE - Делаем шансы на попадания
 	// return TRUE 	// CELADON-EDIT - ORIGINAL
-	if(prob(25))	// С вероятность 20% шальная пуля зацепит лежащего
+	if(prob(50))	// С вероятность 50% шальная пуля зацепит лежащего
 		return TRUE
 	return FALSE
 	// [/CELADON-EDIT]

--- a/mod_celadon/balance/README.md
+++ b/mod_celadon/balance/README.md
@@ -96,7 +96,8 @@ EDIT: `code/__DEFINES/turfs.dm`	- Меняем минимальный урон �
 EDIT: `code/game/turfs/closed/walls.dm` - Меняем хп стены в 2 раза = 800, увеличиваем минимальный порог урона с 8 до 25
 EDIT: `code/game/turfs/closed/minerals.dm` - Убираем флаг на минимальный дамаг стене, назначаем числовой параметр. И даем сопротивление стене из камня в 70% и хп в 1200
 
-EDIT: `code/modules/projectiles/projectile.dm` : Меняем систему лежания и попадания по лежачим и стоячи
+BALANCE_CAN_HIT_TARGET
+- EDIT: `code/modules/projectiles/projectile.dm` : Меняем систему лежания и попадания по лежачим и стоячи
 
 EDIT: `code/modules/modular_computers/file_system/programs/radar.dm` : ставим заглушку, чтобы не пользовались планшетиком с радарчиком, пока кодеры не придумают иной вариант. Главное не забыть
 

--- a/mod_celadon/fixes/code/field_gen.dm
+++ b/mod_celadon/fixes/code/field_gen.dm
@@ -1,3 +1,9 @@
 /obj/machinery/field/generator
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 100, "fire" = 100, "acid" = 100)
+
+/obj/machinery/shieldwall/atmos
+	mouse_opacity = 0
+
+/obj/machinery/power/shieldwallgen
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF


### PR DESCRIPTION
## Описание / Что этот PR делает
1. Возвращает механику, когда в харм интенте при стрельбе можно было 100% выбрать только по лежачую цель, игнорируя всякий мусор и прочее. Но при этом пуля также имеет шанс промахнуться. 
2. Уравниваем шансы попасть по стоячей цели в положении лежа (75%), а из стоячего положения по лежачей цели (75%).
3. Добавляет генератору щита на корабле параметр хп и делает прозрачными эффект самого щита.

## Причина создания ПР / Почему это хорошо для игры
Не будет больше лежачих войнов
Не будет абуза с полем щита, когда невозможно было попасть по лежачему под эффектом желтого голополя
Close #2382

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: механика харм интента по лежачим
tweak: голополе коробля
tweak: шансы попадания
/🆑
```
