### PR TITLE
MAP: Fixes shuttles

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_chariot.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_chariot.json
@@ -13,7 +13,7 @@
 	"faction": "/datum/faction/nt",
 	"tags": [
 		"Исследовательский",
-		"Субшаттл"
+		"Суб-шаттл"
 	],
 	"namelists": [
 		"NANOTRASEN",

--- a/_maps/_mod_celadon/configs/syndicate_gorlex_beetle.json
+++ b/_maps/_mod_celadon/configs/syndicate_gorlex_beetle.json
@@ -2,7 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/CeladonSS13/Shiptest/beta-dev/_maps/_mod_celadon/ship_config_schema.json",
 	"map_name": "Beetle-class Battle Schnau",
 	"map_short_name": "Beetle",
-	"description": "Боевое судно класса Beetle- Небольшое судно используемое Горлексом для подерржи в бою или мелких рейдах. Было разработано при поддержке киберсан для создания манёвренного судна для быстрых операций, в качестве эксперимента экипаж был оснащён МОДкостюмами и лазерным вооружением.",
+	"description": "Боевое судно класса Beetle- Небольшое судно используемое Горлексом для поддержки в бою или мелких рейдах. Было разработано при поддержке киберсан для создания манёвренного судна для быстрых операций, в качестве эксперимента экипаж был оснащён лазерным вооружением.",
 	"map_path": "_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_beetle.dmm",
 	"enabled": true,
 	"limit": 1,

--- a/_maps/_mod_celadon/configs/syndicate_krait.json
+++ b/_maps/_mod_celadon/configs/syndicate_krait.json
@@ -10,7 +10,10 @@
 	"sensor_range": 4,
 	"prefix": "RSSV",
 	"faction": "/datum/faction/syndicate",
-	"tags": ["Исследовательский" ],
+	"tags": [
+		"Исследовательский",
+		"Суб-шаттл"
+	],
 	"namelists": ["CYBERSUN", "GORLEX"],
 	"job_slots": {
 		"Search and Destroy Team Leader": {

--- a/_maps/_mod_celadon/shuttles/elysium/elysium_khalifat.dmm
+++ b/_maps/_mod_celadon/shuttles/elysium/elysium_khalifat.dmm
@@ -37,7 +37,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "ai" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -90,7 +90,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "aA" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black{
@@ -463,7 +463,7 @@
 /obj/structure/cable{
 	icon_state = "5-9"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "cF" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -635,7 +635,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "dq" = (
 /turf/closed/wall/mineral/titanium/survival,
@@ -923,7 +923,7 @@
 /area/ship/security)
 "eQ" = (
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "eR" = (
 /obj/structure/grille,
@@ -990,7 +990,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "fH" = (
 /turf/closed/wall/mineral/wood,
@@ -1235,7 +1235,7 @@
 "gL" = (
 /obj/structure/sauna_oven_steam,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "gQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1245,14 +1245,14 @@
 /obj/structure/barricade/wooden/crude,
 /obj/structure/barricade/wooden,
 /obj/item/shard,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "gU" = (
 /turf/open/floor/carpet/green,
 /area/ship/hallway/aft)
 "gW" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "gX" = (
 /obj/structure/catwalk,
@@ -1615,7 +1615,7 @@
 /obj/structure/sign/poster/elysium/logo{
 	pixel_x = 27
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "iW" = (
 /obj/effect/turf_decal/industrial/caution/red{
@@ -1639,7 +1639,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/frame,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security/armory)
 "je" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal{
@@ -2215,7 +2215,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "mp" = (
 /turf/template_noop,
@@ -2283,7 +2283,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "mS" = (
 /obj/structure/cable/yellow{
@@ -2479,7 +2479,7 @@
 /obj/item/stack/cable_coil/cut/yellow,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security/armory)
 "ow" = (
 /obj/effect/turf_decal/corner/transparent/green/half,
@@ -2640,7 +2640,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "pj" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -2811,7 +2811,7 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "pI" = (
 /obj/effect/turf_decal/elysium_logo/two_one{
@@ -2915,7 +2915,7 @@
 /area/ship/hallway/port)
 "qo" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "qp" = (
 /obj/effect/turf_decal/box,
@@ -3320,7 +3320,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/gibspawner/human/bodypartless,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "sL" = (
 /obj/structure/cable{
@@ -3443,7 +3443,7 @@
 /area/ship/hallway/central)
 "tp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "tq" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -3482,7 +3482,7 @@
 /area/ship/hallway/port)
 "tO" = (
 /obj/item/stack/cable_coil/cut/yellow,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "tR" = (
 /turf/closed/wall/mineral/titanium/survival,
@@ -3805,7 +3805,7 @@
 "wi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/engine)
 "wm" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3835,7 +3835,7 @@
 /mob/living/simple_animal/pet/mothroach{
 	name = "Shaitan"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "wz" = (
 /obj/structure/cable/yellow{
@@ -3861,7 +3861,7 @@
 /area/ship/engineering)
 "wB" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "wF" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -4023,7 +4023,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "xf" = (
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "xg" = (
 /obj/effect/turf_decal/elysium_logo/one_one{
@@ -4056,7 +4056,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "xo" = (
 /obj/structure/cable{
@@ -4133,7 +4133,7 @@
 /area/ship/hallway/central)
 "xF" = (
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security/armory)
 "xH" = (
 /obj/machinery/door/poddoor{
@@ -4389,7 +4389,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "yX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -4429,7 +4429,7 @@
 	dir = 10;
 	id = "khalifat_turrets"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/bridge)
 "zc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4576,7 +4576,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "zS" = (
 /obj/structure/sign/directions/medical{
@@ -4595,7 +4595,7 @@
 	pixel_x = -2;
 	pixel_y = 12
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "zZ" = (
 /obj/effect/turf_decal/corner/opaque/orange/three_quarters{
@@ -4640,7 +4640,7 @@
 /area/ship/engineering/atmospherics)
 "Aj" = (
 /obj/structure/catwalk,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Ao" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4722,7 +4722,7 @@
 /area/ship/cargo)
 "AB" = (
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "AK" = (
 /obj/structure/chair/comfy/shuttle{
@@ -4796,7 +4796,7 @@
 /area/ship/cargo)
 "Bh" = (
 /obj/effect/gibspawner/human/bodypartless,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Bi" = (
 /obj/effect/turf_decal/borderfloorblack{
@@ -4897,7 +4897,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/bedsheet/elysium,
 /obj/item/storage/book/bible/koran,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "BL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -5142,7 +5142,7 @@
 "CO" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "CP" = (
 /obj/machinery/light/directional/east,
@@ -5255,7 +5255,7 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "Dh" = (
 /obj/machinery/light/directional/north,
@@ -5357,7 +5357,7 @@
 "DB" = (
 /obj/effect/turf_decal/steeldecal/steel_decals8,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "DF" = (
 /obj/structure/cable/yellow{
@@ -5401,7 +5401,7 @@
 /area/ship/engineering/communications)
 "DQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "DW" = (
 /obj/effect/decal/cleanable/ash/large,
@@ -5479,7 +5479,7 @@
 /obj/structure/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "ED" = (
 /obj/effect/turf_decal/corner/opaque/orange{
@@ -5512,7 +5512,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "EH" = (
 /obj/structure/window/fulltile,
@@ -5858,7 +5858,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Gv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5927,11 +5927,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "GG" = (
 /obj/structure/sign/plaques/kiddie/badger,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "GH" = (
 /obj/effect/turf_decal/corner/transparent/bar/diagonal,
@@ -6157,7 +6157,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/sandbags,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "HR" = (
 /obj/effect/gibspawner/human/bodypartless,
@@ -6768,7 +6768,7 @@
 /area/ship/hallway/port)
 "KR" = (
 /obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "KU" = (
 /obj/structure/cable/yellow{
@@ -6930,7 +6930,7 @@
 	req_ship_access = 1;
 	req_access_txt = null
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "ML" = (
 /obj/machinery/door/poddoor{
@@ -7148,7 +7148,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "NX" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -7221,7 +7221,7 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/medical)
 "Op" = (
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Ot" = (
 /obj/machinery/shieldgen{
@@ -7318,7 +7318,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/elysium,
 /obj/item/storage/book/bible/koran,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "OZ" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -7348,7 +7348,7 @@
 "Pa" = (
 /obj/effect/decal/cleanable/glass,
 /obj/machinery/autolathe/hacked,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "Pb" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7623,7 +7623,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "QD" = (
 /obj/machinery/door/window/eastright{
@@ -7664,14 +7664,14 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "QR" = (
 /obj/structure/bed,
 /obj/machinery/light/directional/east,
 /obj/item/bedsheet/elysium,
 /obj/item/storage/book/bible/koran,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "QT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -7748,7 +7748,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Ru" = (
 /obj/machinery/camera/autoname{
@@ -7951,7 +7951,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/aft)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -8128,7 +8128,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "Tn" = (
 /obj/structure/cable/yellow{
@@ -8184,7 +8184,7 @@
 /area/ship/engineering/communications)
 "TC" = (
 /obj/machinery/door/airlock/hatch,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "TE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8268,7 +8268,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /obj/item/stack/cable_coil/cut/yellow,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security/armory)
 "Uf" = (
 /obj/item/wallframe/extinguisher_cabinet{
@@ -8468,7 +8468,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/ore/salvage/scrapmetal/ten,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "Vl" = (
 /obj/structure/catwalk,
@@ -8505,7 +8505,7 @@
 	dir = 8
 	},
 /obj/item/clothing/mask/balaclava,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/cargo)
 "VA" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8629,7 +8629,7 @@
 	pixel_x = 20;
 	pixel_y = 11
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "VZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -8760,7 +8760,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "WK" = (
 /obj/effect/turf_decal/corner/opaque/orange{
@@ -8938,7 +8938,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/engineering/atmospherics)
 "Yc" = (
 /obj/structure/catwalk,
@@ -9050,7 +9050,7 @@
 /obj/effect/turf_decal/steeldecal/steel_decals_central2{
 	dir = 1
 	},
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/security)
 "Yy" = (
 /obj/machinery/light/directional/west,
@@ -9221,7 +9221,7 @@
 	pixel_x = 32
 	},
 /obj/structure/crate_shelf,
-/turf/open/floor/plating/wasteplanet/rust,
+/turf/open/floor/plating/rust,
 /area/ship/hallway/port)
 "Zh" = (
 /obj/machinery/porta_turret/ship/elysium{

--- a/_maps/_mod_celadon/shuttles/elysium/elysium_lalish.dmm
+++ b/_maps/_mod_celadon/shuttles/elysium/elysium_lalish.dmm
@@ -71,7 +71,7 @@
 	},
 /obj/effect/turf_decal/steeldecal/steel_decals_central7,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "bZ" = (
 /obj/effect/turf_decal/number/right_three,
@@ -790,7 +790,7 @@
 	pixel_y = -31
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "mg" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1852,7 +1852,7 @@
 	pixel_y = 5;
 	id = "lilash"
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "Ck" = (
 /obj/machinery/light/small/directional/south,
@@ -2474,7 +2474,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "Nf" = (
 /obj/effect/turf_decal/industrial/warning{
@@ -2727,7 +2727,7 @@
 /obj/structure/chair/stool{
 	dir = 4
 	},
-/turf/open/floor/plasteel/strongdark/airless,
+/turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "PI" = (
 /obj/machinery/hydroponics,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -5156,18 +5156,6 @@
 /obj/effect/turf_decal/spline/fancy/opaque/ntblue{
 	dir = 4
 	},
-/obj/item/implant/radio{
-	pixel_x = -11;
-	pixel_y = 9
-	},
-/obj/item/implant/radio{
-	pixel_x = -12;
-	pixel_y = 4
-	},
-/obj/item/implant/radio{
-	pixel_x = -7;
-	pixel_y = 10
-	},
 /obj/item/radio/headset/nanotrasen{
 	pixel_x = -5;
 	pixel_y = -8
@@ -5217,6 +5205,18 @@
 	pixel_y = -3
 	},
 /obj/structure/closet/wall/blue/directional/south,
+/obj/item/radio{
+	pixel_x = -9;
+	pixel_y = 13
+	},
+/obj/item/radio{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/radio{
+	pixel_x = -9;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
 "Es" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -53,6 +53,7 @@
 	},
 /obj/machinery/syndicatebomb/training,
 /mob/living/simple_animal/bot/secbot/beepsky/jr,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "bc" = (
@@ -515,6 +516,13 @@
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/dorm/dormtwo)
+"gB" = (
+/obj/machinery/porta_turret/ship/nt/heavy{
+	id = "teardrop_turrets";
+	dir = 5
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
 "gD" = (
 /obj/effect/turf_decal/corner/opaque/black/mono,
 /obj/structure/window/reinforced{
@@ -1013,7 +1021,9 @@
 /obj/effect/turf_decal/trimline/opaque/bottlegreen/line{
 	dir = 5
 	},
-/obj/structure/chair/sofa/grey/right/directional/east,
+/obj/structure/chair/sofa/grey/right/directional/east{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "ma" = (
@@ -1388,7 +1398,8 @@
 /area/ship/crew/dorm)
 "oI" = (
 /obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets"
+	id = "teardrop_turrets";
+	dir = 9
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -1540,6 +1551,7 @@
 "pX" = (
 /obj/machinery/computer/med_data,
 /obj/effect/turf_decal/trimline/opaque/bottlegreen,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "qe" = (
@@ -1567,6 +1579,13 @@
 	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
+"qr" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
 "qv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1687,6 +1706,7 @@
 	name = "Best medic in the sector";
 	desc = "The adorable little mascot of the Solarian Maritime Society. Popular with the cuties."
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "sH" = (
@@ -1777,6 +1797,13 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
+"tK" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 10
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "tM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/glass,
@@ -1871,7 +1898,8 @@
 /area/ship/hallway/central)
 "ve" = (
 /obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets"
+	id = "teardrop_turrets";
+	dir = 6
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -2087,6 +2115,13 @@
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
+"xy" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "xz" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovgold/corner{
 	dir = 1
@@ -2305,6 +2340,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
+"yW" = (
+/obj/machinery/porta_turret/ship/nt/heavy{
+	id = "teardrop_turrets";
+	dir = 6
+	},
+/turf/closed/wall/mineral/titanium,
+/area/ship/bridge)
 "yZ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/techfloor{
@@ -3206,7 +3248,8 @@
 /area/ship/cargo)
 "JZ" = (
 /obj/machinery/porta_turret/ship/nt/heavy{
-	id = "teardrop_turrets"
+	id = "teardrop_turrets";
+	dir = 4
 	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
@@ -3253,6 +3296,13 @@
 	},
 /obj/effect/turf_decal/corner/opaque/ntblue/half,
 /turf/open/floor/plasteel/heavymetal/var4,
+/area/ship/bridge)
+"Kp" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 5
+	},
+/turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "KE" = (
 /obj/effect/turf_decal/techfloor/orange/corner{
@@ -3506,7 +3556,9 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "Nt" = (
-/obj/machinery/porta_turret/ship/ballistic,
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets"
+	},
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "NB" = (
@@ -4653,13 +4705,13 @@ fa
 yz
 jn
 jn
-oI
+xy
 sB
 sB
 yz
 sB
 sB
-oI
+xy
 jn
 jn
 yz
@@ -4711,7 +4763,7 @@ Eh
 Va
 it
 yz
-oI
+tK
 fa
 fa
 fa
@@ -4864,7 +4916,7 @@ fa
 fa
 fa
 fa
-ve
+qr
 lI
 Ik
 du
@@ -5273,7 +5325,7 @@ fa
 fa
 fa
 fa
-ve
+Kp
 WN
 WN
 RS
@@ -5420,7 +5472,7 @@ fa
 fa
 fa
 fa
-JZ
+gB
 cv
 cv
 hw
@@ -5428,7 +5480,7 @@ cv
 vZ
 cv
 cv
-JZ
+yW
 fa
 fa
 fa

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
@@ -512,7 +512,7 @@
 	pixel_y = -32
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "hL" = (
 /obj/effect/turf_decal/steeldecal/steel_decals4,
 /obj/effect/decal/cleanable/crayon{
@@ -2992,7 +2992,7 @@
 /area/ship/hallway/central)
 "Lj" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Ll" = (
 /obj/structure/chair/sofa/red/old/left/directional/south,
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
@@ -3321,7 +3321,7 @@
 	dir = 2
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Qt" = (
 /obj/effect/turf_decal/corner/opaque/syndiered/half{
 	dir = 8

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_fist_of_freedom.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_fist_of_freedom.dmm
@@ -87,7 +87,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/poddoor{
-	id = "58"
+	id = "fistofF_armory"
 	},
 /turf/open/floor/mineral/titanium,
 /area/ship/security)
@@ -513,10 +513,10 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 8;
-	id = "sgi_holocargo1"
+	id = "fistofF_holobay_S"
 	},
 /obj/machinery/door/poddoor{
-	id = "45"
+	id = "fistofF_blast_S"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -861,8 +861,8 @@
 /area/ship/security)
 "eW" = (
 /obj/machinery/porta_turret/ship/solfed{
-	dir = 9;
-	id = "tomahawk_turrets"
+	dir = 6;
+	id = "fistofF_turrets"
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/bridge)
@@ -987,7 +987,7 @@
 	dir = 5
 	},
 /obj/machinery/button/door{
-	id = "solc_eng";
+	id = "fistofF_eng";
 	name = "Engine Shutters";
 	pixel_x = 8;
 	pixel_y = 19
@@ -1138,7 +1138,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "solc_eng"
+	id = "fistofF_eng"
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
@@ -1271,7 +1271,7 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue/full,
 /obj/machinery/turretid/ship{
 	pixel_y = -27;
-	id = "tomahawk_turrets"
+	id = "fistofF_turrets"
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/bridge)
@@ -1373,7 +1373,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
-	id = "49"
+	id = "fistofF_blast_N"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
@@ -1881,15 +1881,15 @@
 /obj/machinery/button/shieldwallgen{
 	pixel_y = -1;
 	pixel_x = 22;
-	id = "twinkle_holobay";
+	id = "fistofF_holobay";
 	dir = 8
 	},
 /obj/machinery/button/door{
 	pixel_y = -10;
 	name = "Cargo Doors";
-	id = "49";
 	pixel_x = 23;
-	dir = 8
+	dir = 8;
+	id = "fistofF_blast_N"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
@@ -2368,7 +2368,7 @@
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 8;
-	id = "twinkle_holobay";
+	id = "fistofF_holobay";
 	locked = 1
 	},
 /obj/structure/cable{
@@ -2377,7 +2377,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/door/poddoor{
-	id = "49"
+	id = "fistofF_blast_N"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
@@ -2700,7 +2700,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/machinery/door/poddoor{
 	dir = 4;
-	id = "solc_eng"
+	id = "fistofF_eng"
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engine)
@@ -2749,7 +2749,7 @@
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
 	dir = 4;
-	id = "twinkle_holobay";
+	id = "fistofF_holobay";
 	locked = 1
 	},
 /obj/structure/cable{
@@ -2758,7 +2758,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/door/poddoor{
-	id = "49"
+	id = "fistofF_blast_N"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
@@ -3426,7 +3426,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor{
-	id = "58"
+	id = "fistofF_armory"
 	},
 /turf/open/floor/mineral/titanium,
 /area/ship/security)
@@ -4267,10 +4267,10 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	dir = 4;
-	id = "sgi_holocargo1"
+	id = "fistofF_holobay_S"
 	},
 /obj/machinery/door/poddoor{
-	id = "45"
+	id = "fistofF_blast_S"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -4360,6 +4360,13 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/crewthree)
+"BH" = (
+/obj/machinery/porta_turret/ship/solfed{
+	dir = 9;
+	id = "fistofF_turrets"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "BJ" = (
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/structure/window/plasma/reinforced/spawner,
@@ -4730,7 +4737,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door{
-	id = 58;
+	id = "fistofF_armory";
 	dir = 1;
 	pixel_y = -25
 	},
@@ -5093,14 +5100,14 @@
 	},
 /obj/machinery/button/shieldwallgen{
 	dir = 4;
-	id = "sgi_holocargo1";
+	id = "fistofF_holobay_S";
 	pixel_x = -18;
 	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/garbage,
 /obj/machinery/button/door{
-	id = 45;
+	id = "fistofF_blast_S";
 	dir = 4;
 	pixel_x = -20;
 	pixel_y = -7
@@ -6178,6 +6185,12 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer4,
 /turf/open/floor/engine/n2,
 /area/ship/engineering/atmospherics)
+"Mj" = (
+/obj/machinery/porta_turret/ship/solfed{
+	id = "fistofF_turrets"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "Mk" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue{
 	dir = 10
@@ -6372,6 +6385,13 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/engineering/engine)
+"NH" = (
+/obj/machinery/porta_turret/ship/solfed{
+	dir = 10;
+	id = "fistofF_turrets"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -6511,7 +6531,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor{
-	id = "45"
+	id = "fistofF_blast_S"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -7402,6 +7422,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"UD" = (
+/obj/machinery/porta_turret/ship/solfed{
+	dir = 1;
+	id = "fistofF_turrets"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "UE" = (
 /obj/machinery/mineral/ore_redemption{
 	dir = 8;
@@ -7461,7 +7488,7 @@
 	dir = 2
 	},
 /obj/machinery/door/poddoor{
-	id = "45"
+	id = "fistofF_blast_S"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -7996,6 +8023,13 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"XN" = (
+/obj/machinery/porta_turret/ship/solfed{
+	dir = 5;
+	id = "fistofF_turrets"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "XV" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -8137,7 +8171,7 @@
 	dir = 9
 	},
 /obj/machinery/door/poddoor{
-	id = "58"
+	id = "fistofF_armory"
 	},
 /turf/open/floor/mineral/titanium,
 /area/ship/security)
@@ -8289,7 +8323,7 @@ mQ
 mQ
 mQ
 mQ
-eW
+BH
 aB
 cZ
 cZ
@@ -8300,7 +8334,7 @@ cZ
 cZ
 cZ
 aB
-eW
+NH
 mQ
 mQ
 mQ
@@ -8583,7 +8617,7 @@ mQ
 (11,1,1) = {"
 mQ
 mQ
-eW
+BH
 bZ
 bZ
 aI
@@ -8606,7 +8640,7 @@ fJ
 tG
 tG
 aB
-eW
+NH
 mQ
 mQ
 "}
@@ -8973,7 +9007,7 @@ mQ
 (24,1,1) = {"
 mQ
 mQ
-eW
+UD
 zV
 zV
 zV
@@ -8996,7 +9030,7 @@ VP
 VP
 VP
 VP
-eW
+Mj
 mQ
 mQ
 "}
@@ -9213,7 +9247,7 @@ mQ
 (32,1,1) = {"
 mQ
 mQ
-eW
+XN
 XJ
 XJ
 XJ
@@ -9424,7 +9458,7 @@ mQ
 mQ
 mQ
 mQ
-eW
+XN
 iQ
 pr
 qS
@@ -9787,7 +9821,7 @@ mQ
 mQ
 mQ
 mQ
-eW
+XN
 vc
 vc
 vc

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
@@ -378,6 +378,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/tech,
 /area/ship/general/cargo/cargo_bay)
 "eu" = (
@@ -766,6 +767,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/tech,
 /area/ship/general/cargo)
 "ja" = (
@@ -855,6 +857,7 @@
 /obj/effect/turf_decal/trimline/opaque/orange/line{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "jZ" = (
@@ -944,6 +947,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/heavymetal/var1,
 /area/ship/crew/canteen)
+"kx" = (
+/obj/machinery/light/floor{
+	light_color = "#6496FA"
+	},
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	piping_layer = 2
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "kI" = (
 /obj/effect/turf_decal/trimline/opaque/solgovgold/end{
 	dir = 4;
@@ -1612,9 +1625,7 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/engineering)
 "rF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -1886,7 +1897,6 @@
 /obj/item/clothing/suit/armor/vest/solgov/captain,
 /obj/item/clothing/under/solgov/formal/captain,
 /obj/item/clothing/gloves/combat,
-/obj/item/door_remote/captain,
 /obj/item/storage/belt/sabre/solgov,
 /obj/item/clothing/under/solgov,
 /obj/item/clothing/under/solgov/dress,
@@ -2638,7 +2648,8 @@
 /turf/open/floor/wood/walnut,
 /area/ship/crew/cryo)
 "Bb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/binary/pump/on/layer2,
+/obj/structure/closet/firecloset/wall/directional/east,
 /turf/open/floor/plasteel/heavymetal/var1,
 /area/ship/engineering)
 "Be" = (
@@ -3842,6 +3853,7 @@
 	pixel_x = -20;
 	pixel_y = 10
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/strongdark,
 /area/ship/bridge)
 "Pb" = (
@@ -4026,7 +4038,10 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/engineering)
 "QH" = (
-/obj/structure/punching_bag,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	piping_layer = 2
+	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
 "Rk" = (
@@ -5371,7 +5386,7 @@ Ww
 oj
 ri
 eB
-RM
+kx
 dK
 CF
 EK

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_twinkleshine.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_twinkleshine.dmm
@@ -6792,7 +6792,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/suit_storage_unit,
-/obj/item/mod/control/pre_equipped/traitor_elite,
+/obj/item/mod/control/pre_equipped/elite,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/crew/dorm/dormtwo)
 "MC" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправление ошибок у шаттлов.
## Причина создания ПР / Почему это хорошо для игры
Баги - плохо.
Closed #2396

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
fix: Замена неправильных плейтингов у Лалиша и Халифата, Фист оф фридом кнопки и турели более не дублируют чужие айди, Тирдроп турели правильно повернуты среди них более нет предателя, в меде и карго появились файер алярмы, в меде огнетушитель, Целестис заменил импланты раций на обычные рации, Биитл теперь имеет верное описание.
/🆑
```
