### PR TITLE
MAP FIX: Исправляем уголок магазина на зимнем аванпосту

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -1266,6 +1266,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned/brushed{
 	light_color = "#1B1D2E";
 	light_range = 2
@@ -3836,6 +3845,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/tech,
 /area/outpost/operations/outpost_command)
+"chB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2
+	},
+/area/outpost/exterior)
 "chN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -9162,6 +9180,18 @@
 	},
 /turf/open/floor/carpet/green,
 /area/outpost/crew/library)
+"fdu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2
+	},
+/area/outpost/exterior)
 "feb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10530,6 +10560,21 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi)
+"fLT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2
+	},
+/area/outpost/exterior)
 "fMv" = (
 /obj/effect/turf_decal/trimline/opaque/red/line,
 /obj/structure/cable{
@@ -19871,30 +19916,28 @@
 /turf/open/floor/wood,
 /area/outpost/fraction/solfed)
 "kTp" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
+/obj/structure/neon_spline/green{
+	dir = 4;
+	opacity = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/siding/white{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
 	},
-/obj/structure/catwalk/over/plated_catwalk,
-/obj/structure/sign/directions/outpost/shop{
-	pixel_y = -21;
-	dir = 4
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_y = -12
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_y = -7
 	},
+/obj/structure/sign/flag/elysium/directional/west,
 /turf/open/floor/plating{
 	light_color = "#1B1D2E";
 	light_range = 2
 	},
-/obj/structure/flora/ausbushes/ywflowers/hell,
-/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/plating/asteroid/dirt/grass,
 /area/outpost/exterior)
 "kTE" = (
@@ -22316,13 +22359,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/turf_decal/borderfloor/full,
 /obj/machinery/light/floor,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/patterned/cargo_one{
 	light_color = "#1B1D2E";
@@ -23540,6 +23583,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/outpost/crew/cryo)
+"mZJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2
+	},
+/area/outpost/exterior)
 "mZK" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -28426,6 +28478,18 @@
 	},
 /turf/open/floor/plasteel/patterned/grid,
 /area/outpost/fraction/inteq)
+"pFu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed{
+	light_color = "#1B1D2E";
+	light_range = 2
+	},
+/area/outpost/exterior)
 "pFN" = (
 /obj/effect/turf_decal/industrial/traffic{
 	dir = 8
@@ -30481,12 +30545,19 @@
 /turf/open/floor/wood,
 /area/outpost/security/detective)
 "qNb" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/ywflowers/hell,
-/obj/structure/neon_spline/green{
-	dir = 4
+/obj/structure/flora/ausbushes/brflowers{
+	pixel_y = -6;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/ywflowers/hell{
+	pixel_y = -8;
+	pixel_x = 5
 	},
 /obj/structure/railing{
+	dir = 9;
+	layer = 2.89
+	},
+/obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass,
@@ -36199,9 +36270,13 @@
 	},
 /area/outpost/exterior)
 "tVY" = (
-/obj/structure/sign/flag/elysium/directional/west,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/brflowers{
+	opacity = 1
+	},
+/obj/structure/neon_spline/green{
+	dir = 6
+	},
 /turf/open/floor/plating/asteroid/dirt/grass,
 /area/outpost/exterior)
 "tWf" = (
@@ -41260,9 +41335,14 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers/hell,
-/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ppflowers{
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
 /obj/structure/neon_spline/green{
-	dir = 4
+	opacity = 1
 	},
 /turf/open/floor/plating/asteroid/dirt/grass,
 /area/outpost/exterior)
@@ -64718,8 +64798,8 @@ jYj
 lwu
 lwu
 lwu
-sRE
-sRE
+fdu
+mZJ
 nVW
 iaV
 iaV
@@ -64904,9 +64984,9 @@ fwF
 hCa
 hCa
 mot
-hCa
+iET
 aLu
-aLu
+fLT
 daS
 oKH
 oKH
@@ -65092,8 +65172,8 @@ eLF
 atY
 mCz
 sNC
-sRE
-sRE
+pFu
+chB
 fpU
 fpU
 fpU

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -19934,10 +19934,6 @@
 	pixel_y = -7
 	},
 /obj/structure/sign/flag/elysium/directional/west,
-/turf/open/floor/plating{
-	light_color = "#1B1D2E";
-	light_range = 2
-	},
 /turf/open/floor/plating/asteroid/dirt/grass,
 /area/outpost/exterior)
 "kTE" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправил баг карты. Также закольцевал трубы атмоса и придал эстетическйи завершенный вид этому участку

## Причина создания ПР / Почему это хорошо для игры
Баг

## Демонстрация изменений / Тестирование
<img width="621" height="397" alt="изображение" src="https://github.com/user-attachments/assets/7ddc7ce1-34f4-466b-ab80-c737a9022915" />

## Список изменений

```yml
🆑
map: изменил небольшой участок между магазином и инженерным отделом на зимнем аванпосту
/🆑
```
