### PR TITLE
BALANCE: NERF BLUESPACE CRYSTAL - ADD POST TELEPORTING COOLDOWN

### DIFF
--- a/mod_celadon/balance/_balance.dme
+++ b/mod_celadon/balance/_balance.dme
@@ -12,6 +12,7 @@
 #include "code/hostile/frontiersman.dm"
 
 #include "code/backpack.dm"
+#include "code/bscrystal.dm"
 #include "code/cargo.dm"	// Механизм временный, по выводу субшатлов из ремонта, вернуть инфляцию назад.
 #include "code/cc_clothes.dm"
 #include "code/chemestry.dm"	// От ганзы не включенный файл

--- a/mod_celadon/balance/code/bscrystal.dm
+++ b/mod_celadon/balance/code/bscrystal.dm
@@ -1,0 +1,5 @@
+/obj/item/stack/ore/bluespace_crystal/attack_self(mob/user)
+	if(user.next_move > world.time)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	return ..()


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет КД на использование БС кристаллов, ПОСЛЕ их использования в руке.

## Причина создания ПР / Почему это хорошо для игры
Нерф бездумный спам БС кристаллов, позволяющие прощать очень много ошибок и вечно убегать.
Нет это так не должно работать, добавляет ПОСТ-задержку на повторное использование.

**Проще:** ~1 секунда КД на использование следующего кристалла, после телепорта.

## Список изменений

```yml
🆑
balance: Нерф телепортов через БС-кристалы
/🆑
```
