### PR TITLE
FIX: Патроны и гильзы перестают по физике лететь когда их ловят в руку

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -102,6 +102,11 @@
 		return FALSE
 
 	if(stored_ammo.len < max_ammo)
+		// [CELADON-ADD] - FIXES_PHYSICS_AMMO_CASING - Останавливаем физику гильз
+		var/datum/component/movable_physics/physics = R.GetComponent(/datum/component/movable_physics)
+		if(physics)
+			qdel(physics)
+		// [/CELADON-ADD]
 		stored_ammo += R
 		R.forceMove(src)
 		return TRUE
@@ -113,6 +118,11 @@
 				stored_ammo -= AC
 				AC.forceMove(get_turf(src.loc))
 
+				// [CELADON-ADD] - FIXES_PHYSICS_AMMO_CASING - Останавливаем физику гильз
+				var/datum/component/movable_physics/physics = R.GetComponent(/datum/component/movable_physics)
+				if(physics)
+					qdel(physics)
+				// [/CELADON-ADD]
 				stored_ammo += R
 				R.forceMove(src)
 				return TRUE

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -175,6 +175,11 @@
 		else
 			chambered = magazine.get_round(keep_bullet || bolt_type == BOLT_TYPE_NO_BOLT)
 		if (bolt_type != BOLT_TYPE_OPEN)
+			// [CELADON-ADD] - FIXES_PHYSICS_AMMO_CASING - Останавливаем физику гильз
+			var/datum/component/movable_physics/physics = chambered.GetComponent(/datum/component/movable_physics)
+			if(physics)
+				qdel(physics)
+			// [/CELADON-ADD]
 			chambered.forceMove(src)
 
 ///updates a bunch of racking related stuff and also handles the sound effects and the like

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -318,6 +318,11 @@ FIXES_PARROT_DROP_ITEM
 
 FIXES_CRAFT_MENU
 - `code/datums/components/crafting/crafting.dm` : Обновляем меню крафта автоматически, не в ручную же это делать
+
+FIXES_PHYSICS_AMMO_CASING
+- `mod_celadon/fixes/code/ammo.dm`								: тут прок на то чтобы останавливать физику патрона\гильзы если ты поймал её в руку 
+- `code/modules/projectiles/guns/ballistic.dm`					: тут прок на то чтобы останавливать физику патрона\гильзы если ты вставил её в оружие
+- `code/modules/projectiles/boxes_magazines/_box_magazine.dm`	: тут прок на то чтобы останавливать физику Патрона\гильзы если ты вставил её в обойму
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.

--- a/mod_celadon/fixes/code/ammo.dm
+++ b/mod_celadon/fixes/code/ammo.dm
@@ -17,3 +17,10 @@
 
 /obj/item/ammo_box/magazine/rottweiler_308_box
 	caliber = ".308"
+
+// FIXES_PHYSICS_AMMO_CASING
+/obj/item/ammo_casing/pickup(mob/user)
+	. = ..()
+	var/datum/component/movable_physics/physics = GetComponent(/datum/component/movable_physics)
+	if(physics)
+		qdel(physics)


### PR DESCRIPTION
## Описание / Что этот PR делает
Если при перезарядке любого оружия успеть словить патрон или гильзу, то у неё перестает работать физика.

## Причина создания ПР / Почему это хорошо для игры
Больше никаких фокусов, ломающих физику движения предмета если их вставить обратно в обойму или в оружие. Также фиксить и то когда предмет в руке

Closed https://canary.discord.com/channels/1100198143456465067/1340243748516397107

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: Проверки на физон при ловле патронов или гильз
/🆑
```
