### PR TITLE
FIX: Зарядка патронами на растояние

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -131,7 +131,11 @@
 	if(istype(attacking_obj, /obj/item/ammo_box))
 		var/obj/item/ammo_box/attacking_box = attacking_obj
 		for(var/obj/item/ammo_casing/casing_to_insert in attacking_box.stored_ammo)
-			if(!((instant_load && attacking_box.instant_load) || (stored_ammo.len >= max_ammo) || istype(attacking_obj, /obj/item/ammo_box/magazine/ammo_stack) && do_after(user, 0.5 SECONDS, attacking_box, timed_action_flags = IGNORE_USER_LOC_CHANGE)))
+			// [CELADON-EDIT] - FIXES_LONG_RELOAD_AMMO - Явно указываю параметр target для do_after
+			// if(!((instant_load && attacking_box.instant_load) || (stored_ammo.len >= max_ammo) || istype(attacking_obj, /obj/item/ammo_box/magazine/ammo_stack) && do_after(user, 0.5 SECONDS, src)))	// ORIGINAL
+			var/timed_action_flags = (user.is_holding(src) || src.loc == user) ? IGNORE_USER_LOC_CHANGE : NONE
+			if(!((instant_load && attacking_box.instant_load) || (stored_ammo.len >= max_ammo) || istype(attacking_obj, /obj/item/ammo_box/magazine/ammo_stack) && do_after(user, 0.5 SECONDS, target = src, timed_action_flags = timed_action_flags)))
+			// [/CELADON-EDIT]
 				break
 			var/did_load = give_round(casing_to_insert, replace_spent)
 			if(!did_load)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -318,6 +318,9 @@ FIXES_PARROT_DROP_ITEM
 
 FIXES_CRAFT_MENU
 - `code/datums/components/crafting/crafting.dm` : Обновляем меню крафта автоматически, не в ручную же это делать
+
+FIXES_LONG_RELOAD_AMMO
+- `code/modules/projectiles/boxes_magazines/_box_magazine.dm` : Прерывает зарядку патронами, если игрок отойдет на растояние. Явно указываю параметр target для do_after чтобы проверка расстояния работала корректно
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Делает так что если игрок отойдет от обоймы во время заталкивания патронов, то процесс прервется.

## Причина создания ПР / Почему это хорошо для игры
Closed https://canary.discord.com/channels/1100198143456465067/1350106264188751962

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
tweak: указана явная цель для зарядки патронами, для корректного прерывания
/🆑
```
