### PR TITLE
MAP: Руина для луны - "Lunar Dispersal"

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/MoonRuins/lunar_dispersal.dmm
+++ b/_maps/_mod_celadon/RandomRuins/MoonRuins/lunar_dispersal.dmm
@@ -1,0 +1,10599 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/mob/living/simple_animal/hostile/human/zombie,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"ag" = (
+/turf/template_noop,
+/area/template_noop)
+"an" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"aq" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/mob_spawn/human/miner,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"aM" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"aY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"bg" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"bi" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"bn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"by" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"bJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"bT" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"cb" = (
+/obj/structure/salvageable/computer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"ch" = (
+/obj/effect/spawner/random/trash,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"cl" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"cD" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"cZ" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/gun,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"dG" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/match,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"eA" = (
+/obj/structure/salvageable/destructive_analyzer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"eN" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"eQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/robot_debris{
+	icon_state = "gib7"
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"eY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"fx" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"fC" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"fI" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"gx" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/food/drinks/trophy/bronze_cup,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/survey_handheld,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"gC" = (
+/obj/effect/turf_decal/road{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"gL" = (
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"gX" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/moon_coarse/dark,
+/area/overmap_encounter/planetoid/moon/explored)
+"hm" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/radio,
+/obj/item/radio,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"ho" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"hP" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"hT" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"hU" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/kinetic_crusher,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"iE" = (
+/mob/living/basic/hivebot/strong,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"iO" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"iP" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"jc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/food/pie_smudge,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"jd" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"jf" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"jy" = (
+/obj/structure/closet,
+/obj/item/pickaxe/drill,
+/obj/item/clothing/gloves/explorer,
+/obj/item/storage/backpack/satchel/explorer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"jF" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"jK" = (
+/obj/item/disk/holodisk,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"jR" = (
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"ke" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"kn" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"kp" = (
+/obj/item/disk/holodisk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"ky" = (
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"kD" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/mining_scanner,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"kS" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"lg" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/laser_pointer/upgraded,
+/obj/item/lazarus_injector,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"lo" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"lI" = (
+/obj/structure/frame/machine,
+/obj/machinery/camera,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"lN" = (
+/obj/structure/crate_shelf,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"lY" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"mo" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"mI" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/road,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"mJ" = (
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"mO" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"nb" = (
+/turf/closed/wall/concrete,
+/area/overmap_encounter/planetoid/moon/explored)
+"ne" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/waffles,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"nn" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/camera,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"nD" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/gun/mini/empty,
+/obj/item/stock_parts/cell/gun/mini,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"nE" = (
+/obj/structure/safe,
+/obj/item/organ/cyberimp/arm/flash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"nR" = (
+/obj/machinery/suit_storage_unit/industrial,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"nX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"nY" = (
+/obj/structure/salvageable/circuit_imprinter,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"or" = (
+/obj/structure/fence,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"oJ" = (
+/turf/closed/wall/concrete,
+/area/ruin/moon/lunar_dispersal/manufactory)
+"oK" = (
+/obj/effect/turf_decal/road/edge,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"pr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/live,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"ps" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"pA" = (
+/obj/structure/closet/crate/critter,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"pM" = (
+/mob/living/simple_animal/hostile/human/skeleton,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"pU" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/gun/upgraded/empty,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"pV" = (
+/obj/item/pickaxe/emergency,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"ql" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"qt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"qw" = (
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"qH" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"qU" = (
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/camera,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"rE" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"rL" = (
+/obj/structure/crate_shelf/built,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"rM" = (
+/obj/structure/salvageable/autolathe,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"rQ" = (
+/obj/effect/turf_decal/road{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"rV" = (
+/mob/living/basic/hivebot/strong,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"rY" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"sz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"sH" = (
+/obj/effect/turf_decal/road,
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"sK" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"sS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"sZ" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/gun/energy/laser/redtag{
+	icon_state = "meteor_gun";
+	name = "meteor gun";
+	desc = "For the love of god, make sure you're aiming this the right way!"
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"tc" = (
+/obj/item/gun/energy/tesla_cannon,
+/obj/structure/guncloset,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"tj" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/multitool,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"tq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wallframe/button,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"tw" = (
+/obj/structure/closet/cardboard/metal,
+/mob/living/simple_animal/hostile/human/zombie,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"tB" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/syringe,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/soap,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"tD" = (
+/obj/machinery/camera,
+/turf/open/floor/plating/asteroid/moon/lit/surface_craters,
+/area/overmap_encounter/planetoid/moon/explored)
+"tU" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"tV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"uc" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"uo" = (
+/obj/structure/closet/crate/large,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"us" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/human/skeleton,
+/mob/living/simple_animal/hostile/human/skeleton,
+/mob/living/simple_animal/hostile/human/skeleton,
+/mob/living/simple_animal/hostile/human/skeleton,
+/mob/living/simple_animal/hostile/human/skeleton,
+/mob/living/simple_animal/hostile/human/skeleton,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"uw" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"uE" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/spray,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"uI" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"uP" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"vi" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"vE" = (
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"vL" = (
+/obj/structure/salvageable/protolathe/reployer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"vO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"vV" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"wb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/computer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"ws" = (
+/turf/open/floor/plating/asteroid/moon_coarse,
+/area/overmap_encounter/planetoid/moon/explored)
+"wR" = (
+/obj/structure/guncloset,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"xf" = (
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"xM" = (
+/obj/machinery/camera,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"xO" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"xR" = (
+/obj/item/mine/pressure/explosive/live,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"xX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"yA" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"yI" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"yK" = (
+/turf/closed/mineral/random/moon,
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"yR" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pushbroom,
+/obj/item/plunger,
+/obj/item/soap/homemade,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"zn" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pizzabox/bomb,
+/obj/item/pizzabox/pineapple,
+/obj/item/pizzabox,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lipstick,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"zC" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/turf_decal/road,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"zO" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/radio,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"zS" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"zT" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"zX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"An" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Ao" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/item/trash/can/food/beans,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Aq" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"AG" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"AK" = (
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"AX" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Bd" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/rcl,
+/obj/item/inducer,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"BM" = (
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"BN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"BR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"BV" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Cf" = (
+/obj/machinery/camera,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Cj" = (
+/obj/item/weldingtool,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Cq" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Cu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"CH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"CK" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"CT" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"DF" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"DM" = (
+/obj/item/mine/pressure/explosive/live,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ec" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Ej" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pestle,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Ep" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"EO" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Fc" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/holosign_creator/janibarrier,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Fd" = (
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Fs" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Fv" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pneumatic_cannon,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Fz" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"FG" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pickaxe,
+/obj/item/mining_scanner,
+/obj/item/disk/design_disk/ammo_1911,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"FK" = (
+/obj/effect/turf_decal/road{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ge" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Go" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"Gw" = (
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"GG" = (
+/obj/machinery/camera{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/moon/lit/surface_craters,
+/area/overmap_encounter/planetoid/moon/explored)
+"GI" = (
+/turf/open/floor/plating/asteroid/moon/lit/surface_craters,
+/area/overmap_encounter/planetoid/moon/explored)
+"GQ" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/healthanalyzer,
+/obj/item/organ/cyberimp/eyes/hud/medical,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"GR" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Hy" = (
+/obj/structure/frame/machine,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Id" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ig" = (
+/obj/structure/sacrificealtar,
+/obj/item/reagent_containers/food/drinks/trophy/gold_cup{
+	pixel_y = 13
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"Ih" = (
+/obj/machinery/door/airlock/mining{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Ik" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"It" = (
+/turf/closed/wall/concrete/reinforced{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"Iu" = (
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"IC" = (
+/obj/structure/crate_shelf/built,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ja" = (
+/obj/effect/turf_decal/road,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Jo" = (
+/obj/structure/closet,
+/obj/item/pickaxe/drill,
+/obj/item/clothing/gloves/explorer,
+/obj/item/storage/backpack/satchel/explorer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Jq" = (
+/obj/structure/crate_shelf,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Jt" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Jw" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/blood/random,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"JA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"JD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"JH" = (
+/obj/item/holosign_creator/medical/infinite,
+/obj/item/toy/windupToolbox,
+/turf/open/floor/plating/asteroid/moon_coarse/dark,
+/area/overmap_encounter/planetoid/moon/explored)
+"JR" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"JS" = (
+/obj/structure/frame/computer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Kf" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/tray,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"Kn" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Kr" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/oar,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Kx" = (
+/obj/structure/fence,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ky" = (
+/obj/structure/salvageable/machine,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"KD" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"KG" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Le" = (
+/obj/structure/closet/crate,
+/obj/structure/crate_shelf,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Lh" = (
+/obj/effect/turf_decal/road/edge{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Lo" = (
+/obj/structure/closet/crate/large,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Mb" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/dropper,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/hemostat,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Me" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Mt" = (
+/obj/structure/safe,
+/obj/item/newspaper,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"MI" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"MR" = (
+/obj/structure/salvageable/machine,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Nd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Nh" = (
+/obj/structure/salvageable/computer,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Nu" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pda,
+/obj/effect/spawner/random/maintenance,
+/obj/item/melee/sword/mass,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"NB" = (
+/turf/open/floor/plating/rust/rockplanet/lit{
+	initial_gas_mix = "TEMP=2.7";
+	name = "plating"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"NP" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"NV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"NZ" = (
+/obj/structure/safe,
+/obj/item/spacecash/bundle/mediumrand,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"Og" = (
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib5";
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Os" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glitter,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ox" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"OD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Pn" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/resonator,
+/obj/machinery/camera,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Pv" = (
+/obj/structure/mineral_door/iron,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"PY" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Qe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Qi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Qt" = (
+/obj/structure/fence/corner,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"QB" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"QC" = (
+/obj/structure/crate_shelf/built,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"QG" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"QM" = (
+/obj/structure/salvageable/server,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"RI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance/three,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"RN" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"RX" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"Sn" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Sz" = (
+/turf/closed/mineral/random/moon,
+/area/overmap_encounter/planetoid/moon/explored)
+"SF" = (
+/obj/effect/turf_decal/road/edge,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"SM" = (
+/obj/item/gun/energy/laser/hitscanpistol,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/guncloset,
+/turf/open/floor/plasteel/strongdark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/mutiny)
+"SV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/mine/pressure/explosive/shrapnel,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/surveillancecenter)
+"Tb" = (
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Tt" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Tx" = (
+/obj/structure/fence,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ty" = (
+/obj/structure/safe,
+/obj/item/organ/cyberimp/eyes/hud/diagnostic,
+/obj/item/organ/eyes/robotic/glow,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"TD" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "streak3"
+	},
+/obj/effect/decal/remains/robot,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"TX" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/hatchet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Uj" = (
+/turf/open/floor/plating/asteroid/moon_coarse/dark,
+/area/overmap_encounter/planetoid/moon/explored)
+"UK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/telecomms/relay,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"UY" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/mop,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/implanter/mindshield,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Vg" = (
+/obj/structure/reagent_dispensers/foamtank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Vr" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Vw" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Vy" = (
+/obj/machinery/suit_storage_unit/industrial,
+/obj/item/clothing/mask/gas/explorer,
+/obj/item/clothing/suit/hooded/explorer,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Wj" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Wo" = (
+/obj/structure/mineral_door/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Wq" = (
+/obj/structure/grille,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Wt" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Ww" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"WP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wallframe/light_switch,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"WQ" = (
+/obj/item/mine/pressure/explosive/live,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"WT" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Xd" = (
+/obj/structure/closet/cardboard/metal,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/hemostat/supermatter,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"Xl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Xn" = (
+/obj/effect/turf_decal/road{
+	dir = 9
+	},
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Xs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"Xu" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"XB" = (
+/obj/effect/turf_decal/road,
+/turf/open/floor/concrete/pavement{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"XT" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/reservoir)
+"Yc" = (
+/obj/structure/closet/crate,
+/obj/structure/crate_shelf,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Yj" = (
+/obj/structure/grille,
+/turf/open/floor/plating/asteroid/moon/lit/surface_craters,
+/area/overmap_encounter/planetoid/moon/explored)
+"Ym" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/picket_sign,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Yn" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"Ys" = (
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"YD" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/reagent_containers/food/drinks/flask,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"YX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/concrete,
+/area/overmap_encounter/planetoid/moon/explored)
+"Zd" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"Zm" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/concrete{
+	light_range = 2;
+	light_power = 0.6;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"ZC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wallframe/light_fixture/small,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/ambry)
+"ZI" = (
+/obj/effect/spawner/random/trash,
+/turf/open/floor/concrete/slab_4{
+	light_power = 0.6;
+	light_range = 2;
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/overmap_encounter/planetoid/moon/explored)
+"ZR" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "floor6";
+	pixel_x = -9
+	},
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+"ZW" = (
+/obj/structure/closet/cardboard/metal,
+/obj/item/pinpointer/mineral,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/ruin/moon/lunar_dispersal/manufactory)
+
+(1,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(2,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(3,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(4,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+ws
+ws
+ws
+ws
+Ys
+bJ
+bJ
+rY
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(5,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+Ys
+DF
+DF
+DF
+Ys
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+ws
+xR
+qH
+gL
+bJ
+bJ
+Ys
+BN
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(6,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+DF
+DF
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+QB
+DF
+bJ
+bJ
+bJ
+DF
+qH
+BN
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(7,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+ws
+Ys
+DF
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+nb
+DF
+DF
+Sz
+Sz
+Uj
+DF
+DF
+OD
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(8,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+nb
+nb
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(9,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(10,1,1) = {"
+ag
+ag
+ag
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GG
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(11,1,1) = {"
+ag
+ag
+ws
+ws
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+nb
+nb
+nb
+nb
+Tx
+Tx
+Tx
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Sz
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(12,1,1) = {"
+ag
+ag
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+Tx
+Tx
+nb
+nb
+Ww
+qH
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+"}
+(13,1,1) = {"
+ag
+ag
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+rY
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+ag
+ag
+"}
+(14,1,1) = {"
+ag
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+ag
+ag
+ag
+"}
+(15,1,1) = {"
+ag
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+ws
+sS
+WT
+It
+It
+It
+It
+It
+Kx
+nb
+nb
+nb
+nb
+tD
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+ag
+ag
+"}
+(16,1,1) = {"
+ag
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+DF
+DF
+AX
+Wj
+Wj
+It
+iE
+TD
+nE
+It
+Ww
+BN
+Ys
+qH
+nb
+nb
+nb
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+ag
+"}
+(17,1,1) = {"
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+DF
+BN
+WT
+Iu
+It
+qU
+rV
+Mt
+It
+ws
+ws
+ws
+ws
+ws
+BN
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+"}
+(18,1,1) = {"
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+DF
+Ys
+Ww
+It
+It
+ZC
+rV
+Ty
+It
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+ag
+"}
+(19,1,1) = {"
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+DF
+qH
+BN
+It
+Xs
+eQ
+JA
+NZ
+It
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+ag
+"}
+(20,1,1) = {"
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+DF
+DF
+BN
+It
+Zd
+It
+Ig
+It
+It
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+"}
+(21,1,1) = {"
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+BN
+CT
+rE
+Zm
+vE
+It
+It
+It
+Vr
+Ys
+Ys
+BN
+uI
+BN
+BN
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+"}
+(22,1,1) = {"
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ZI
+bJ
+cl
+gL
+cl
+gL
+gL
+bJ
+bJ
+cl
+gL
+Jt
+gL
+ZI
+gL
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+"}
+(23,1,1) = {"
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+gL
+gL
+bJ
+bJ
+gL
+bJ
+bJ
+bJ
+gL
+gL
+bJ
+bJ
+bJ
+bJ
+bJ
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+"}
+(24,1,1) = {"
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Ys
+gL
+AG
+Ys
+ch
+Sz
+Sz
+Sz
+Sz
+Sz
+xR
+kS
+Ys
+Zm
+WT
+BN
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+ag
+"}
+(25,1,1) = {"
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+DF
+DF
+or
+DF
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+Sz
+ag
+ag
+ag
+"}
+(26,1,1) = {"
+ws
+Ys
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+DF
+qt
+bJ
+DF
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+ag
+ag
+ag
+"}
+(27,1,1) = {"
+ws
+DF
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+DF
+bJ
+Jt
+DF
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+ag
+"}
+(28,1,1) = {"
+ws
+DF
+DF
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+DF
+DF
+or
+DF
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+"}
+(29,1,1) = {"
+ws
+qH
+DF
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+DF
+Jt
+gL
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+BN
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(30,1,1) = {"
+ag
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+DF
+DF
+gL
+Ao
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+Ys
+bJ
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(31,1,1) = {"
+ag
+ag
+ag
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+DF
+Jt
+tq
+DF
+DF
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+BN
+BN
+ws
+ws
+mo
+bJ
+gL
+Ys
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(32,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+DF
+an
+nX
+DF
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+fI
+fI
+fI
+fI
+BN
+bJ
+bJ
+Ys
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+KD
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(33,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Sz
+Sz
+ws
+ws
+hT
+hT
+hT
+Pv
+hT
+hT
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Cj
+BV
+rM
+Ky
+fI
+BN
+gL
+ho
+Ys
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+KD
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(34,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+ws
+hT
+SM
+vO
+aY
+pU
+hT
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Nh
+uw
+Qe
+Qe
+fI
+BN
+Aq
+bJ
+Ys
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+KD
+Ww
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+"}
+(35,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+DF
+DF
+Tx
+Tx
+Tx
+hT
+tc
+pM
+aa
+cZ
+hT
+hT
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Sz
+Gw
+QM
+Fd
+BV
+SV
+lY
+bJ
+bJ
+NP
+qH
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ag
+ag
+ag
+"}
+(36,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+Sz
+DF
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+DF
+DF
+DF
+DF
+ws
+ws
+ws
+ws
+hT
+wR
+vO
+RI
+nD
+hT
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Gw
+Fd
+MR
+wb
+Gw
+nY
+zT
+fI
+Ys
+bJ
+gL
+Ys
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+ws
+ag
+ag
+ag
+"}
+(37,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+DF
+OD
+gL
+gL
+gL
+lN
+DF
+DF
+Wq
+Ys
+ws
+ws
+ws
+ws
+hT
+hT
+hT
+hT
+hT
+hT
+Sz
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Ky
+Gw
+jf
+kp
+Qe
+RN
+fI
+PY
+Xl
+gL
+AG
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+ag
+"}
+(38,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+qH
+Ys
+BN
+Ww
+gL
+bJ
+bJ
+Yc
+DF
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+yK
+Gw
+vL
+fI
+rY
+NP
+bJ
+Ys
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+"}
+(39,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+qH
+Ys
+BN
+xX
+bJ
+bJ
+gL
+Le
+DF
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+fI
+Ys
+gL
+bJ
+Ys
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+"}
+(40,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+Jt
+BN
+bJ
+gL
+gL
+PY
+DF
+DF
+Wq
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+gL
+gL
+BN
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+"}
+(41,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+Jt
+BN
+gL
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+gL
+Ys
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+"}
+(42,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+DF
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Ys
+ws
+ws
+ws
+ws
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+"}
+(43,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+"}
+(44,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+"}
+(45,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+ag
+"}
+(46,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+ag
+ag
+"}
+(47,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+KD
+ag
+ag
+ag
+"}
+(48,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Sz
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+KD
+ag
+ag
+ag
+"}
+(49,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+KD
+ag
+ag
+ag
+"}
+(50,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+KD
+ag
+ag
+ag
+"}
+(51,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+KD
+ag
+ag
+ag
+"}
+(52,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+KD
+ag
+ag
+ag
+"}
+(53,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+KD
+ag
+ag
+ag
+"}
+(54,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+Qt
+DF
+ag
+ag
+"}
+(55,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+KD
+ag
+ag
+"}
+(56,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+nb
+Ys
+BN
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+Yj
+GI
+GI
+GI
+KD
+ag
+ag
+"}
+(57,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+BN
+tV
+EO
+BN
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+DF
+GI
+GI
+GI
+KD
+ag
+ag
+"}
+(58,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+nb
+Jq
+QG
+tV
+YX
+GI
+bJ
+bJ
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+ke
+DF
+xO
+GI
+GI
+KD
+GI
+ag
+"}
+(59,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+BN
+nb
+tV
+tV
+Yn
+BN
+GI
+Ys
+Qi
+bJ
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+GI
+GI
+GI
+DF
+qH
+DF
+sK
+DF
+GI
+KD
+GI
+ag
+"}
+(60,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+nb
+IC
+Ys
+tV
+tV
+Xu
+GI
+GI
+Ys
+BN
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+gX
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+GI
+GI
+BN
+qH
+Wq
+Wq
+Wq
+qH
+rY
+KD
+GI
+GI
+"}
+(61,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+NB
+Ge
+BR
+tV
+BN
+NB
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+Yj
+DF
+DF
+DF
+Wq
+UK
+Wq
+DF
+DF
+DF
+Yj
+GI
+"}
+(62,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+BN
+BN
+tV
+Ys
+nb
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+ws
+GI
+GI
+Ym
+qH
+Wq
+uP
+Wq
+sK
+BN
+KD
+GI
+GI
+"}
+(63,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+xf
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+GI
+GI
+GI
+DF
+qH
+DF
+sK
+DF
+GI
+KD
+GI
+GI
+"}
+(64,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+Ys
+DF
+BN
+GI
+GI
+KD
+GI
+GI
+"}
+(65,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+DF
+GI
+GI
+GI
+KD
+GI
+GI
+"}
+(66,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+nb
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+Yj
+GI
+GI
+GI
+KD
+GI
+GI
+"}
+(67,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+nb
+nb
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+KD
+GI
+GI
+"}
+(68,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+nb
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+KD
+GI
+GI
+"}
+(69,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+GI
+GI
+"}
+(70,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+GI
+GI
+"}
+(71,1,1) = {"
+GI
+GI
+GI
+Uj
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Sz
+ws
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+DF
+DF
+tD
+GI
+"}
+(72,1,1) = {"
+GI
+GI
+Sz
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+GI
+GI
+GI
+GI
+GI
+Ys
+sS
+DF
+DF
+DF
+GI
+GI
+"}
+(73,1,1) = {"
+GI
+GI
+Sz
+Sz
+Uj
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+qH
+DF
+DF
+DF
+GI
+GI
+ag
+"}
+(74,1,1) = {"
+GI
+GI
+GI
+Uj
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+GI
+GI
+GI
+BN
+DF
+DF
+DF
+GI
+GI
+GI
+ag
+"}
+(75,1,1) = {"
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+BN
+Ys
+DF
+DF
+DF
+GI
+GI
+ag
+ag
+ag
+"}
+(76,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+oJ
+oJ
+oJ
+Ys
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+DF
+DF
+DF
+DF
+GI
+GI
+ag
+ag
+ag
+ag
+"}
+(77,1,1) = {"
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+nb
+An
+An
+An
+An
+An
+oJ
+BN
+BN
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+DF
+DF
+DF
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+"}
+(78,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+NB
+An
+An
+An
+yA
+aM
+yA
+An
+An
+An
+An
+An
+An
+An
+An
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+DF
+DF
+GI
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+"}
+(79,1,1) = {"
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+oJ
+An
+eY
+Wo
+ZR
+bT
+MI
+Wo
+MI
+eY
+ne
+bi
+pr
+Ox
+An
+BN
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+GI
+GI
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+"}
+(80,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+oJ
+An
+eY
+oJ
+oJ
+oJ
+oJ
+oJ
+oJ
+cb
+MI
+by
+eY
+vi
+An
+BN
+bJ
+bJ
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+GI
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+"}
+(81,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+Ys
+oJ
+An
+MI
+YD
+Ej
+Lo
+UY
+jd
+oJ
+Ep
+eY
+QC
+MI
+zS
+An
+An
+gL
+bJ
+Ys
+ws
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+"}
+(82,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+BN
+An
+tB
+GR
+FG
+uE
+Xd
+Kr
+oJ
+JS
+tU
+mO
+Tb
+Ox
+An
+An
+bJ
+gL
+Ys
+Go
+Go
+Go
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+"}
+(83,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+NB
+An
+dG
+zn
+Fc
+jK
+yR
+bg
+oJ
+lI
+Tb
+Kn
+eY
+Ox
+An
+An
+bJ
+gL
+Ys
+Go
+bn
+sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+"}
+(84,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+An
+eN
+Mb
+hm
+pA
+tj
+Vw
+oJ
+cb
+MI
+ql
+eY
+uc
+An
+cD
+bJ
+gL
+Go
+Go
+JD
+CH
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+GI
+ag
+ag
+ag
+ag
+ag
+"}
+(85,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+An
+gx
+ZW
+Vg
+lg
+Og
+hU
+oJ
+eA
+eY
+yI
+bi
+Ec
+CK
+gL
+ho
+bJ
+jR
+qw
+NV
+BM
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+ws
+ws
+ag
+ag
+ag
+ag
+"}
+(86,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+An
+GQ
+sZ
+TX
+Bd
+us
+uo
+oJ
+JS
+MI
+rL
+eY
+Tb
+CK
+gL
+bJ
+Os
+jR
+Kf
+WP
+NV
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+GI
+GI
+ws
+ws
+ag
+ag
+ag
+ag
+"}
+(87,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+GI
+An
+aq
+Jw
+Fv
+Nu
+ps
+tw
+oJ
+eA
+eY
+eY
+Ik
+fC
+An
+PY
+gL
+bJ
+Go
+Go
+nn
+zX
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+GI
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+"}
+(88,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+GI
+GI
+Sz
+Sz
+Sz
+Sz
+Sz
+GI
+An
+An
+An
+An
+An
+oJ
+oJ
+oJ
+oJ
+oJ
+Ih
+oJ
+oJ
+An
+An
+gL
+bJ
+Ys
+Go
+XT
+CH
+RX
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+"}
+(89,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+oJ
+An
+An
+JR
+Jo
+jy
+jy
+eY
+eY
+eY
+Fs
+An
+An
+Cf
+bJ
+BN
+Go
+Go
+Go
+Go
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ag
+ag
+"}
+(90,1,1) = {"
+ag
+ag
+ag
+GI
+GI
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+oJ
+An
+kD
+Tb
+eY
+eY
+bi
+eY
+eY
+Wt
+An
+An
+bJ
+bJ
+bJ
+Ys
+Ys
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ws
+ag
+"}
+(91,1,1) = {"
+ag
+ag
+ag
+ag
+GI
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+oJ
+An
+Pn
+bi
+Tb
+eY
+eY
+Wt
+Wt
+Tb
+An
+An
+bJ
+bJ
+bJ
+bJ
+AG
+Ys
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+"}
+(92,1,1) = {"
+ag
+ag
+ag
+ag
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+oJ
+An
+zO
+nR
+Vy
+Vy
+Tb
+eY
+eY
+Me
+An
+An
+Ys
+WQ
+bJ
+ho
+bJ
+BN
+BN
+Ys
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+"}
+(93,1,1) = {"
+ag
+ag
+ag
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+An
+An
+An
+An
+An
+An
+An
+An
+An
+An
+Wj
+kn
+bJ
+bJ
+gL
+gL
+gL
+bJ
+gL
+Ys
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(94,1,1) = {"
+ag
+ag
+ag
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+BN
+Ys
+oJ
+oJ
+oJ
+ws
+ws
+Ys
+gL
+kn
+kn
+Cq
+Wj
+gL
+gL
+bJ
+iO
+gL
+Ys
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(95,1,1) = {"
+ag
+ag
+ag
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Ys
+gL
+bJ
+bJ
+bJ
+Ys
+nb
+qH
+Ys
+bJ
+ho
+gL
+Ys
+Ys
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(96,1,1) = {"
+ag
+ag
+ag
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+BN
+gL
+gL
+bJ
+gL
+Ys
+DF
+DF
+nb
+nb
+PY
+bJ
+bJ
+gL
+Ys
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(97,1,1) = {"
+ag
+ag
+ag
+ws
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Ys
+PY
+Ys
+BN
+BN
+BN
+BN
+BN
+BN
+Ys
+bJ
+bJ
+bJ
+Ys
+nb
+DF
+Uj
+DF
+nb
+qH
+gL
+bJ
+jF
+Ys
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(98,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+cl
+gL
+bJ
+bJ
+bJ
+ky
+bJ
+bJ
+bJ
+bJ
+bJ
+gL
+Ys
+nb
+DF
+Uj
+JH
+Uj
+DF
+nb
+xM
+gL
+bJ
+Ys
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+ag
+"}
+(99,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Sz
+Sz
+Sz
+pV
+gL
+Cu
+bJ
+bJ
+bJ
+bJ
+bJ
+bJ
+ho
+bJ
+gL
+gL
+qH
+nb
+nb
+DF
+Uj
+DF
+DF
+nb
+Ys
+bJ
+gL
+mJ
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+Sz
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+Sz
+ag
+"}
+(100,1,1) = {"
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+Sz
+Sz
+Sz
+Sz
+Sz
+Ys
+BN
+BN
+BN
+BN
+BN
+Zm
+Ys
+Ys
+BN
+BN
+Ys
+BN
+bJ
+bJ
+bJ
+BN
+nb
+DF
+DF
+nb
+nb
+Hy
+gL
+bJ
+bJ
+BN
+Ys
+Ys
+BN
+BN
+Ys
+Ys
+Ys
+Ys
+Wj
+Ys
+BN
+BN
+Ys
+BN
+BN
+BN
+BN
+BN
+BN
+BN
+BN
+Ys
+BN
+Ys
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Uj
+Sz
+Sz
+Sz
+ag
+"}
+(101,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+nb
+ws
+ws
+ws
+ws
+BN
+bJ
+bJ
+gL
+bJ
+Ys
+nb
+nb
+DF
+Ys
+gL
+gL
+bJ
+bJ
+BN
+Xn
+Ja
+Ja
+XB
+XB
+XB
+XB
+Ja
+mI
+mI
+Ja
+Ja
+Ja
+XB
+Ja
+sH
+Ja
+XB
+XB
+zC
+Ja
+Ja
+Ja
+Ja
+XB
+XB
+Sz
+Sz
+Sz
+Sz
+Sz
+Uj
+Uj
+Sz
+ag
+"}
+(102,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+nb
+ws
+ws
+ws
+Ys
+bJ
+bJ
+bJ
+gL
+Ys
+qH
+Ys
+bJ
+bJ
+bJ
+bJ
+Ys
+FK
+oK
+Nd
+AK
+AK
+AK
+Nd
+Nd
+AK
+AK
+lo
+AK
+AK
+AK
+Nd
+Nd
+AK
+AK
+Nd
+Nd
+AK
+AK
+vV
+AK
+AK
+Nd
+Nd
+AK
+AK
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(103,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+nb
+ws
+ws
+ws
+AG
+bJ
+jF
+bJ
+bJ
+bJ
+cl
+bJ
+gL
+gL
+Ys
+Xn
+oK
+AK
+AK
+AK
+Nd
+Nd
+Nd
+Nd
+Nd
+Sn
+Sn
+Nd
+Nd
+AK
+Nd
+Nd
+Nd
+AK
+AK
+AK
+Nd
+Nd
+Nd
+Nd
+AK
+AK
+Nd
+AK
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+"}
+(104,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+Ys
+bJ
+bJ
+gL
+bJ
+bJ
+gL
+gL
+Ys
+Xn
+SF
+Nd
+Nd
+Nd
+Nd
+Nd
+XB
+Ja
+Nd
+Nd
+lo
+AK
+AK
+Ja
+Ja
+Nd
+AK
+Nd
+jc
+AK
+XB
+XB
+AK
+DM
+Nd
+Nd
+AK
+Ja
+Ja
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+"}
+(105,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+Ys
+Ys
+BN
+BN
+BN
+BN
+Ys
+Ys
+gC
+Nd
+Nd
+AK
+Nd
+Nd
+Nd
+Nd
+AK
+AK
+AK
+Sn
+AK
+AK
+AK
+AK
+Nd
+Nd
+Nd
+Nd
+Nd
+AK
+AK
+AK
+Nd
+Nd
+Nd
+AK
+AK
+Nd
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(106,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+Ys
+gC
+AK
+AK
+AK
+Nd
+Nd
+Nd
+AK
+AK
+lo
+AK
+Nd
+Nd
+AK
+AK
+AK
+hP
+Nd
+Nd
+Nd
+Nd
+Nd
+fx
+Nd
+Nd
+AK
+AK
+AK
+AK
+Nd
+AK
+Sz
+Uj
+Uj
+Uj
+Uj
+Uj
+Sz
+"}
+(107,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+ws
+Ys
+gC
+ws
+AK
+AK
+AK
+ws
+AK
+Lh
+KG
+Id
+KG
+KG
+Fz
+Fz
+Fz
+Fz
+Fz
+Fz
+KG
+KG
+KG
+KG
+KG
+Fz
+Fz
+iP
+Fz
+Fz
+Fz
+KG
+AK
+AK
+Sz
+Uj
+Uj
+Sz
+Sz
+ag
+"}
+(108,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+Ys
+gC
+AK
+AK
+gC
+AK
+AK
+ws
+rQ
+Ys
+Wj
+Ys
+Ys
+Ys
+Ys
+Ys
+AG
+Ys
+Ys
+Ys
+BN
+BN
+BN
+BN
+Ys
+Ys
+Ys
+BN
+BN
+BN
+Ys
+Ys
+Ys
+Ys
+Sz
+Sz
+Sz
+ag
+ag
+"}
+(109,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+gC
+ws
+AK
+ws
+AK
+AK
+Tt
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+"}
+(110,1,1) = {"
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ws
+ws
+ws
+AK
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ws
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+"}

--- a/mod_celadon/areas/code/ruin.dm
+++ b/mod_celadon/areas/code/ruin.dm
@@ -219,3 +219,146 @@
 /area/ruin/jungle/syndifortshuttle
 	name = "Syndi Fort Shuttle"
 	icon_state = "green"
+
+/// MARK: Whitesands
+
+/area/ruin/whitesands/trainyard/shuttle
+	name = "shuttle"
+	icon_state = "shuttle"
+/area/ruin/whitesands/trainyard/engineering
+	name = "engineering"
+	icon_state = "yellow"
+/area/ruin/whitesands/trainyard/train
+	name = "train"
+	icon_state = "bridge"
+/area/ruin/whitesands/trainyard/cargo
+	name = "cargo"
+	icon_state = "mining"
+/area/ruin/whitesands/trainyard/dorm
+	name = "dorm"
+	icon_state = "crew_quarters"
+/area/ruin/whitesands/trainyard/hangar
+	name = "hangar"
+	icon_state = "storage"
+/area/ruin/whitesands/trainyard/carriage
+	name = "carriage"
+	icon_state = "green"
+/area/ruin/whitesands/trainyard/checkpoint
+	name = "checkpoint"
+	icon_state = "red"
+/area/ruin/whitesands/trainyard/checkpoint/second
+	name = "checkpoint 2"
+	icon_state = "blue"
+/area/ruin/whitesands/trainyard/checkpoint/storage
+	name = "storage"
+	icon_state = "quartstorage"
+/area/ruin/whitesands/trainyard/checkpoint/control
+	name = "control room"
+	icon_state = "captain"
+
+// MARK: Moon
+/area/ruin/moon/yotastation/dorm
+	name = "control room"
+	icon_state = "captain"
+
+/area/ruin/moon/yotastation/rnd
+	name = "reserch"
+	icon_state = "toxlab"
+
+/area/ruin/moon/yotastation/robotics
+	name = "robotics"
+	icon_state = "medresearch"
+
+/area/ruin/moon/yotastation/dorm
+	name = "dorm"
+	icon_state = "crew_quarters"
+
+
+/area/ruin/moon/yotastation/atmos
+	name = "Atmos"
+	icon_state = "atmos"
+
+/area/ruin/moon/yotastation/atmos2
+	name = "Atmos2"
+	icon_state = "atmos"
+
+/area/ruin/moon/yotastation/engineering
+	name = "engineering"
+	icon_state = "eng"
+
+/area/ruin/moon/yotastation/bridge
+	name = "bridge"
+	icon_state = "bridge"
+
+/area/ruin/moon/yotastation/brig
+	name = "security"
+	icon_state = "security"
+
+/area/ruin/moon/yotastation/cargo
+	name = "cargo"
+	icon_state = "cargo_1"
+
+/area/ruin/moon/yotastation/armory
+	name = "Armory"
+	icon_state = "armory"
+
+/area/ruin/moon/yotastation/biochamberice
+	name = "biochamber-ice"
+	icon_state = "general"
+
+/area/ruin/moon/yotastation/biochamberforest
+	name = "biochamber-forest"
+	icon_state = "general"
+
+/area/ruin/moon/yotastation/biochamberjungle
+	name = "biochamber-jungle"
+	icon_state = "general"
+
+/area/ruin/moon/yotastation/biochamberforest2
+	name = "biochamber-forest2"
+	icon_state = "general"
+
+/area/ruin/moon/yotastation/dorm2
+	name = "dorm2"
+	icon_state = "crew_quarters"
+
+/area/ruin/moon/yotastation/medbayholl
+	name = "medbay-holl"
+	icon_state = "med_1"
+
+/area/ruin/moon/yotastation/medbay
+	name = "medbay"
+	icon_state = "med_1"
+
+/area/ruin/moon/yotastation/eva
+	name = "eva"
+	icon_state = "Sleep"
+
+/area/ruin/moon/yotastation/circleholl1
+	name = "circle-holl1"
+	icon_state = "crew_quarters"
+
+/area/ruin/moon/yotastation/cencomm
+	name = "centralcomm"
+	icon_state = "crew_quarters"
+
+/area/ruin/moon/lunar_dispersal/manufactory
+	name = "manufactory"
+	icon_state = "cargo_1"
+
+/area/ruin/moon/lunar_dispersal/ambry
+	name = "ambry"
+	icon_state = "general"
+
+/area/ruin/moon/lunar_dispersal/surveillancecenter
+	name = "surveillance center"
+	icon_state = "bridge"
+
+/area/ruin/moon/lunar_dispersal/reservoir
+	name = "reservoir"
+	icon_state = "atmos"
+
+/area/ruin/moon/lunar_dispersal/mutiny
+	name = "mutiny"
+	icon_state = "security"
+

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -1006,6 +1006,14 @@
 	suffix = "whitesands_brazillianlab.dmm"
 	ruin_tags = list(RUIN_TAG_BOSS_COMBAT, RUIN_TAG_MAJOR_LOOT, RUIN_TAG_INHOSPITABLE)
 
+/datum/map_template/ruin/whitesands/trainyard	// NEW
+	id = "train-yard"
+	name = "Train Yard"
+	description = "Attacked train station. What the hell are train doing on a sand planet?"
+	suffix = "whitesands_surface_trainyard.dmm"
+	cost = 3
+	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
+
 //							///
 //		MARK: Plasma
 //							///
@@ -1206,7 +1214,12 @@
 //							///
 //		MARK: Moon
 //							///
-
+/datum/map_template/ruin/moon/lunar_dispersal
+	id = "lunar_dispersal"
+	name = "Lunar Dispersal"
+	description = "Concrete buildings falling into oblivion."
+	suffix = "lunar_dispersal.dmm"
+	cost = 2
 
 
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавление новой руины Lunar Dispersal для лунного планетоида, где ранее ничего не существовало.
## Причина создания ПР / Почему это хорошо для игры
Пустая планета теперь чуть менее пустая
## Демонстрация изменений / Тестирование
<img width="3520" height="2400" alt="image" src="https://github.com/user-attachments/assets/af15283b-b678-4eb7-b485-f251bab20dd4" />

## Список изменений

```yml
🆑
add: Зоны для руин
map: Lunar Dispersal moon ruin
/🆑
```
