### PR TITLE
MAP: Clandestine-class Observing Corvette, fix syndicate_jungle ruin, qol for Lightning.

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_syndicate.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_syndicate.dmm
@@ -2,40 +2,54 @@
 "ah" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "aj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "al" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "an" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 4
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "aF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "aJ" = (
 /obj/effect/spawner/bunk_bed,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "aY" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
@@ -46,11 +60,15 @@
 /mob/living/simple_animal/hostile/human/ramzi/ranged/smg,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "bc" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "bd" = (
 /obj/structure/table,
 /obj/item/ammo_box/magazine/m10mm_ringneck,
@@ -59,30 +77,40 @@
 /obj/item/ammo_box/magazine/m10mm_ringneck,
 /obj/item/ammo_box/magazine/m10mm_ringneck,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "bs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "bt" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "bz" = (
 /obj/machinery/door/airlock/multi_tile/security{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/oil/slippery{
+	alpha = 0
+	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "bC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Window Shutters";
@@ -91,7 +119,9 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "bP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -100,31 +130,43 @@
 	blocks_emissive = 1
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "bR" = (
 /obj/structure/spacevine,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "bS" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "bV" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cd" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ce" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cm" = (
 /mob/living/simple_animal/hostile/asteroid/lobstrosity/beach{
 	dir = 4;
@@ -135,14 +177,18 @@
 	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cn" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/effect/abstract/turf_fire/magical,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "cp" = (
 /mob/living/simple_animal/hostile/human/ramzi/ranged/sniper{
 	health = 200;
@@ -150,7 +196,9 @@
 	aggro_vision_range = 18
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cr" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 6
@@ -159,33 +207,45 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "cz" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cO" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cS" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cU" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "cX" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "df" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -193,12 +253,13 @@
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
-/obj/machinery/porta_turret/ruin/ramzi/super_heavy{
-	dir = 10;
+/obj/machinery/porta_turret/ruin/ramzi/light{
 	id = "syndifort"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "dq" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/tree/jungle/small{
@@ -206,10 +267,14 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ds" = (
 /turf/closed/indestructible/rock,
-/area/overmap_encounter/planetoid/cave/explored)
+/area/overmap_encounter/planetoid/cave/explored{
+	light_on = 0
+	})
 "dt" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -222,42 +287,58 @@
 	},
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "dw" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "dF" = (
 /obj/structure/flora/rock,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "dK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "dN" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment{
 	pixel_y = 31
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "dO" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "dP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/colored/red,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "dX" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/template_noop,
-/area/space)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ed" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 1
@@ -269,7 +350,9 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "ef" = (
 /mob/living/simple_animal/hostile/human/ramzi{
 	desc = "God dammit Jerry! Why the fuck are you barricading yourself in with all of our weapon supplies?";
@@ -281,25 +364,35 @@
 	mission_index = 2
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "es" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "et" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ex" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ez" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "eE" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -313,27 +406,37 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "eR" = (
 /obj/structure/closet/crate/secure/science,
 /obj/item/research_notes/loot/medium,
 /obj/item/stack/sheet/plastic/twenty,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "eU" = (
 /obj/structure/chair/plastic,
 /obj/effect/landmark/mission_poi/guard{
 	type_to_spawn = /mob/living/simple_animal/hostile/human/ramzi/ranged
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "eW" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "eX" = (
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
@@ -351,29 +454,41 @@
 /area/ruin/jungle/syndifortshuttle)
 "fe" = (
 /turf/closed/wall,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "fi" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "fn" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fv" = (
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "fx" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fE" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fH" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
@@ -384,21 +499,29 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "fJ" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fN" = (
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "fO" = (
 /obj/effect/turf_decal/corner/opaque/bar/border,
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "fS" = (
 /mob/living/simple_animal/hostile/human/ramzi{
 	unsuitable_atmos_damage = 0;
@@ -407,24 +530,32 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "fZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "gb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "gf" = (
 /obj/structure/closet/crate/secure/gear,
 /obj/item/blackmarket_uplink,
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "gj" = (
 /obj/structure/rack,
 /obj/item/melee/sledgehammer/gorlex,
@@ -437,7 +568,9 @@
 	},
 /obj/item/scalpel,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "gr" = (
 /obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
 	dir = 8
@@ -446,7 +579,9 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "gw" = (
 /mob/living/simple_animal/hostile/human/ramzi/ranged/space/shotgun{
 	maxHealth = 300;
@@ -460,14 +595,18 @@
 	name = "evil chair"
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "gG" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "gK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -476,13 +615,19 @@
 	icon_state = "1-10"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "gO" = (
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "gP" = (
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "gQ" = (
 /obj/machinery/light/small/directional/south{
 	light_color = "#FA6496";
@@ -490,18 +635,15 @@
 	},
 /obj/structure/table_frame,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "gU" = (
 /obj/machinery/light/directional/west,
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort/jerry)
-"gX" = (
-/mob/living/simple_animal/hostile/human/ramzi/melee/space/stormtrooper/sledge{
-	health = 400;
-	maxHealth = 400
-	},
-/turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "gY" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment{
 	pixel_y = 32;
@@ -514,7 +656,9 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ha" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Main Hall"
@@ -523,25 +667,33 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "he" = (
 /obj/structure/flora/tree/jungle/small{
 	pixel_x = -11
 	},
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "hi" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "hk" = (
 /mob/living/simple_animal/hostile/human/nanotrasen/ranged{
 	health = 200;
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ho" = (
 /obj/machinery/door/window/brigdoor/southright{
 	req_one_access = list(1)
@@ -576,11 +728,15 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "hH" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "hK" = (
 /obj/effect/decal/remains/human,
 /obj/machinery/light/small/directional/south{
@@ -592,7 +748,9 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "hQ" = (
 /obj/structure/cable{
 	icon_state = "6-9"
@@ -600,19 +758,25 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "hZ" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ii" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "ik" = (
 /obj/item/melee/knife/combat{
 	name = "bushcutter";
@@ -621,41 +785,57 @@
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ip" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "iy" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "iz" = (
 /obj/machinery/light/colored/red{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "iA" = (
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "iE" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "iO" = (
 /turf/open/floor/plasteel/tech/tcomms,
 /area/ruin/jungle/syndifort3)
 "iR" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "iY" = (
 /turf/closed/wall/mineral/wood,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "jb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname{
@@ -663,18 +843,24 @@
 	},
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "jh" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "jr" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "jt" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -695,28 +881,38 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/patterned/brushed,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "jy" = (
 /obj/item/trash/plate,
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "jB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "jL" = (
 /obj/structure/chair/comfy/beige/old/directional/east,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "jM" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "jQ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/cable{
@@ -725,7 +921,9 @@
 /turf/open/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "kp" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -736,33 +934,45 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "kr" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ks" = (
 /turf/open/floor/plating/asteroid/dirt,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "kB" = (
 /obj/structure/flora/stump,
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "kD" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/whitesands/earth,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "kJ" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "kM" = (
 /obj/item/paper/crumpled/bloody/fluff/ruin/space/ramzistation,
 /obj/structure/sign/poster/contraband/gec{
@@ -772,23 +982,31 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "kY" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lb" = (
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lc" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ld" = (
 /obj/structure/railing{
 	dir = 8
@@ -805,7 +1023,9 @@
 	},
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lf" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9;
@@ -813,16 +1033,22 @@
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lq" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lx" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lE" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -831,7 +1057,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "lH" = (
 /obj/item/trash/candle{
 	pixel_x = 9;
@@ -839,7 +1067,9 @@
 	},
 /obj/machinery/light/colored/red,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "lW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -865,25 +1095,33 @@
 	dir = 8
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "mo" = (
 /mob/living/simple_animal/hostile/human/nanotrasen/ranged{
 	health = 200;
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mq" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mr" = (
 /mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser{
 	health = 250;
 	maxHealth = 250
 	},
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -892,7 +1130,9 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "mv" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -912,36 +1152,48 @@
 "my" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mA" = (
 /obj/machinery/papershredder,
 /obj/machinery/light/colored/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "mF" = (
 /obj/effect/turf_decal/corner/opaque/bar/bordercee,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "mM" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mN" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mT" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -959,42 +1211,57 @@
 "mV" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "mY" = (
-/obj/machinery/porta_turret/ruin/ramzi/super_heavy{
-	id = "syndifort";
-	dir = 4
+/obj/machinery/porta_turret/ruin/ramzi/light{
+	id = "syndifort"
 	},
 /turf/open/floor/plating/asteroid/whitesands/earth,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "nb" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "nf" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "nj" = (
 /obj/structure/bed/roller,
 /obj/item/stack/medical/gauze,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "np" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ns" = (
 /obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
 	dir = 8
 	},
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "nw" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "nG" = (
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -1004,15 +1271,21 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "nH" = (
 /turf/closed/wall/rust,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "nO" = (
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "oi" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -1020,11 +1293,15 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ol" = (
 /obj/item/mine/proximity/explosive/live,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "op" = (
 /obj/structure/table/syndi,
 /obj/item/documents/syndicate,
@@ -1038,7 +1315,9 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "or" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -1050,27 +1329,35 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "ox" = (
 /mob/living/simple_animal/hostile/gorilla{
-	health = 300;
+	health = 190;
 	maxHealth = 300
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "oB" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "oC" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "oF" = (
 /obj/structure/flora/driftlog,
 /obj/structure/flora/driftlog{
@@ -1082,26 +1369,34 @@
 	pixel_x = -10
 	},
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "oN" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -4
 	},
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "oQ" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "oX" = (
 /obj/item/target,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "pe" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -1111,40 +1406,54 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "pj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/gorilla{
-	health = 300;
+	health = 190;
 	maxHealth = 300
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "pr" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ps" = (
 /obj/structure/flora/stump,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "pu" = (
 /obj/structure/flora/driftlog,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "pz" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	pixel_x = 3
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "pF" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "qd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/button/door{
@@ -1174,31 +1483,43 @@
 	pixel_y = -4
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "qj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/abstract/turf_fire/magical,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "qq" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "qx" = (
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "qA" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "qE" = (
 /obj/structure/spacevine/dead,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "qY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/shreds,
@@ -1206,7 +1527,9 @@
 /obj/structure/grille/broken,
 /obj/effect/abstract/turf_fire/magical,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "rg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1222,7 +1545,9 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "rh" = (
 /obj/effect/turf_decal/corner/opaque/bar/bordercorner{
 	dir = 8
@@ -1243,7 +1568,9 @@
 	name = "Bye"
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "rk" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Gear Room Shutters";
@@ -1252,64 +1579,88 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "rK" = (
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "rN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/colored/red,
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "rS" = (
 /obj/item/mine/proximity/spawner/manhack/live,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "rU" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "rZ" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
 /obj/structure/grille,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "sb" = (
 /obj/structure/flora/driftlog,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sl" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/blood,
 /obj/item/stack/medical/gauze,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "sp" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sq" = (
 /obj/structure/sign/poster/contraband/syndicate{
 	pixel_y = 31
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "sw" = (
 /obj/structure/flora/driftlog,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sx" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -4
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sz" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
@@ -1319,7 +1670,9 @@
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1327,12 +1680,16 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "sJ" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "sW" = (
 /obj/structure/cable{
 	icon_state = "2-4";
@@ -1341,13 +1698,17 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "sY" = (
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "tc" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable{
@@ -1360,7 +1721,9 @@
 "td" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "tf" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1373,7 +1736,9 @@
 	},
 /obj/effect/turf_decal/industrial/outline/yellow,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "th" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south{
@@ -1385,19 +1750,25 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "tm" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "tt" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "tv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1406,44 +1777,60 @@
 	icon_state = "4-9"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "tJ" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "tL" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "tZ" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ua" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ud" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ug" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "uh" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ui" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -1452,27 +1839,37 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ul" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "un" = (
 /obj/effect/decal/cleanable/vomit{
 	pixel_y = -18;
 	pixel_x = 7
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "uv" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ux" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "uB" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/food/pizzaslice/donkpocket,
@@ -1482,23 +1879,31 @@
 /obj/item/storage/box/donkpockets/donkpocketberry,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "uE" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "uR" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -4
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "uX" = (
 /obj/machinery/light/colored/red{
 	dir = 1
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "uY" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -1508,12 +1913,16 @@
 	},
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "uZ" = (
 /obj/effect/spawner/bunk_bed,
 /obj/item/stack/medical/gauze,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "vb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/food/grown/banana{
@@ -1521,17 +1930,23 @@
 	pixel_x = -8
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ve" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vh" = (
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -1539,45 +1954,61 @@
 	},
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "vs" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vt" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "vA" = (
 /obj/item/food/grown/banana{
 	pixel_x = -15;
 	pixel_y = -15
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vF" = (
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vJ" = (
 /obj/structure/bed,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "vL" = (
 /obj/item/paper/crumpled,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "vN" = (
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vP" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ruin/jungle/syndifortshuttle)
@@ -1587,11 +2018,15 @@
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "vZ" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wb" = (
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
 /obj/machinery/light/directional/south,
@@ -1604,17 +2039,23 @@
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wh" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wo" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wp" = (
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -1643,7 +2084,9 @@
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "wz" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/steeldecal/steel_decals10,
@@ -1656,23 +2099,31 @@
 "wD" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "wM" = (
 /obj/item/mine/pressure/explosive/shrapnel/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "wQ" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "xa" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -1684,13 +2135,17 @@
 	type_to_spawn = /mob/living/simple_animal/hostile/human/ramzi
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "xi" = (
 /obj/item/grown/bananapeel,
 /obj/structure/spacevine/dense,
 /obj/structure/spacevine/dead,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "xm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1698,7 +2153,9 @@
 /obj/machinery/camera/autoname,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "xr" = (
 /obj/structure/dresser,
 /obj/item/binoculars{
@@ -1708,7 +2165,9 @@
 /area/ruin/jungle/syndifort3)
 "xv" = (
 /turf/open/floor/plating/jungleplanet,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "xC" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Command Room Shutters";
@@ -1718,12 +2177,16 @@
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "xF" = (
 /obj/structure/spacevine,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "xI" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 9
@@ -1731,49 +2194,67 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/squirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "xJ" = (
 /obj/structure/sign/poster/contraband/syndicate{
 	pixel_y = -32
 	},
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "xV" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 10
 	},
 /obj/structure/table,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "yd" = (
 /obj/effect/turf_decal/trimline/opaque/bar/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "yh" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "yi" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "yn" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ys" = (
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "yt" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "yx" = (
 /obj/structure/sign/donk{
 	pixel_y = 33
@@ -1782,20 +2263,28 @@
 	dir = 1
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "yy" = (
-/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/oil/slippery{
+	alpha = 0
+	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "yD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "yH" = (
 /obj/structure/plasticflaps,
 /obj/item/mine/directional/claymore/live{
 	dir = 8;
-	pixel_x = -11
+	alpha = 100
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/jungle/syndifort3)
@@ -1817,28 +2306,38 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "yL" = (
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "yM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "yP" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	pixel_x = -1;
 	pixel_y = -3
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "yQ" = (
 /mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser{
 	health = 250;
 	maxHealth = 250
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "yT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1850,7 +2349,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "yZ" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/jungle/syndifort3)
@@ -1860,21 +2361,29 @@
 	maxHealth = 200
 	},
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "zl" = (
 /obj/structure/spacevine/dense,
 /obj/item/mine/proximity/spawner/manhack/live,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "zt" = (
 /turf/closed/wall/mineral/plastitanium/interior,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "zu" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "zF" = (
 /obj/machinery/fax/syndicate,
 /obj/structure/table/reinforced,
@@ -1885,42 +2394,58 @@
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "zK" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "zM" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "zR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "zX" = (
 /obj/structure/spacevine,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Aa" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ad" = (
 /obj/structure/spacevine,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Af" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Ah" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood,
@@ -1928,20 +2453,28 @@
 /obj/item/organ/lungs,
 /obj/item/organ/stomach,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Ai" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Al" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/patterned/brushed,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Am" = (
 /obj/structure/flora/driftlog,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ao" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Window Shutters";
@@ -1950,7 +2483,9 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Ap" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 4
@@ -1961,29 +2496,39 @@
 	aggro_vision_range = 18
 	},
 /turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Aq" = (
 /obj/item/mine/pressure/explosive/shrapnel/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "At" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Au" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "AB" = (
 /obj/machinery/computer/security{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "AQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -1993,23 +2538,31 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "AT" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "AV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/anomaly/plasmasoul/planetary,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ba" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Bo" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
@@ -2021,7 +2574,9 @@
 	dir = 1
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Bv" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/item/toy/nuke,
@@ -2030,16 +2585,22 @@
 	icon_state = "panelscorched";
 	initial_gas_mix = "ws_atmos"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Bx" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "By" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "BC" = (
 /obj/structure/chair/plastic,
 /obj/machinery/light/small/directional/north,
@@ -2049,19 +2610,27 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "BE" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "BH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "BJ" = (
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "BK" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable{
@@ -2071,7 +2640,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "BV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2083,7 +2654,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Cc" = (
 /obj/structure/table/syndi,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
@@ -2109,7 +2682,9 @@
 	melee_damage_upper = 30
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "CI" = (
 /obj/structure/cable{
 	icon_state = "0-5"
@@ -2118,14 +2693,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "CL" = (
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "CN" = (
 /obj/effect/turf_decal/corner/opaque/bar/bordercorner,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "CQ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -2149,42 +2730,58 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "De" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Dk" = (
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Dn" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Dt" = (
 /obj/structure/spacevine/dead,
 /mob/living/carbon/monkey,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Dv" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "DH" = (
 /obj/structure/spacevine,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "DL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "DO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2198,7 +2795,9 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "DP" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
@@ -2207,7 +2806,9 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "DS" = (
 /obj/structure/grille,
 /obj/structure/window/plasma/reinforced/plastitanium,
@@ -2223,50 +2824,68 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ej" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Ek" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Es" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Eu" = (
 /obj/structure/flora/grass/jungle,
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ew" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "EA" = (
 /obj/structure/spacevine/dense,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "EF" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "EQ" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ER" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Window Shutters";
@@ -2274,7 +2893,9 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "ET" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Gear Room Shutters";
@@ -2289,14 +2910,18 @@
 	},
 /obj/machinery/light/colored/red,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Fg" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Fj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2305,18 +2930,24 @@
 	name = "Power Shack"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Fk" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Fm" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Fn" = (
 /obj/item/paper/crumpled,
 /obj/item/paper/crumpled,
@@ -2342,30 +2973,40 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Fo" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 4;
 	atom_integrity = 100
 	},
 /turf/open/floor/plasteel/patterned/brushed,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "FF" = (
 /obj/item/mine/proximity/explosive/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "FI" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "FM" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "FP" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2373,35 +3014,49 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "FV" = (
 /obj/item/mine/proximity/spawner/manhack/live,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ga" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plasteel/patterned/brushed,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Gb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Gc" = (
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Gh" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Gm" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Gs" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2410,18 +3065,24 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GE" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/whitesands/earth,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GK" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2434,7 +3095,9 @@
 	pixel_y = 10
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GQ" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
@@ -2443,7 +3106,9 @@
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GR" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
@@ -2452,12 +3117,16 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "GU" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "GV" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 5
@@ -2467,7 +3136,9 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Hb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2476,7 +3147,9 @@
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Hf" = (
 /obj/structure/sign/poster/contraband/m90{
 	pixel_y = 33
@@ -2487,7 +3160,9 @@
 "Hn" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Hv" = (
 /obj/effect/turf_decal/corner/opaque/bar/bordercorner{
 	dir = 4
@@ -2497,7 +3172,9 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Hx" = (
 /obj/item/ammo_casing/spent{
 	dir = 1;
@@ -2515,12 +3192,16 @@
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "HB" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "HG" = (
 /mob/living/simple_animal/hostile/asteroid/lobstrosity/beach{
 	dir = 8;
@@ -2530,12 +3211,14 @@
 	melee_damage_upper = 30
 	},
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "HH" = (
 /obj/structure/plasticflaps,
 /obj/item/mine/directional/claymore/live{
 	dir = 4;
-	pixel_x = 11
+	alpha = 100
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/jungle/syndifort3)
@@ -2545,7 +3228,9 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "HR" = (
 /obj/structure/chair/plastic,
 /mob/living/simple_animal/hostile/human/ramzi/ranged{
@@ -2553,7 +3238,9 @@
 	health = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Il" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/techfloor{
@@ -2570,12 +3257,16 @@
 /obj/item/binoculars,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Iw" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "IA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/syndicate{
@@ -2592,56 +3283,74 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "IC" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "IM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "IO" = (
 /obj/structure/flora/tree/jungle/small{
 	pixel_y = 16;
 	pixel_x = -42
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "IQ" = (
 /obj/structure/flora/ausbushes,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "IX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/door_assembly/door_assembly_hatch,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Jb" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Jf" = (
 /obj/structure/chair/comfy/beige/old/directional/east{
 	dir = 1
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Jg" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ji" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 8
@@ -2673,14 +3382,20 @@
 "Jq" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Jt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Jv" = (
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Jx" = (
 /obj/structure/table/wood,
 /obj/item/paper/crumpled,
@@ -2691,7 +3406,9 @@
 	pixel_x = 13
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "JA" = (
 /obj/item/bedsheet/syndie,
 /obj/structure/bed,
@@ -2702,7 +3419,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "JN" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
@@ -2715,11 +3434,15 @@
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "JO" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "JQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2729,14 +3452,18 @@
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "JR" = (
 /mob/living/simple_animal/hostile/human/ramzi/ranged/smg{
 	health = 200;
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "JT" = (
 /obj/item/bedsheet/syndie{
 	dir = 4
@@ -2749,27 +3476,37 @@
 "JW" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "JX" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "JY" = (
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Kf" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ki" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Km" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2778,34 +3515,48 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Kp" = (
 /obj/machinery/light/colored/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Kr" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Kw" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ky" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "KP" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "KQ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "KT" = (
 /obj/structure/closet/syndicate/personal{
 	name = "Squad Leader's closet";
@@ -2827,14 +3578,18 @@
 /area/ruin/jungle/syndifortshuttle)
 "KY" = (
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ld" = (
 /mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser{
 	health = 250;
 	maxHealth = 250
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ln" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2845,11 +3600,15 @@
 /obj/item/storage/box/ammo/c10mm,
 /obj/item/storage/box/ammo/c10mm,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Lp" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Lr" = (
 /obj/effect/turf_decal/steeldecal/steel_decals9{
 	dir = 8
@@ -2863,18 +3622,21 @@
 /obj/structure/cable{
 	icon_state = "0-9"
 	},
-/obj/machinery/porta_turret/ruin/ramzi{
-	dir = 6;
+/obj/machinery/porta_turret/ruin/ramzi/light{
 	id = "syndifort"
 	},
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Lu" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Lx" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2884,25 +3646,33 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Lz" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "LD" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9;
 	atom_integrity = 100
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "LG" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "LQ" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 4
@@ -2925,14 +3695,18 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Mb" = (
 /mob/living/simple_animal/hostile/gorilla{
-	health = 300;
+	health = 190;
 	maxHealth = 300
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Mo" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 4
@@ -2947,20 +3721,26 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "My" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "MF" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "ML" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush/b,
@@ -2968,46 +3748,64 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "MP" = (
 /turf/open/floor/plasteel/patterned/brushed,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "MT" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Nb" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/ruin/jungle/syndifort3)
 "Nc" = (
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ne" = (
 /obj/structure/spacevine,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Nv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Ny" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Nz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "NH" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/carpet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "NM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3015,7 +3813,9 @@
 	id = "jsynwin"
 	},
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "NS" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -3025,11 +3825,15 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Oa" = (
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Oe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -3037,20 +3841,28 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Of" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ol" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "OB" = (
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "OC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/industrial/outline/yellow,
@@ -3061,36 +3873,50 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "OI" = (
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "OL" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "OS" = (
 /obj/structure/spacevine/dense,
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "OW" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/syndi_cakes,
 /obj/machinery/fax/ruin,
 /turf/open/floor/plating,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Pe" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ph" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Pj" = (
 /obj/structure/sign/poster/contraband/syndicate,
 /turf/closed/wall/mineral/plastitanium,
@@ -3100,7 +3926,9 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Pp" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 10
@@ -3110,22 +3938,30 @@
 /obj/item/gun/ballistic/automatic/pistol/ringneck/no_mag,
 /obj/effect/decal/cleanable/blood/hitsplatter,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Pq" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Pt" = (
 /obj/item/mine/proximity/explosive/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Px" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "PA" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 6
@@ -3134,7 +3970,9 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "PB" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -3143,7 +3981,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "PJ" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/glasses/eyepatch{
@@ -3151,12 +3991,16 @@
 	},
 /obj/item/clothing/neck/tie/red,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "PL" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "PN" = (
 /obj/machinery/power/shieldwallgen/atmos/roundstart{
 	id = "crux_holofan"
@@ -3190,7 +4034,9 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/spacevine/dead,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "PT" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 10
@@ -3211,10 +4057,14 @@
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "PZ" = (
 /turf/template_noop,
-/area/space)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Qi" = (
 /obj/structure/cable{
 	icon_state = "4-10"
@@ -3223,7 +4073,9 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Qj" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/stack/ore/salvage/scrapmetal,
@@ -3231,7 +4083,9 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Qk" = (
 /obj/docking_port/mobile{
 	dir = 8;
@@ -3248,11 +4102,15 @@
 /obj/effect/mob_spawn/human/corpse/vigilitas_trooper,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Qr" = (
 /obj/structure/table,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Qs" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3266,31 +4124,47 @@
 /obj/item/mine/proximity/spawner/manhack/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Qx" = (
 /obj/structure/flora/junglebush,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QD" = (
 /obj/item/paper/crumpled/bloody,
 /obj/machinery/light/colored/red,
+/mob/living/simple_animal/hostile/human/ramzi/melee/space/stormtrooper/sledge{
+	health = 400;
+	maxHealth = 400
+	},
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "QE" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QF" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QG" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QL" = (
 /obj/effect/turf_decal/corner/opaque/bar/border{
 	dir = 1
@@ -3300,29 +4174,41 @@
 	color = "#CC0000"
 	},
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "QN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "QR" = (
 /obj/machinery/porta_turret/ruin/ramzi/super_heavy,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QT" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "QV" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Rb" = (
 /turf/closed/indestructible/rock,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Rg" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
@@ -3336,45 +4222,63 @@
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Rt" = (
 /obj/structure/flora/driftlog,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Rw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Rx" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Rz" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "RA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "RD" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "RE" = (
 /obj/structure/spacevine/dense,
 /obj/structure/spacevine/dense,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "RF" = (
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "RG" = (
 /obj/structure/table,
 /obj/item/grenade/frag,
@@ -3382,15 +4286,21 @@
 /obj/item/grenade/frag,
 /obj/item/grenade/frag,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "RJ" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/whitesands/earth,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "RL" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "RR" = (
 /obj/structure/sign/poster/contraband/cybersun_borg{
 	pixel_y = 31
@@ -3412,7 +4322,9 @@
 	pixel_y = 18
 	},
 /turf/open/floor/carpet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "RU" = (
 /obj/item/food/grown/banana{
 	pixel_y = 6;
@@ -3420,12 +4332,16 @@
 	},
 /obj/structure/spacevine/dead,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Sh" = (
 /obj/effect/anomaly/plasmasoul/planetary,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Sl" = (
 /obj/effect/turf_decal/techfloor{
 	dir = 6
@@ -3438,17 +4354,23 @@
 "Sm" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Sp" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/grown/bananapeel,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SH" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -3458,27 +4380,37 @@
 	maxHealth = 200
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SM" = (
 /obj/structure/spacevine,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SO" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SQ" = (
 /obj/machinery/door/airlock/highsecurity,
-/obj/effect/decal/cleanable/oil/slippery,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/oil/slippery{
+	alpha = 0
 	},
 /turf/open/floor/plasteel/tech/tcomms,
 /area/ruin/jungle/syndifort3)
@@ -3486,38 +4418,52 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SV" = (
 /obj/effect/decal/cleanable/shreds,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "SX" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Tb" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Td" = (
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Tt" = (
 /obj/item/ammo_casing/c10mm,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Tv" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Tw" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -3544,7 +4490,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "TC" = (
 /obj/item/trash/syndi_cakes,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -3552,20 +4500,28 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "TF" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "TH" = (
 /obj/item/mine/proximity/spawner/manhack/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "TK" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "TP" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
@@ -3574,17 +4530,23 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "TV" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ue" = (
 /obj/item/mine/proximity/spawner/manhack/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ug" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -3601,7 +4563,9 @@
 "Uh" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ui" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
@@ -3609,13 +4573,13 @@
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
-/obj/machinery/porta_turret/ruin/ramzi{
-	dir = 10;
-	layer = 3.1;
+/obj/machinery/porta_turret/ruin/ramzi/light{
 	id = "syndifort"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Uj" = (
 /obj/structure/dresser,
 /turf/open/floor/mineral/plastitanium,
@@ -3624,30 +4588,40 @@
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Us" = (
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Uu" = (
 /obj/structure/cable{
 	icon_state = "6-9"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Uw" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Uz" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "UG" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -3659,7 +4633,9 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "UO" = (
 /mob/living/simple_animal/hostile/human/ramzi/melee/space/sledge{
 	maxHealth = 300;
@@ -3672,15 +4648,21 @@
 	icon_state = "1-6"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "UZ" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ve" = (
 /turf/open/floor/plating/asteroid/whitesands/earth,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Vf" = (
 /obj/effect/turf_decal/industrial/outline/red,
 /obj/structure/barricade/sandbags,
@@ -3688,24 +4670,29 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Vl" = (
 /obj/item/mine/proximity/explosive/live,
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Vn" = (
 /obj/structure/cable{
 	icon_state = "0-6"
 	},
-/obj/machinery/porta_turret/ruin/ramzi{
-	dir = 9;
+/obj/machinery/porta_turret/ruin/ramzi/light{
 	id = "syndifort"
 	},
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "VD" = (
 /obj/effect/turf_decal/techfloor/orange{
 	dir = 4
@@ -3732,11 +4719,15 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "VV" = (
 /obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wg" = (
 /obj/structure/deployable_barricade/sandbags{
 	dir = 8
@@ -3746,7 +4737,9 @@
 	},
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wh" = (
 /obj/machinery/door/airlock/multi_tile/security{
 	dir = 4
@@ -3756,78 +4749,106 @@
 	dir = 8
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Wj" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wk" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/spacevine/dead,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wl" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wm" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wo" = (
 /obj/item/stack/ore/salvage/scrapmetal,
 /obj/structure/grille,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Ws" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wu" = (
 /obj/item/mine/proximity/explosive/live,
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Wz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "WG" = (
 /obj/structure/closet/crate/secure/weapon,
 /obj/item/gun/ballistic/automatic/smg/cobra,
 /obj/item/ammo_box/magazine/m45_cobra,
 /obj/item/ammo_box/magazine/m45_cobra,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "WT" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Xa" = (
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Xc" = (
 /obj/structure/flora/junglebush/large,
 /obj/structure/flora/junglebush,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Xo" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Xx" = (
 /obj/structure/cable{
 	icon_state = "5-8"
@@ -3835,7 +4856,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "XE" = (
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ruin/jungle/syndifort3)
@@ -3843,25 +4866,35 @@
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/structure/grille/broken,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "XM" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "XP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "XT" = (
 /mob/living/simple_animal/hostile/human/ramzi/ranged/sniper,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "XZ" = (
 /obj/structure/deployable_barricade/sandbags{
 	pixel_y = -9
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Ya" = (
 /obj/item/trash/syndi_cakes,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3869,23 +4902,31 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/jungle,
-/area/ruin/jungle/syndifort/jerry)
+/area/ruin/jungle/syndifort/jerry{
+	light_on = 0
+	})
 "Yd" = (
 /obj/structure/flora/junglebush/c,
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Yj" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Yk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Ym" = (
 /obj/structure/railing{
 	dir = 8
@@ -3897,11 +4938,15 @@
 "YD" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plating/asteroid/dirt/beach,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YE" = (
 /obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YF" = (
 /obj/structure/cable{
 	icon_state = "5-8"
@@ -3909,31 +4954,43 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "YK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "YL" = (
 /obj/structure/flora/stump,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YM" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YO" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "YQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -3942,24 +4999,34 @@
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "plating_rust"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "YV" = (
 /obj/effect/anomaly/plasmasoul/planetary,
 /turf/open/floor/plating/ship/water/beach/deep,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "Zb" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Zc" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/strongdark,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "Zo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ammo_casing/c10mm,
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "Zp" = (
 /obj/machinery/telecomms/receiver,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -3977,27 +5044,37 @@
 	dir = 4
 	},
 /turf/open/floor/plating/jungleplanet,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ZD" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/hangar/plasteel/white,
-/area/ruin/jungle/syndifort2)
+/area/ruin/jungle/syndifort2{
+	light_on = 0
+	})
 "ZF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/rust,
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 "ZG" = (
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
+/area/overmap_encounter/planetoid/jungle/explored{
+	light_on = 0
+	})
 "ZU" = (
 /obj/item/target,
 /turf/open/floor/plating/jungleplanet{
 	icon_state = "panelscorched"
 	},
-/area/ruin/jungle/syndifort)
+/area/ruin/jungle/syndifort{
+	light_on = 0
+	})
 
 (1,1,1) = {"
 Xa
@@ -7497,7 +8574,7 @@ RF
 Gm
 CY
 jM
-gX
+RF
 QD
 Ai
 Xa

--- a/_maps/_mod_celadon/configs/independent_intelof.json
+++ b/_maps/_mod_celadon/configs/independent_intelof.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://raw.githubusercontent.com/CeladonSS13/Shiptest/beta-dev/_maps/_mod_celadon/ship_config_schema.json",
+	"map_name": "Clandestine-class Observing Corvette",
+	"map_short_name": "Clandestine",
+	"description": "ОТСУТСТВУЮТ ДАННЫЕ, ОБРАТИТЕСЬ В СООТВЕТСТВУЮЩИЕ СЛУЖБЫ.",
+	"map_path": "_maps/_mod_celadon/shuttles/independent/independent_intelof.dmm",
+	"enabled": false,
+	"limit": 1,
+	"sensor_range": 6,
+	"prefix": "ISV",
+	"faction": "/datum/faction/independent",
+	"tags": [
+		"Особый"
+	],
+	"namelists": [
+		"SOLFED"
+	],
+	"job_slots": {
+	"Intellegence Officer": {
+        "outfit": "/datum/outfit/job/cel/solfed/intelof",
+        "officer": true,
+        "slots": 1
+    }
+}
+}

--- a/_maps/_mod_celadon/shuttles/independent/independent_intelof.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_intelof.dmm
@@ -1,0 +1,3169 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"av" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 8;
+	name = "Cargo Bay";
+	req_access_txt = "8132"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"ax" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"ay" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/airalarm/directional/north{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"aQ" = (
+/obj/machinery/ltsrbt,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"aS" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"bg" = (
+/obj/machinery/computer/helm/viewscreen/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"bh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"bi" = (
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/engineering)
+"bq" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"bz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"bJ" = (
+/obj/structure/closet/wall/red/directional/west,
+/obj/item/clothing/under/solgov/dress,
+/obj/item/clothing/under/syndicate/sniper,
+/obj/item/clothing/mask/breath/facemask,
+/obj/item/clothing/gloves/combat/insul,
+/obj/item/clothing/gloves/combat/maid,
+/obj/item/clothing/shoes/combat,
+/obj/item/elysm_manual,
+/obj/item/melee/classic_baton/telescopic,
+/obj/item/card/id/syndicate/anyone,
+/obj/item/clothing/suit/armor/vest/duster{
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 55, "bio" = 100, "rad" = 70, "fire" = 100, "acid" = 100, "wound" = 50)
+	},
+/obj/item/clothing/glasses/thermal/syndi,
+/obj/item/radio/headset/headset_medsec/alt{
+	name = "bowman headset";
+	desc = "Damn. It looks good"
+	},
+/obj/item/clothing/head/beret/hop{
+	name = "beret";
+	desc = "Just a beret";
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	},
+/obj/item/storage/backpack/chameleon,
+/obj/item/storage/belt/chameleon,
+/obj/item/encryptionkey/syndicate,
+/obj/item/encryptionkey/solgov{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/melee/energy/sword/saber/knife/yellow,
+/obj/item/melee/energy/sword/saber/knife/yellow{
+	pixel_y = 7
+	},
+/obj/item/paper{
+	pixel_y = 4;
+	name = "Рекомендательная записка";
+	default_raw_text = "<table width="100%" height="100%" bgcolor="#094175" cellpadding="15"> <tr><td><center><b><font size="4" color="#dbdbd7">Solarian Confederation Frontier Affairs</font></b><br><font size="3" color="#dbdbd7">Рекомендательная записка</font><hr width="90%" color="#f5cf25"></center><font face="Courier New" color="#dbdbd7"> <p> Я, [Atremar Monreschare]<br>В должности [Special Field Operations Officer].<p><p>Уведомляю вас, что вам поручена особая миссия по сбору и передачи информации высшему коммандованию, о любой подозрительной или враждебной активности всех находящихся в секторе кораблей.<br><br>Для того чтобы не вызывать подозрений и лишнее внимание ваш корабль был зарегистрирован как Независимое судно, а вы как Независимый Капитан.<br><br>Ваша задача помимо сбора информации так же состоит в том, чтобы вас не раскрыли.<br><br>1.Вы можете безпрепятственно устранять любого кто вторгся на ваш корабль.<br>2.Вы можете безпрепятственно устранять любого кто угрожает вам, вашей жизни, и вашей миссии.<br>3.Немедленно уведомляйте командование о любых нарушениях/несоответствующем поведении со стороны служащих регулярной армии Солнечной Федерации.<br><br>После прочтения поставьте печать и отправьте данный документ на факс : Solarian Confederation Frontier Affairs. В случае если вам необходимы дополнительные инструкции, свяжитесь с нами по факсу.<br><br><center><font color="#dbdbd7" size="2">[Место для штампа]</font></center><br><br><br><hr width="90%" color="#f5cf25"><font size="1" color="#dbdbd7"><p align="justify">ДАННЫЙ ДОКУМЕНТ СЧИТАЕТСЯ ОФИЦИАЛЬНЫМ ТОЛЬКО ПРИ НАЛИЧИИ ПОДПИСИ УПОЛНОМОЧЕННОГО ЛИЦА И СООТВЕТСТВУЮЩЕГО ЕГО ДОЛЖНОСТИ ШТАМПА. В СЛУЧАЕ ОТСУТСТВИЯ ЛЮБОГО ИЗ УКАЗАННЫХ ЭЛЕМЕНТОВ ДАННЫЙ ДОКУМЕНТ НЕ ЯВЛЯЕТСЯ ОФИЦИАЛЬНЫМ И РЕКОМЕНДУЕТСЯ ЕГО УДАЛИТЬ С ЛЮБОГО ИНФОРМАЦИОННОГО НОСИТЕЛЯ.</p><hr width="90%" color="#f5cf25"><center><b><font color="#dbdbd7">Cлава Солнечной Федерации!</font></b><br><b><font color="#dbdbd7">© Solarian Confederation Frontier Affairs.</font></b></center></font></td></tr></table>";
+	layer = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"cu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"cz" = (
+/obj/effect/spawner/structure/window/reinforced{
+	color = "#CEB689";
+	layer = 5
+	},
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"cF" = (
+/obj/structure/transit_tube/station/reverse/flipped{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"cM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"cO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"cT" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs{
+	icon = 'icons/obj/stairs.dmi'
+	},
+/area/ship/bridge)
+"du" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"dJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"dU" = (
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"dX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"eq" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"eT" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/marble/black,
+/area/ship/engineering)
+"fa" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"fs" = (
+/obj/machinery/holopad/emergency/command,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"fu" = (
+/obj/structure/window/reinforced/fulltile/shuttle{
+	color = "#CEB689"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "Illegal_bridge"
+	},
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"ge" = (
+/obj/machinery/cryopod,
+/obj/structure/curtain/cloth/grey{
+	layer = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"gY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/heavymetal/var4,
+/area/ship/engineering)
+"hh" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/radio/intercom/wideband/directional/north{
+	pixel_y = 11
+	},
+/obj/machinery/button/door{
+	id = "Illegal_bridge";
+	name = "Bridge";
+	pixel_x = -6;
+	pixel_y = -21;
+	dir = 1;
+	req_access_txt = "8132"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"ht" = (
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/clip_patroller{
+	desc = "Specific Hardsuit,looks unique";
+	name = "space hardsuit";
+	armor = list("melee" = 35, "bullet" = 35, "laser" = 25, "energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 90, "fire" = 75, "acid" = 75, "wound" = 70)
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"hZ" = (
+/obj/structure/closet/wall/directional{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpack/crisis,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/medical,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"ih" = (
+/obj/effect/turf_decal/corner/opaque/beige/half,
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"iR" = (
+/obj/machinery/light/colored/white{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"iW" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"jt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"jW" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "Illegal_eng"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"jX" = (
+/obj/machinery/light/colored/red/directional/west{
+	pixel_x = -4
+	},
+/obj/machinery/syndicatebomb/self_destruct,
+/obj/structure/sign/poster/solgov/mars{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/ship/bridge)
+"kN" = (
+/turf/template_noop,
+/area/ship/external/dark)
+"kS" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"ls" = (
+/obj/structure/window/reinforced/tinted{
+	color = "#CEB689";
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"lP" = (
+/obj/machinery/power/apc/auto_name/directional/west{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"mf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"mg" = (
+/obj/structure/transit_tube{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/ship/external/dark)
+"mk" = (
+/obj/docking_port/mobile{
+	dir = 4;
+	launch_status = 0;
+	preferred_direction = 4;
+	port_direction = 2
+	},
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"mE" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"mN" = (
+/obj/structure/closet/wall/directional{
+	dir = 1;
+	pixel_y = 32
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"mQ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/pen/fourcolor{
+	pixel_y = 2;
+	pixel_x = -7
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 6;
+	pixel_x = -5
+	},
+/obj/item/taperecorder{
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"ne" = (
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"nK" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"nU" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"oc" = (
+/obj/structure/neon_spline/white{
+	dir = 8;
+	alpha = 0
+	},
+/turf/open/floor/marble/black,
+/area/ship/engineering)
+"oh" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"pb" = (
+/obj/structure/transit_tube/station/dispenser/flipped{
+	layer = 4;
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"pl" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plasteel/heavymetal/var4,
+/area/ship/engineering)
+"ps" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"pK" = (
+/obj/machinery/light/colored/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/heavymetal/var2,
+/area/ship/engineering)
+"pL" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"qk" = (
+/obj/structure/bed,
+/obj/structure/sign/poster/bay/bay_6{
+	pixel_x = -32
+	},
+/obj/item/bedsheet/yellow,
+/obj/structure/curtain/cloth/grey{
+	layer = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"ql" = (
+/obj/effect/spawner/structure/window/reinforced{
+	color = "#CEB689";
+	layer = 5
+	},
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/floor/plasteel/tech,
+/area/ship/engineering)
+"qq" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"qr" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.04
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"qv" = (
+/obj/machinery/light/colored/white,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"qB" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "Illegal_halo"
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "Illegal_gate"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"qO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack/dark/other,
+/area/ship/engineering)
+"rh" = (
+/obj/effect/turf_decal/borderfloorblack/corner,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"rD" = (
+/obj/machinery/button/door{
+	id = "Illegal_eng";
+	name = "Engine Shutters";
+	pixel_y = 22;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"rH" = (
+/obj/item/stack/sheet/mineral/plasma/ten,
+/obj/structure/closet/wall/orange/directional/east{
+	name = "fuel locker";
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/item/stack/sheet/mineral/plasma/ten,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"rZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"ss" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	req_one_access = list(61,11);
+	color = "#CEB689";
+	req_access_txt = "8132"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"sw" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 8;
+	name = "Cargo Bay";
+	req_access_txt = "8132"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ship/bridge)
+"tn" = (
+/obj/structure/transit_tube/station/reverse/flipped,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"to" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"tz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"ua" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/power/apc/auto_name/directional/west{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 19;
+	pixel_y = -18
+	},
+/turf/open/floor/plating,
+/area/ship/engineering)
+"uD" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"uL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"uV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/stairs_pack/dark/other{
+	dir = 10
+	},
+/area/ship/engineering)
+"vo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"wd" = (
+/obj/structure/dresser{
+	dir = 8
+	},
+/obj/item/lighter/zippo/sol{
+	pixel_y = 9;
+	pixel_x = -3
+	},
+/obj/item/binoculars{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"wq" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/heavymetal/var2,
+/area/ship/engineering)
+"wz" = (
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"wQ" = (
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"wR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 19
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"xl" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/newspaper{
+	pixel_y = 4
+	},
+/obj/item/blackmarket_uplink{
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"xm" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/jukebox/boombox,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"xr" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"xI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/heavymetal/var4,
+/area/ship/engineering)
+"yf" = (
+/obj/structure/transit_tube/station/dispenser/reverse,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"yp" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"zo" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"zp" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/stamp/solfed/captain{
+	pixel_y = 5;
+	pixel_x = 1
+	},
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"zI" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"AL" = (
+/obj/machinery/light/colored/white{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"AT" = (
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"AZ" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 1;
+	piping_layer = 2
+	},
+/turf/open/floor/engine,
+/area/ship/bridge)
+"BD" = (
+/turf/template_noop,
+/area/template_noop)
+"BK" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"BO" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"Cl" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/structure/neon_spline/yellow{
+	dir = 8;
+	alpha = 0
+	},
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"Cs" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"CH" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"CX" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 8;
+	name = "Cargo Bay";
+	req_access = "8132"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"DB" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"DC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"DZ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/mob/living/simple_animal/bot/medbot,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Ea" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"EA" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Fd" = (
+/obj/machinery/airalarm/directional/south{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 32
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Fh" = (
+/obj/effect/turf_decal/corner/opaque/beige/half{
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"FC" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"GE" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ship/bridge)
+"GJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs{
+	dir = 1;
+	icon = 'icons/obj/stairs.dmi'
+	},
+/area/ship/bridge)
+"GM" = (
+/obj/machinery/light/colored/white,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"He" = (
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"HS" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"If" = (
+/obj/machinery/light/colored/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"Il" = (
+/obj/structure/table/greyscale{
+	color = "#CEB689"
+	},
+/obj/machinery/jukebox/boombox,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Io" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Jg" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/bridge)
+"Jl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Jn" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "Illegal_halo";
+	dir = 1
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "Illegal_gate"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"JC" = (
+/obj/machinery/firealarm/directional/south{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/stairs/stairs_pack/dark/other{
+	dir = 1
+	},
+/area/ship/engineering)
+"JO" = (
+/obj/machinery/light/colored/white{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Km" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Kq" = (
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Ks" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/light/colored/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/marble,
+/area/ship/engineering)
+"Kv" = (
+/obj/structure/extinguisher_cabinet/directional/north{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/stairs/stairs_pack/dark/other{
+	dir = 6
+	},
+/area/ship/engineering)
+"KC" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 8;
+	name = "Cargo Bay";
+	req_access_txt = "8132"
+	},
+/turf/open/floor/marble/black,
+/area/ship/engineering)
+"Lg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Mo" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/marble,
+/area/ship/engineering)
+"MD" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"ME" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ship/engineering)
+"MR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Nt" = (
+/obj/structure/closet/wall{
+	dir = 4;
+	icon_state = "emergency_wall";
+	pixel_x = 28
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.04
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"NH" = (
+/obj/structure/table/greyscale{
+	color = "#CEB689"
+	},
+/obj/item/gps{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/obj/item/gun/energy/plasmacutter/adv,
+/obj/item/pickaxe/drill/jackhammer,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"NL" = (
+/obj/structure/window/reinforced/fulltile/shuttle{
+	color = "#CEB689"
+	},
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "Illegal_eng"
+	},
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"Oa" = (
+/turf/open/floor/marble/black,
+/area/ship/engineering)
+"OA" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"OZ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Pf" = (
+/obj/machinery/light/colored/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Qq" = (
+/obj/machinery/light/colored/white{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Rl" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "Illegal_eng"
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/turf/open/floor/plasteel/heavymetal/var4,
+/area/ship/engineering)
+"Rr" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4,
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/engine,
+/area/ship/bridge)
+"RA" = (
+/obj/machinery/button/door{
+	id = "Illegal_eng";
+	name = "Engine Shutters";
+	pixel_y = -22;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden,
+/turf/open/floor/plasteel/heavymetal/var2,
+/area/ship/engineering)
+"RT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.04
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"RX" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/fax/solgov,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Sn" = (
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty{
+	pixel_y = 6
+	},
+/obj/structure/closet/wall/orange/directional/east{
+	name = "materials locker";
+	dir = 2;
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"So" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"SI" = (
+/obj/machinery/light/colored/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"SY" = (
+/obj/effect/turf_decal/corner/opaque/beige/half{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"Tf" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"Tl" = (
+/obj/structure/window/reinforced/tinted{
+	color = "#CEB689";
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/borderfloorblack/full,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"TK" = (
+/obj/machinery/power/ship_gravity,
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"TT" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/heavymetal/var3,
+/area/ship/engineering)
+"Vs" = (
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/engine/hull/reinforced{
+	icon = 'mod_celadon/_storage_icons/icons/structures/floors/metal_2.dmi';
+	icon_state = "metal_1"
+	},
+/area/ship/external/dark)
+"WL" = (
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"YG" = (
+/obj/structure/sign/poster/tg/tg_10{
+	pixel_x = 32
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/heavymetal/var2,
+/area/ship/engineering)
+"YQ" = (
+/obj/machinery/button/door{
+	id = "Illegal_gate";
+	name = "gate";
+	pixel_y = 22;
+	pixel_x = -6;
+	req_access_txt = "8132"
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "Illegal_halo";
+	pixel_x = 7;
+	pixel_y = 21
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/borderfloorblack/full,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4;
+	layer = 2.04
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ship/engineering)
+"YT" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"YV" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/ship/engineering)
+"YY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4;
+	name = "Helm";
+	color = "#545253"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+"Zx" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/obj/effect/turf_decal/corner/opaque/beige/mono,
+/turf/open/floor/marble,
+/area/ship/engineering)
+"ZS" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ship/bridge)
+
+(1,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(2,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(3,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(4,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(5,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(6,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(7,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(8,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+aS
+wq
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+wq
+aS
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+mk
+BD
+BD
+"}
+(9,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+aS
+jW
+aS
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+aS
+Rl
+aS
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+BD
+BD
+"}
+(10,1,1) = {"
+BD
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+aS
+Ea
+fa
+ME
+BO
+BD
+BD
+BD
+BD
+BD
+aS
+aS
+aS
+Ea
+aS
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+BD
+BD
+"}
+(11,1,1) = {"
+BD
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+aS
+rD
+If
+wQ
+BK
+aS
+BD
+BD
+BD
+aS
+aS
+pl
+pK
+RA
+aS
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+dU
+BD
+BD
+"}
+(12,1,1) = {"
+BD
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+aS
+gY
+Uq
+Uq
+iW
+aS
+BD
+BD
+BD
+aS
+oh
+YG
+xI
+Tf
+aS
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+dU
+BD
+BD
+"}
+(13,1,1) = {"
+BD
+dU
+dU
+dU
+dU
+BD
+BD
+BD
+BD
+Vs
+dU
+aS
+aS
+aS
+av
+aS
+aS
+aS
+NL
+NL
+NL
+aS
+aS
+aS
+CX
+aS
+aS
+aS
+dU
+Vs
+BD
+BD
+BD
+dU
+dU
+dU
+dU
+dU
+BD
+BD
+"}
+(14,1,1) = {"
+BD
+dU
+dU
+dU
+dU
+dU
+ih
+Vs
+Vs
+Vs
+aS
+aS
+OZ
+MR
+MR
+Qq
+cO
+uV
+DC
+DC
+jt
+qO
+cO
+Qq
+MR
+tz
+TK
+aS
+aS
+Vs
+Vs
+Vs
+Fh
+dU
+dU
+dU
+dU
+dU
+BD
+BD
+"}
+(15,1,1) = {"
+BD
+BD
+dU
+dU
+dU
+dU
+ih
+Vs
+Vs
+Vs
+aS
+Il
+vo
+Lg
+cM
+uL
+nU
+JC
+ay
+YV
+ua
+Kv
+CH
+cu
+cM
+rZ
+ax
+rH
+aS
+Vs
+Vs
+Vs
+Fh
+dU
+dU
+dU
+dU
+BD
+BD
+BD
+"}
+(16,1,1) = {"
+BD
+BD
+dU
+dU
+dU
+dU
+ih
+Vs
+Vs
+aS
+aS
+NH
+vo
+ax
+OA
+ax
+aS
+aS
+aS
+KC
+aS
+aS
+bz
+ax
+OA
+vo
+ax
+Sn
+aS
+aS
+Vs
+Vs
+Fh
+dU
+dU
+dU
+dU
+BD
+BD
+BD
+"}
+(17,1,1) = {"
+BD
+BD
+BD
+dU
+dU
+dU
+ih
+Vs
+aS
+aS
+bg
+OA
+vo
+ax
+cF
+TT
+aS
+ge
+Oa
+oc
+Oa
+eT
+bz
+mE
+pb
+to
+du
+OA
+pL
+aS
+aS
+Vs
+Fh
+dU
+dU
+dU
+BD
+BD
+BD
+BD
+"}
+(18,1,1) = {"
+BD
+BD
+BD
+dU
+dU
+dU
+ih
+aS
+aS
+AL
+MR
+MR
+iR
+aS
+ql
+aS
+aS
+aS
+Mo
+Ks
+Zx
+ps
+mf
+aS
+ql
+aS
+JO
+MR
+du
+qv
+aS
+aS
+Fh
+dU
+dU
+dU
+BD
+BD
+BD
+BD
+"}
+(19,1,1) = {"
+BD
+BD
+BD
+BD
+dU
+dU
+bi
+aS
+YQ
+RT
+Nt
+qr
+aS
+aS
+mg
+kN
+kN
+Jg
+Jg
+Jg
+Jg
+dX
+kN
+kN
+mg
+aS
+aS
+qq
+He
+nK
+ne
+aS
+aS
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+"}
+(20,1,1) = {"
+BD
+BD
+BD
+BD
+dU
+bi
+bi
+aS
+qB
+Jn
+aS
+aS
+aS
+kN
+mg
+kN
+Jg
+Jg
+AZ
+jX
+Rr
+bh
+Jg
+kN
+mg
+kN
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+aS
+dU
+BD
+BD
+BD
+BD
+BD
+"}
+(21,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+dU
+ih
+Vs
+Cl
+Cl
+aS
+kN
+kN
+kN
+cz
+Jg
+Jg
+Jg
+Jg
+sw
+Jg
+dX
+Jg
+Jg
+cz
+kN
+kN
+kN
+aS
+Vs
+Vs
+Vs
+Fh
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(22,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+dU
+ih
+Vs
+Vs
+Vs
+Vs
+kN
+Jg
+Jg
+yf
+xr
+Pf
+DZ
+DB
+ZS
+Jl
+zI
+Pf
+MD
+tn
+Jg
+Jg
+kN
+Vs
+Vs
+Vs
+Vs
+Fh
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(23,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+Vs
+Vs
+Jg
+Jg
+Jg
+xm
+ZS
+eq
+Io
+Fd
+GE
+uD
+wR
+lP
+Km
+Cs
+zo
+Tl
+dJ
+dJ
+yp
+kS
+Vs
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(24,1,1) = {"
+BD
+BD
+BD
+BD
+SY
+SY
+SY
+SY
+SY
+Jg
+Jg
+ht
+Kq
+YT
+Io
+Io
+Io
+bq
+bq
+Jg
+bq
+bq
+Io
+mQ
+wz
+ss
+FC
+AT
+Jg
+Jg
+SY
+SY
+SY
+SY
+SY
+BD
+BD
+BD
+BD
+BD
+"}
+(25,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+dU
+Jg
+Jg
+Jg
+hZ
+HS
+So
+WL
+Jg
+bJ
+qk
+wd
+bq
+WL
+zp
+aQ
+ls
+Jg
+Jg
+Jg
+dU
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(26,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+Vs
+Jg
+Jg
+Jg
+mN
+So
+cT
+WL
+fs
+WL
+GJ
+rh
+xl
+Jg
+Jg
+Jg
+Vs
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(27,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+dU
+dU
+Jg
+Jg
+SI
+cT
+HS
+HS
+HS
+GJ
+GM
+Jg
+Jg
+dU
+dU
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(28,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+BD
+dU
+Vs
+Jg
+Jg
+Jg
+RX
+YY
+hh
+Jg
+Jg
+Jg
+Vs
+dU
+BD
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(29,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+Vs
+dU
+SY
+fu
+fu
+EA
+fu
+fu
+SY
+dU
+Vs
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(30,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+dU
+dU
+Vs
+fu
+fu
+fu
+Vs
+dU
+dU
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(31,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+BD
+dU
+Vs
+Vs
+fu
+Vs
+Vs
+dU
+BD
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(32,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+dU
+dU
+Vs
+BD
+Vs
+dU
+dU
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(33,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+Vs
+BD
+Vs
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(34,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(35,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(36,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(37,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(38,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(39,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(40,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}
+(41,1,1) = {"
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+BD
+"}

--- a/_maps/_mod_celadon/shuttles/independent/independent_intelof.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_intelof.dmm
@@ -102,12 +102,6 @@
 /obj/item/melee/energy/sword/saber/knife/yellow{
 	pixel_y = 7
 	},
-/obj/item/paper{
-	pixel_y = 4;
-	name = "Рекомендательная записка";
-	default_raw_text = "<table width="100%" height="100%" bgcolor="#094175" cellpadding="15"> <tr><td><center><b><font size="4" color="#dbdbd7">Solarian Confederation Frontier Affairs</font></b><br><font size="3" color="#dbdbd7">Рекомендательная записка</font><hr width="90%" color="#f5cf25"></center><font face="Courier New" color="#dbdbd7"> <p> Я, [Atremar Monreschare]<br>В должности [Special Field Operations Officer].<p><p>Уведомляю вас, что вам поручена особая миссия по сбору и передачи информации высшему коммандованию, о любой подозрительной или враждебной активности всех находящихся в секторе кораблей.<br><br>Для того чтобы не вызывать подозрений и лишнее внимание ваш корабль был зарегистрирован как Независимое судно, а вы как Независимый Капитан.<br><br>Ваша задача помимо сбора информации так же состоит в том, чтобы вас не раскрыли.<br><br>1.Вы можете безпрепятственно устранять любого кто вторгся на ваш корабль.<br>2.Вы можете безпрепятственно устранять любого кто угрожает вам, вашей жизни, и вашей миссии.<br>3.Немедленно уведомляйте командование о любых нарушениях/несоответствующем поведении со стороны служащих регулярной армии Солнечной Федерации.<br><br>После прочтения поставьте печать и отправьте данный документ на факс : Solarian Confederation Frontier Affairs. В случае если вам необходимы дополнительные инструкции, свяжитесь с нами по факсу.<br><br><center><font color="#dbdbd7" size="2">[Место для штампа]</font></center><br><br><br><hr width="90%" color="#f5cf25"><font size="1" color="#dbdbd7"><p align="justify">ДАННЫЙ ДОКУМЕНТ СЧИТАЕТСЯ ОФИЦИАЛЬНЫМ ТОЛЬКО ПРИ НАЛИЧИИ ПОДПИСИ УПОЛНОМОЧЕННОГО ЛИЦА И СООТВЕТСТВУЮЩЕГО ЕГО ДОЛЖНОСТИ ШТАМПА. В СЛУЧАЕ ОТСУТСТВИЯ ЛЮБОГО ИЗ УКАЗАННЫХ ЭЛЕМЕНТОВ ДАННЫЙ ДОКУМЕНТ НЕ ЯВЛЯЕТСЯ ОФИЦИАЛЬНЫМ И РЕКОМЕНДУЕТСЯ ЕГО УДАЛИТЬ С ЛЮБОГО ИНФОРМАЦИОННОГО НОСИТЕЛЯ.</p><hr width="90%" color="#f5cf25"><center><b><font color="#dbdbd7">Cлава Солнечной Федерации!</font></b><br><b><font color="#dbdbd7">© Solarian Confederation Frontier Affairs.</font></b></center></font></td></tr></table>";
-	layer = 6
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "cu" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
@@ -200,6 +200,7 @@
 	dir = 4
 	},
 /obj/structure/sign/flag/solfed/directional/west,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "cE" = (
@@ -839,17 +840,13 @@
 /turf/open/floor/plasteel/lightgrey,
 /area/ship/crew/canteen)
 "jM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/shuttle/engine/electric/premium,
 /obj/docking_port/mobile{
 	dir = 4;
 	port_direction = 2;
 	preferred_direction = 4
 	},
-/turf/open/floor/plating,
-/area/ship/engineering)
+/turf/template_noop,
+/area/ship/external)
 "jQ" = (
 /obj/machinery/chem_heater{
 	pixel_y = 3
@@ -1876,6 +1873,7 @@
 /obj/effect/turf_decal/trimline/opaque/orange/line{
 	dir = 6
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "tx" = (
@@ -1998,23 +1996,8 @@
 	dir = 10
 	},
 /obj/structure/table/wood,
-/obj/item/storage/fancy/coffee_cart_rack{
-	pixel_x = -6;
+/obj/machinery/microwave{
 	pixel_y = 6
-	},
-/obj/item/blank_coffee_cartridge{
-	pixel_x = 2
-	},
-/obj/item/blank_coffee_cartridge{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/blank_coffee_cartridge{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/fancy/coffee_cart_rack{
-	pixel_x = -8
 	},
 /turf/open/floor/plasteel/strongdark,
 /area/ship/crew/canteen)
@@ -2312,6 +2295,20 @@
 /obj/item/reagent_containers/glass/coffee_cup,
 /obj/item/reagent_containers/glass/coffee_cup,
 /obj/item/reagent_containers/condiment/sugar,
+/obj/item/blank_coffee_cartridge{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/blank_coffee_cartridge{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = -8
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = -8
+	},
 /turf/open/floor/plasteel/strongdark,
 /area/ship/crew/canteen)
 "xT" = (
@@ -2704,9 +2701,9 @@
 	pixel_x = -5;
 	pixel_y = 1
 	},
-/obj/item/stamp/solfed/commander{
+/obj/item/stamp/solfed/captain{
 	pixel_y = 3;
-	pixel_x = 8
+	pixel_x = 9
 	},
 /turf/open/floor/plasteel/telecomms_floor,
 /area/ship/bridge)
@@ -3429,7 +3426,6 @@
 	pixel_x = 0;
 	pixel_y = 2
 	},
-/obj/item/gun/energy/floragun,
 /obj/item/seeds/coffee,
 /obj/item/seeds/coffee,
 /turf/open/floor/suns/hatch{
@@ -3666,6 +3662,7 @@
 /area/ship/crew/canteen)
 "My" = (
 /obj/effect/turf_decal/corner/opaque/solgovblue/border,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "MC" = (
@@ -3921,15 +3918,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Py" = (
-/obj/docking_port/stationary{
-	width = 30;
-	height = 15;
-	dwidth = 15;
-	dir = 8
-	},
-/turf/template_noop,
-/area/template_noop)
 "PD" = (
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/line{
 	dir = 6
@@ -4117,6 +4105,7 @@
 /obj/effect/turf_decal/corner/opaque/solgovblue/border{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Sw" = (
@@ -4393,7 +4382,6 @@
 /area/ship/general/cargo)
 "Vy" = (
 /obj/structure/closet/wall/red/directional/west,
-/obj/item/gun/ballistic/revolver/viper/indie,
 /obj/item/gun/ballistic/revolver/viper/indie,
 /obj/item/gun/ballistic/revolver/viper/indie,
 /obj/item/storage/box/ammo/a357,
@@ -4936,7 +4924,7 @@ yQ
 yQ
 yQ
 yQ
-yQ
+jM
 yQ
 yQ
 yQ
@@ -4962,7 +4950,6 @@ yQ
 yQ
 yQ
 yQ
-Py
 yQ
 yQ
 yQ
@@ -4978,7 +4965,8 @@ yQ
 yQ
 yQ
 yQ
-jM
+yQ
+bw
 yQ
 yQ
 yQ

--- a/mod_celadon/outfit/code/solfed/_outfit.dm
+++ b/mod_celadon/outfit/code/solfed/_outfit.dm
@@ -218,6 +218,28 @@
 	. = ..()
 	get_solfed_captain_access(H)
 
+/datum/outfit/job/cel/solfed/intelof
+	name = "SF - Intellegence Officer"
+	job_icon = "sf_komandant"
+
+	jobtype = /datum/job/captain
+
+	id = /obj/item/card/id
+	gloves = /obj/item/clothing/gloves/color/white
+	uniform = /obj/item/clothing/under/rank/security/detective/grey
+	suit = /obj/item/clothing/suit/toggle/lawyer/charcoal
+	neck = /obj/item/clothing/neck/tie/black
+	dcoat = null
+	glasses = /obj/item/clothing/glasses/sunglasses
+	head = null
+	accessory = null
+
+	satchel = /obj/item/storage/backpack/satchel/leather
+
+/datum/outfit/job/cel/solfed/captain/post_equip(mob/living/carbon/human/H)
+	. = ..()
+	get_solfed_captain_access(H)
+
 /datum/outfit/job/cel/solfed/captain/admiral
 	name = "SF - Flottenadmiral"
 	job_icon = "sf_admiral"


### PR DESCRIPTION
## Описание / Что этот PR делает
Новый корабль+QoL+Нерф руины.
## Причина создания ПР / Почему это хорошо для игры
QoL - для Лайтнинга
Добавление нового щитспавн судна, в будущем возможно станет доступным на постоянной основе
Ослабление черезмерно сильной руины, слишком агрессивная среда выводит игроков пачками.

## Список изменений

Уменьшено ХП горилл на Джунглевой руине с 300 до 190.
Заменены турели .50 на более малого калибра чтобы маленькие пупсики не умирали с плюхи Тайпана, которая спрятана за мешком с песком, под лозой, и охраной трех мобов.
Мои некоторые подъебки не работали - теперь работают.

Лайтнинг:
Добавил микроволновку.
После инцидента с химиком который прожег пол, было решено добавить несколько огнетушителей.
Легкий нерф ботаники.
Убран один револьвер.

Новый кораблик для педальских экспериментов, щитспавн.
```yml
🆑
add: Что-то добавлено
balance: Что-то изменено в балансе
tweak: Что-то изменено по мелочи
fix: Что-то исправлено
map: Изменения на карте

/🆑
```
<img width="515" height="376" alt="image" src="https://github.com/user-attachments/assets/957cdef8-f335-4285-af14-526e8973d606" />

