### PR TITLE
FIX: Броня культистов без текстур

### DIFF
--- a/mod_celadon/fixes/code/icons.dm
+++ b/mod_celadon/fixes/code/icons.dm
@@ -17,3 +17,11 @@
 
 /obj/item/gun/energy/pulse/carbine
 	mob_overlay_icon = 'mod_celadon/_storage_icons/icons/items/weapons/overlay/onmob.dmi'
+
+/obj/item/clothing/suit/space/hardsuit/cult
+	icon_state = "cult_armor"
+	item_state = "cult_armor"
+
+/obj/item/clothing/head/helmet/space/hardsuit/cult
+	icon_state = "cult_helmet"
+	item_state = "cult_helmet"


### PR DESCRIPTION
## Описание / Что этот PR делает
Так как офы выпилили культистов, то и проебались названия спрайтов. Теперь все ок!

## Причина создания ПР / Почему это хорошо для игры
Closed https://canary.discord.com/channels/1100198143456465067/1413801303846420530

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: утерянные названия спрайтов
/🆑
```
