### PR TITLE
FIX: Белоснежные вещи не меняли цвета свои

### DIFF
--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -43,6 +43,7 @@
 #include "code/dock_empty_space_fix.dm"
 #include "code/sledgehammer.dm"
 #include "code/hooded.dm"
+#include "code/suit.dm"
 
 #include "code/antagonists/space_ninja.dm"
 

--- a/mod_celadon/fixes/code/suit.dm
+++ b/mod_celadon/fixes/code/suit.dm
@@ -1,0 +1,17 @@
+/obj/item/clothing/suit/toggle/pufferjacket/reskin_obj(mob/user)
+	. = ..()
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_wear_suit()
+
+/obj/item/clothing/suit/toggle/puffervest/reskin_obj(mob/user)
+	. = ..()
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_wear_suit()
+
+/obj/item/clothing/suit/toggle/windbreaker/reskin_obj(mob/user)
+	. = ..()
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_wear_suit()


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь все корректно работает, колесо выбора цвета для вещей с лодаута:
pufferjacket
puffervest
windbreaker

## Причина создания ПР / Почему это хорошо для игры
Closed https://canary.discord.com/channels/1100198143456465067/1414902472564150403
Closed https://canary.discord.com/channels/1100198143456465067/1416026218490499142

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: обновление отображение вещей
/🆑
```
