### PR TITLE
FIX: Безсанкционные цены на уран

### DIFF
--- a/mod_celadon/economy/code/exports/materials.dm
+++ b/mod_celadon/economy/code/exports/materials.dm
@@ -11,6 +11,8 @@
 
 /datum/export/material/uranium
 	cost = 20
+	sell_floor = 5
+	elasticity_coeff = 0.01
 	material_id = /datum/material/uranium
 	unit_name = "cm3 of uranium"
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавлена минимальная цена для продажи урана (5), и коеф.снижения цены эластичности на уран (0.01)

## Причина создания ПР / Почему это хорошо для игры
Из-за того что уран не как не реагировал, можно было фармить много денях
Closed https://canary.discord.com/channels/1100198143456465067/1425612377986044084

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: коэф.эластичности и минимальная цена
/🆑
```
