### PR TITLE
FIX: Доступы Executioner и Teardrop

### DIFF
--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -115,7 +115,7 @@
 	can_be_unanchored = 1;
 	icon_state = "warden";
 	name = "master at arms' locker";
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/item/clothing/shoes/combat,
 /obj/item/megaphone/sec,
@@ -875,7 +875,7 @@
 	pixel_x = -19;
 	pixel_y = 9;
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /obj/effect/turf_decal/industrial/traffic/corner{
@@ -1126,7 +1126,7 @@
 	pixel_x = 18;
 	pixel_y = 9;
 	dir = 8;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/corner{
 	dir = 4
@@ -1391,7 +1391,7 @@
 	can_be_unanchored = 1;
 	icon_state = "brig_phys";
 	name = "equipment locker";
-	req_access_txt = "8484"
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
@@ -3224,7 +3224,7 @@
 "Ob" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4052,7 +4052,7 @@
 	name = "Armory shuters";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/machinery/turretid/ship{
 	pixel_y = 34;

--- a/mod_celadon/outfit/code/nanotrasen/vigilitas_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/vigilitas_outfit.dm
@@ -4,7 +4,7 @@
 	name = "NT Vigilitas - Leutenant"
 	job_icon = "clip_cmm6"
 
-	jobtype = /datum/job/hos
+	jobtype = /datum/job/captain
 
 	id = /obj/item/card/id/cel/nanotrasen/vigilitas_leutenant
 
@@ -36,7 +36,7 @@
 	name = "NT Vigilitas - Sergeant"
 	job_icon = "clip_cmm5"
 
-	jobtype = /datum/job/warden
+	jobtype = /datum/job/hos
 
 	id = /obj/item/card/id/cel/nanotrasen/vigilitas_sergeant
 	belt = /obj/item/pda/heads/hos


### PR DESCRIPTION
## Описание / Что этот PR делает
ТМ на альфу с починкой доступов на двух кораблях - InteQ Executioner и NT TearDrop
## Причина создания ПР / Почему это хорошо для игры

## Демонстрация изменений / Тестирование
<img width="159" height="173" alt="image" src="https://github.com/user-attachments/assets/98c574ba-8d9f-406a-aa8d-d9a3375087ab" />
<img width="150" height="178" alt="image" src="https://github.com/user-attachments/assets/74a3b99c-0c9d-4733-a46f-89ab6c56acd1" />
<img width="189" height="139" alt="image" src="https://github.com/user-attachments/assets/46dc16ec-735a-435c-a4c9-3eea2d442309" />
<img width="124" height="149" alt="image" src="https://github.com/user-attachments/assets/953da986-44a1-49ea-b97d-b0d3f82abfc2" />

## Список изменений

```yml
🆑
fix: Что-то исправлено
/🆑
```
