### PR TITLE
FIX: Исправление недочётов в оутфитах

### DIFF
--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -112,7 +112,7 @@
 	can_be_unanchored = 1;
 	icon_state = "warden";
 	name = "master at arms' locker";
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/item/clothing/shoes/combat,
 /obj/item/megaphone/sec,
@@ -872,7 +872,7 @@
 	pixel_x = -19;
 	pixel_y = 9;
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /obj/effect/turf_decal/industrial/traffic/corner{
@@ -1123,7 +1123,7 @@
 	pixel_x = 18;
 	pixel_y = 9;
 	dir = 8;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/corner{
 	dir = 4
@@ -1385,7 +1385,7 @@
 	can_be_unanchored = 1;
 	icon_state = "brig_phys";
 	name = "equipment locker";
-	req_access_txt = "8484"
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
@@ -3218,7 +3218,7 @@
 "Ob" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4046,7 +4046,7 @@
 	name = "Armory shuters";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/machinery/turretid/ship{
 	pixel_y = 34;

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -112,7 +112,7 @@
 	can_be_unanchored = 1;
 	icon_state = "warden";
 	name = "master at arms' locker";
-	req_access_txt = "3"
+	req_access_txt = "8485"
 	},
 /obj/item/clothing/shoes/combat,
 /obj/item/megaphone/sec,
@@ -167,14 +167,6 @@
 /obj/machinery/autolathe/hacked,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/industrial/traffic/fulltile,
-/obj/machinery/button/door{
-	id = "exec_armorysh2";
-	name = "Armory shuters";
-	pixel_x = 18;
-	pixel_y = 9;
-	dir = 8;
-	req_access_txt = "8485"
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "bE" = (
@@ -880,7 +872,7 @@
 	pixel_x = -19;
 	pixel_y = 9;
 	dir = 4;
-	req_access_txt = list(19,3)
+	req_access_txt = "8485"
 	},
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /obj/effect/turf_decal/industrial/traffic/corner{
@@ -1131,7 +1123,7 @@
 	pixel_x = 18;
 	pixel_y = 9;
 	dir = 8;
-	req_access_txt = list(19,3)
+	req_access_txt = "8485"
 	},
 /obj/effect/turf_decal/industrial/traffic/corner{
 	dir = 4
@@ -1393,7 +1385,7 @@
 	can_be_unanchored = 1;
 	icon_state = "brig_phys";
 	name = "equipment locker";
-	req_access_txt = "5"
+	req_access_txt = "8484"
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
@@ -1440,17 +1432,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
-"oy" = (
-/obj/machinery/button/door{
-	id = "exec_armorysh2";
-	name = "Armory shuters";
-	pixel_x = 18;
-	pixel_y = 9;
-	dir = 8;
-	req_access_txt = "8485"
-	},
-/turf/closed/wall/mineral/plastitanium,
-/area/ship/security/armory)
 "oF" = (
 /obj/structure/catwalk,
 /turf/open/floor/engine/hull/reinforced,
@@ -3237,7 +3218,7 @@
 "Ob" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	req_access_txt = "3"
+	req_access_txt = "8485"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3404,14 +3385,6 @@
 	dir = 1;
 	pixel_x = -10;
 	pixel_y = -20
-	},
-/obj/machinery/button/door{
-	id = "exec_armorysh2";
-	name = "Armory shuters";
-	pixel_x = 18;
-	pixel_y = 9;
-	dir = 8;
-	req_access_txt = "8485"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -4073,7 +4046,7 @@
 	name = "Armory shuters";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = list(19,3)
+	req_access_txt = "8485"
 	},
 /obj/machinery/turretid/ship{
 	pixel_y = 34;
@@ -4834,7 +4807,7 @@ gR
 tX
 cL
 bC
-oy
+CV
 SP
 Ey
 SP

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -112,7 +112,7 @@
 	can_be_unanchored = 1;
 	icon_state = "warden";
 	name = "master at arms' locker";
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/item/clothing/shoes/combat,
 /obj/item/megaphone/sec,
@@ -167,6 +167,14 @@
 /obj/machinery/autolathe/hacked,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/industrial/traffic/fulltile,
+/obj/machinery/button/door{
+	id = "exec_armorysh2";
+	name = "Armory shuters";
+	pixel_x = 18;
+	pixel_y = 9;
+	dir = 8;
+	req_access_txt = "8485"
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "bE" = (
@@ -872,7 +880,7 @@
 	pixel_x = -19;
 	pixel_y = 9;
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/fulltile,
 /obj/effect/turf_decal/industrial/traffic/corner{
@@ -1123,7 +1131,7 @@
 	pixel_x = 18;
 	pixel_y = 9;
 	dir = 8;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/effect/turf_decal/industrial/traffic/corner{
 	dir = 4
@@ -1385,7 +1393,7 @@
 	can_be_unanchored = 1;
 	icon_state = "brig_phys";
 	name = "equipment locker";
-	req_access_txt = "8484"
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/medical)
@@ -1432,6 +1440,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/fore)
+"oy" = (
+/obj/machinery/button/door{
+	id = "exec_armorysh2";
+	name = "Armory shuters";
+	pixel_x = 18;
+	pixel_y = 9;
+	dir = 8;
+	req_access_txt = "8485"
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ship/security/armory)
 "oF" = (
 /obj/structure/catwalk,
 /turf/open/floor/engine/hull/reinforced,
@@ -3218,7 +3237,7 @@
 "Ob" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	req_access_txt = "8485"
+	req_access_txt = "3"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -3385,6 +3404,14 @@
 	dir = 1;
 	pixel_x = -10;
 	pixel_y = -20
+	},
+/obj/machinery/button/door{
+	id = "exec_armorysh2";
+	name = "Armory shuters";
+	pixel_x = 18;
+	pixel_y = 9;
+	dir = 8;
+	req_access_txt = "8485"
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
@@ -4046,7 +4073,7 @@
 	name = "Armory shuters";
 	pixel_x = 6;
 	pixel_y = 25;
-	req_access_txt = "8485"
+	req_access_txt = list(19,3)
 	},
 /obj/machinery/turretid/ship{
 	pixel_y = 34;
@@ -4807,7 +4834,7 @@ gR
 tX
 cL
 bC
-CV
+oy
 SP
 Ey
 SP

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -247,3 +247,10 @@
 	name = "SUNS PDA"
 	default_cartridge = /obj/item/cartridge/medical
 	icon_state = "pda-suns"
+
+// [CELADON-ADD] - scientist-PDA
+/obj/item/pda/scientist
+	name = "scientist PDA"
+	default_cartridge = /obj/item/cartridge/chemistry
+	icon_state = "pda-science"
+// [/CELADON-ADD]

--- a/mod_celadon/outfit/code/independent/_outfit.dm
+++ b/mod_celadon/outfit/code/independent/_outfit.dm
@@ -467,7 +467,7 @@
 	job_icon = "stationengineer"
 	jobtype = /datum/job/engineer
 
-	belt = /obj/item/storage/belt/utility/full/engil
+	belt = /obj/item/storage/belt/utility/full/engi
 	gloves = null
 	ears = /obj/item/radio/headset/headset_eng
 	uniform = /obj/item/clothing/under/overalls/olive

--- a/mod_celadon/outfit/code/independent/_outfit.dm
+++ b/mod_celadon/outfit/code/independent/_outfit.dm
@@ -467,7 +467,7 @@
 	job_icon = "stationengineer"
 	jobtype = /datum/job/engineer
 
-	belt = null
+	belt = /obj/item/storage/belt/utility/full/engil
 	gloves = null
 	ears = /obj/item/radio/headset/headset_eng
 	uniform = /obj/item/clothing/under/overalls/olive
@@ -484,7 +484,7 @@
 /datum/outfit/job/cel/independent/engineer/salvage
 	name = "IND - Engineer (Salvager)"
 
-	belt = null
+	belt = /obj/item/storage/belt/utility/full/engi
 	l_pocket = null
 
 // MARK:Chief Engineer

--- a/mod_celadon/outfit/code/inteq/_outfit.dm
+++ b/mod_celadon/outfit/code/inteq/_outfit.dm
@@ -5,6 +5,8 @@
 
 	id = /obj/item/card/id/cel/inteq
 	uniform = /obj/item/clothing/under/syndicate/inteq
+	ears = /obj/item/radio/headset/inteq
+	shoes = /obj/item/clothing/shoes/combat
 	alt_uniform = /obj/item/clothing/under/syndicate/inteq/sneaksuit
 	duffelbag = /obj/item/storage/backpack/duffelbag/inteq
 	backpack = /obj/item/storage/backpack
@@ -43,31 +45,36 @@
 	name = "IQ - Recruit"
 	jobtype = /datum/job/assistant
 	job_icon = "assistant"
+	id_assignment = "Recruit"
 
 	id = /obj/item/card/id/cel/inteq/recruit
-	mask = /obj/item/clothing/mask/balaclava
-	ears = /obj/item/radio/headset
-	r_pocket = /obj/item/radio
+	mask = /obj/item/clothing/mask/balaclava/inteq
+	shoes = /obj/item/clothing/shoes/jackboots
 
 //MARK: Капитан
 /datum/outfit/job/cel/inteq/captain
 	name = "IQ - Vanguard"
 	jobtype = /datum/job/captain
 	job_icon = "captain"
+	id_assignment = "Vanguard"
 
 	id = /obj/item/card/id/cel/inteq/vanguard
 	head = /obj/item/clothing/head/beret/sec/hos/inteq
+	ears = /obj/item/radio/headset/inteq/alt/captain
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	suit = /obj/item/clothing/suit/armor/vest/inteq
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 	suit_store = /obj/item/gun/ballistic/revolver/horizonx
 	gloves = /obj/item/clothing/gloves/combat
 
 //MARK: Командир
 /datum/outfit/job/cel/inteq/captain/honorable
 	name = "IQ - Honorable Vanguard"
+	id_assignment = "Honorable Vanguard"
 
 	id = /obj/item/card/id/cel/inteq/honorable_rearguard
+	ears = /obj/item/radio/headset/inteq/alt/captain
 	head = /obj/item/clothing/head/beret/sec/hos/inteq/honorable
 	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 	suit = /obj/item/clothing/suit/armor/hos/inteq/honorable
@@ -81,39 +88,44 @@
 	jobtype = /datum/job/captain
 
 	id = /obj/item/card/id/cel/inteq/vanguard
+	ears = /obj/item/radio/headset/inteq/alt
 	head = /obj/item/clothing/head/beret/sec/hos/inteq
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	suit = /obj/item/clothing/suit/armor/vest/inteq
 	gloves = /obj/item/clothing/gloves/combat
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 
 //MARK: Лейтенант первого класса
 /datum/outfit/job/cel/inteq/enforcer
-	name = "IQ - Enforcer class One"
+	name = "IQ - Enforcer Class One"
 	jobtype = /datum/job/warden
 	job_icon = "lieutenant"
+	id_assignment = "Enforcer Class One"
 
 	id = /obj/item/card/id/cel/inteq/enforcer
 	head = /obj/item/clothing/head/beret/sec/hos/inteq
-	mask = /obj/item/clothing/mask/balaclava
+	ears = /obj/item/radio/headset/inteq/alt
+	mask = /obj/item/clothing/mask/balaclava/inteq
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	suit = /obj/item/clothing/suit/armor/vest/inteq
 	suit_store = /obj/item/gun/ballistic/automatic/pistol/usp45
 	belt = /obj/item/ammo_box/magazine/usp45_standart
 	gloves = /obj/item/clothing/gloves/combat
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 
 //MARK: Парамедик
 /datum/outfit/job/cel/inteq/paramedic
 	job_icon = "medicaldoctor"
 	jobtype = /datum/job/paramedic
 	name = "IQ - Corpsman"
+	id_assignment = "Corpsman"
 
 	id = /obj/item/card/id/cel/inteq/medic
 	uniform = /obj/item/clothing/under/syndicate/inteq/corpsman
 	head = /obj/item/clothing/head/soft/inteq/corpsman
 	suit = /obj/item/clothing/suit/armor/inteq/corpsman
-	shoes = /obj/item/clothing/shoes/combat
 	belt = /obj/item/storage/belt/medical/webbing/paramedic
-	ears = /obj/item/radio/headset/headset_medsec/alt
+	ears = /obj/item/radio/headset/headset_medsec
 
 	suit_store = /obj/item/flashlight/pen/paramedic
 	backpack_contents = list(/obj/item/roller=1)
@@ -128,10 +140,9 @@
 	id = /obj/item/card/id/cel/inteq/honorable_medic
 	head = /obj/item/clothing/head/beret/cmo
 	belt = /obj/item/storage/belt/medical/webbing/paramedic
-	ears = /obj/item/radio/headset/inteq/captain
-	uniform = /obj/item/clothing/under/syndicate/inteq/corpsman
+	ears = /obj/item/radio/headset/headset_medsec/alt
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 	alt_uniform = /obj/item/clothing/under/syndicate/inteq/corpsman/skirt
-	shoes = /obj/item/clothing/shoes/combat
 	suit = /obj/item/clothing/suit/hooded/wintercoat/security/inteq/alt
 	alt_suit = /obj/item/clothing/suit/armor/inteq/corpsman
 	dcoat = /obj/item/clothing/suit/armor/hos/inteq
@@ -143,16 +154,16 @@
 	name = "IQ - Enforcer"
 	jobtype = /datum/job/officer
 	job_icon = "lieutenant"
+	id_assignment = "Enforcer"
 
 	id = /obj/item/card/id/cel/inteq/enforcer
-	ears = /obj/item/radio/headset/alt
-	head = /obj/item/clothing/head/helmet/inteq
+	head = /obj/item/clothing/head/helmet/m10/inteq
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	belt = /obj/item/storage/belt/security/webbing/inteq
 	mask = /obj/item/clothing/mask/balaclava/inteq
+	ears = /obj/item/radio/headset/inteq/alt
 	uniform = /obj/item/clothing/under/syndicate/inteq
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/security/inteq
-	shoes = /obj/item/clothing/shoes/combat
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	gloves = /obj/item/clothing/gloves/combat
 
@@ -181,20 +192,22 @@
 	name = "IQ - Master At Arms"
 	jobtype = /datum/job/warden
 	job_icon = "warden"
+	id_assignment = "Master At Arms"
 
 	id = /obj/item/card/id/cel/inteq/master_at_arms
 
 	ears = /obj/item/radio/headset/inteq/alt
 	head = /obj/item/clothing/head/warden/inteq
-	uniform = /obj/item/clothing/under/syndicate/inteq
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/inteq
 	mask = /obj/item/clothing/mask/balaclava/inteq
 	belt = /obj/item/storage/belt/military/assault
 	suit = /obj/item/clothing/suit/armor/vest/security/warden/inteq
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/security/inteq
-	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	suit_store = null
+	l_pocket = /obj/item/restraints/handcuffs
+	r_pocket = /obj/item/assembly/flash/handheld
 
 	courierbag = /obj/item/storage/backpack/messenger/inteq
 
@@ -203,29 +216,32 @@
 	name = "IQ - Artificer Class One"
 	jobtype = /datum/job/chief_engineer
 	job_icon = "chiefengineer"
+	id_assignment = "Artificer Class One"
 
 	id = /obj/item/card/id/cel/inteq/honorable_artificer
-	ears = /obj/item/radio/headset/inteq
-	uniform = /obj/item/clothing/under/syndicate/inteq/artificer
+	ears = /obj/item/radio/headset/inteq/alt
+	uniform = /obj/item/clothing/under/syndicate/inteq/honorable
 	head = /obj/item/clothing/head/hardhat/white
 	mask = /obj/item/clothing/mask/balaclava/inteq
 	dcoat = /obj/item/clothing/suit/hooded/wintercoat/security/inteq
-	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/color/yellow
-	belt = /obj/item/storage/belt/utility/full
 	belt = /obj/item/storage/belt/utility/chief/full
 	courierbag = /obj/item/storage/backpack/messenger/inteq
+	r_pocket = /obj/item/t_scanner
+
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
 
 //MARK: Инженегр
 /datum/outfit/job/cel/inteq/engineer
 	name = "IQ - Artificer"
 	jobtype = /datum/job/engineer
 	job_icon = "stationengineer"
+	id_assignment = "Artificer"
 
 	id = /obj/item/card/id/cel/inteq/artificer
-	ears = /obj/item/radio/headset/alt
 	uniform = /obj/item/clothing/under/syndicate/inteq/artificer
 	head = /obj/item/clothing/head/soft/inteq
-	shoes = /obj/item/clothing/shoes/combat
 	belt = /obj/item/storage/belt/utility/full/engi
 	r_pocket = /obj/item/t_scanner
+
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/cheap=1)

--- a/mod_celadon/outfit/code/nanotrasen/deforest_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/deforest_outfit.dm
@@ -6,14 +6,20 @@
 
 	id = /obj/item/card/id/cel/nanotrasen/deforest_cmo
 
+	belt = /obj/item/pda/heads/cmo
+
 /datum/outfit/job/cel/nanotrasen/scientist/deforest_researcher
 	name = "NT DeForest - Scientist"
 	job_icon = "scientist"
+
+	belt = /obj/item/pda/scientist
 
 	id = /obj/item/card/id/cel/nanotrasen/deforest_researcher
 
 /datum/outfit/job/cel/nanotrasen/scientist/deforest_researcher/genetic
 	name = "NT DeForest - Scientist Genetic"
+
+	belt = /obj/item/pda/geneticist
 
 /datum/outfit/job/cel/nanotrasen/scientist/deforest_researcher/roboticist
 	name = "NT DeForest - Scientist Roboticist"
@@ -25,6 +31,8 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/nanotrasen
 	ears = /obj/item/radio/headset/nanotrasen
 	glasses = /obj/item/clothing/glasses/welding
+	belt = /obj/item/storage/belt/utility/full
+	l_pocket = /obj/item/pda/roboticist
 
 	backpack_contents = list(/obj/item/weldingtool/hugetank)
 

--- a/mod_celadon/outfit/code/nanotrasen/nakamura_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/nakamura_outfit.dm
@@ -6,6 +6,8 @@
 
 	id = /obj/item/card/id/cel/nanotrasen/nakamura_ce
 
+	l_pocket = /obj/item/pda/heads/ce
+
 // MARK: Command
 
 /datum/outfit/job/cel/nanotrasen/quartermaster/nakamura
@@ -14,6 +16,8 @@
 
 	id = /obj/item/card/id/cel/nanotrasen/nakamura_command
 
+	belt = /obj/item/pda/quartermaster
+
 // MARK: Crew
 
 /datum/outfit/job/cel/nanotrasen/atmos/nakamura
@@ -21,6 +25,9 @@
 	job_icon = "atmospherictechnician"
 
 	id = /obj/item/card/id/cel/nanotrasen/nakamura_atmostechnic
+
+	belt = /obj/item/storage/belt/utility/atmostech
+	l_pocket = /obj/item/pda/atmos
 
 /datum/outfit/job/cel/nanotrasen/engineer/nakamura
 	name = "NT Nakamura - Engineer"

--- a/mod_celadon/outfit/code/nanotrasen/nakamura_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/nakamura_outfit.dm
@@ -3,10 +3,16 @@
 /datum/outfit/job/cel/nanotrasen/ce/nakamura
 	name = "NT Nakamura - Cheif of Engineer"
 	job_icon = "chiefengineer"
+	jobtype = /datum/job/captain
 
 	id = /obj/item/card/id/cel/nanotrasen/nakamura_ce
 
 	l_pocket = /obj/item/pda/heads/ce
+
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
+	courierbag = /obj/item/storage/backpack/messenger/engi
 
 // MARK: Command
 
@@ -29,11 +35,21 @@
 	belt = /obj/item/storage/belt/utility/atmostech
 	l_pocket = /obj/item/pda/atmos
 
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
+	courierbag = /obj/item/storage/backpack/messenger/engi
+
 /datum/outfit/job/cel/nanotrasen/engineer/nakamura
 	name = "NT Nakamura - Engineer"
 	job_icon = "stationengineer"
 
 	id = /obj/item/card/id/cel/nanotrasen/nakamura_engineer
+
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
+	courierbag = /obj/item/storage/backpack/messenger/engi
 
 // MARK: Assistant
 

--- a/mod_celadon/outfit/code/nanotrasen/nslogistic_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/nslogistic_outfit.dm
@@ -14,11 +14,15 @@
 
 	id = /obj/item/card/id/cel/nanotrasen/nslogistic_rd
 
+	belt = /obj/item/pda/heads/rd
+
 /datum/outfit/job/cel/nanotrasen/quartermaster/nslogistic
 	name = "NT N+S Logistic - Quartermaster"
 	job_icon = "quartermaster"
 
 	id = /obj/item/card/id/cel/nanotrasen/nslogistic_quartermaster
+
+	belt = /obj/item/pda/quartermaster
 
 // MARK: Crew
 
@@ -27,6 +31,8 @@
 	job_icon = "shaftminer"
 
 	id = /obj/item/card/id/cel/nanotrasen/nslogistic_miner
+
+	belt = /obj/item/pda/shaftminer
 
 /datum/outfit/job/cel/nanotrasen/cargo_tech/nslogistic
 	name = "NT N+S Logistic - Cargo Tech"

--- a/mod_celadon/outfit/code/nanotrasen/vigilitas_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/vigilitas_outfit.dm
@@ -1,10 +1,10 @@
 // MARK: Captain
 
 /datum/outfit/job/cel/nanotrasen/captain/vigilitas
-	name = "NT Vigilitas - Leutenant"
+	name = "NT Vigilitas - Leutenant (Darect Captain)"
 	job_icon = "clip_cmm6"
 
-	jobtype = /datum/job/hos
+	jobtype = /datum/job/captain
 
 	id = /obj/item/card/id/cel/nanotrasen/vigilitas_leutenant
 
@@ -36,7 +36,7 @@
 	name = "NT Vigilitas - Sergeant"
 	job_icon = "clip_cmm5"
 
-	jobtype = /datum/job/warden
+	jobtype = /datum/job/hos
 
 	id = /obj/item/card/id/cel/nanotrasen/vigilitas_sergeant
 	belt = /obj/item/pda/heads/hos

--- a/mod_celadon/outfit/code/pirate/ramzi.dm
+++ b/mod_celadon/outfit/code/pirate/ramzi.dm
@@ -6,7 +6,7 @@
 	uniform = /obj/item/clothing/under/syndicate/ramzi
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/pirate
+	ears = /obj/item/radio/headset/pirate/alt
 	neck = /obj/item/clothing/neck/dogtag/ramzi
 	id = /obj/item/card/id/cel/ramzi
 	box = /obj/item/storage/box/survival/ramzi
@@ -38,7 +38,6 @@
 	ears = /obj/item/radio/headset/pirate/alt/captain
 	head = /obj/item/clothing/head/ramzi/beret
 	suit = /obj/item/clothing/suit/armor/ramzi/officer
-	belt = /obj/item/storage/belt/security/webbing/ramzi
 
 /datum/outfit/job/cel/pirate/ramzi/trooper
 	job_icon = "pirate"
@@ -49,6 +48,7 @@
 
 	id = /obj/item/card/id/cel/ramzi/commando
 
+	belt = /obj/item/storage/belt/security/webbing/ramzi
 	l_pocket = /obj/item/flashlight/seclite
 
 //MARK: RAMZI PIRATE
@@ -59,7 +59,7 @@
 	uniform = /obj/item/clothing/under/syndicate/ramzi
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/pirate
+	ears = /obj/item/radio/headset/pirate/alt
 	box = /obj/item/storage/box/survival/ramzi
 	id = /obj/item/card/id
 

--- a/mod_celadon/outfit/code/pirate/ramzi.dm
+++ b/mod_celadon/outfit/code/pirate/ramzi.dm
@@ -6,7 +6,7 @@
 	uniform = /obj/item/clothing/under/syndicate/ramzi
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/pirate/alt
+	ears = /obj/item/radio/headset/pirate
 	neck = /obj/item/clothing/neck/dogtag/ramzi
 	id = /obj/item/card/id/cel/ramzi
 	box = /obj/item/storage/box/survival/ramzi
@@ -30,6 +30,7 @@
 
 	id_assignment = "Battle Master"
 	jobtype = /datum/job/captain
+	faction_icon = "bg_pirate"
 	job_icon = "piratecaptain"
 
 	id = /obj/item/card/id/cel/ramzi/battlemaster
@@ -37,16 +38,16 @@
 	ears = /obj/item/radio/headset/pirate/alt/captain
 	head = /obj/item/clothing/head/ramzi/beret
 	suit = /obj/item/clothing/suit/armor/ramzi/officer
+	belt = /obj/item/storage/belt/security/webbing/ramzi
 
 /datum/outfit/job/cel/pirate/ramzi/trooper
-	job_icon = "assistant"
+	job_icon = "pirate"
 	name = "Ramzi Clique Rondo - Commando"
 
 	id_assignment = "Commando"
 	jobtype = /datum/job/officer
 
 	id = /obj/item/card/id/cel/ramzi/commando
-	belt = /obj/item/storage/belt/security/webbing/ramzi
 
 	l_pocket = /obj/item/flashlight/seclite
 
@@ -58,8 +59,8 @@
 	uniform = /obj/item/clothing/under/syndicate/ramzi
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset/pirate/alt
-	box = /obj/item/storage/box/survival
+	ears = /obj/item/radio/headset/pirate
+	box = /obj/item/storage/box/survival/ramzi
 	id = /obj/item/card/id
 
 	faction_icon = "bg_pirate"
@@ -90,6 +91,8 @@
 
 /datum/outfit/job/cel/pirate/ramzi/captain
 	name = "Ramzi Clique - Captain"
+
+	faction_icon = "bg_pirate"
 	job_icon = "piratecaptain"
 
 	jobtype = /datum/job/captain


### PR DESCRIPTION
## Описание / Что этот PR делает
Чиним и дополняем пробелы в аутфитах НТ, Интек и ИНД
## Причина создания ПР / Почему это хорошо для игры
Красиво и логично = хорошо
Closed #2451

## Демонстрация изменений / Тестирование

Добавил ПДА research ибо их е было почему-то у оффов (наверное, потому что нет картриджа под ресерч, выдал химик картридж)
<details><summary>Чиним отсутствующие ПДА у некоторых ролей НТ и выдаём инж пояса</summary>
<img width="279" height="654" alt="image" src="https://github.com/user-attachments/assets/e9186c3d-6344-4369-8ed0-a0c1468e855a" />
<img width="453" height="608" alt="image" src="https://github.com/user-attachments/assets/a7372210-6fa5-4adf-ac3c-20d8a75e4c4f" />
<img width="490" height="591" alt="image" src="https://github.com/user-attachments/assets/75b17904-1bde-4353-b5ff-13bcd1ed99f8" />
<img width="385" height="219" alt="image" src="https://github.com/user-attachments/assets/60e4a185-13f4-4299-9781-656b4ebf100a" />
</details>

<details><summary>Чиним отображение и лодаут Рамзи с Рондо, а таке слегка их нерфим по просьбе в другом ПРе</summary>
1.кэпу боуман и разгруз

2.комбатасам убрать разгруз и выдать обычный пират наушник

3.починить коробки

4.починить иконки ролей

<img width="160" height="105" alt="image" src="https://github.com/user-attachments/assets/19f7e623-2db5-47b3-a44a-7b4818e64681" />
<img width="574" height="664" alt="image" src="https://github.com/user-attachments/assets/e25bb65a-bc52-4bec-b0d0-3fc8c6485095" />
<img width="706" height="631" alt="image" src="https://github.com/user-attachments/assets/ef7f3f2b-5b1a-4c47-a606-7b21413d361a" />
</details>

## Список изменений
НТ выданы ПДА, где они были потеряны. Роли чет еще
Интек - наушники, комбат бутсы, балаклавы, сьюты.
Рамзи Рондд - иконки, коробки, разгрузки, наушники
```yml
🆑
add: Что-то добавлено
tweak: Что-то изменено по мелочи
fix: Что-то исправлено
/🆑
```
