### PR TITLE
FIX: Отсутствие галстуков и шемагов на персонаже

### DIFF
--- a/mod_celadon/fixes/code/icons.dm
+++ b/mod_celadon/fixes/code/icons.dm
@@ -25,3 +25,58 @@
 /obj/item/clothing/head/helmet/space/hardsuit/cult
 	icon_state = "cult_helmet"
 	item_state = "cult_helmet"
+
+// MARK: Шемаги
+
+/obj/item/clothing/neck/shemagh
+	item_state = "shemagh"
+
+/obj/item/clothing/neck/shemagh/khaki
+	item_state = "shemagh_khaki"
+
+/obj/item/clothing/neck/shemagh/olive
+	item_state = "shemagh_olive"
+
+/obj/item/clothing/neck/shemagh/brown
+	item_state = "shemagh_brown"
+
+/obj/item/clothing/neck/shemagh/black
+	item_state = "shemagh_black"
+
+// MARK: Галстуки
+
+/obj/item/clothing/neck/tie/blue
+	item_state = "bluetie"
+
+/obj/item/clothing/neck/tie/red
+	item_state = "redtie"
+
+/obj/item/clothing/neck/tie/black
+	item_state = "blacktie"
+//
+/obj/item/clothing/neck/tie/orange
+	item_state = "orangetie"
+
+/obj/item/clothing/neck/tie/light_blue
+	item_state = "lightbluetie"
+
+/obj/item/clothing/neck/tie/purple
+	item_state = "purpletie"
+
+/obj/item/clothing/neck/tie/green
+	item_state = "greentie"
+
+/obj/item/clothing/neck/tie/brown
+	item_state = "browntie"
+//
+/obj/item/clothing/neck/tie/rainbow
+	item_state = "rainbow_tie"
+
+/obj/item/clothing/neck/tie/horrible
+	item_state = "horribletie"
+
+/obj/item/clothing/neck/tie/detective
+	item_state = "detective"
+
+/obj/item/clothing/neck/maid
+	item_state = "maid_neck"


### PR DESCRIPTION
## Описание / Что этот PR делает
Делает так что теперь галстуки и шемаги отобразятся на кукле. Кроме т р а н с шмоток

## Причина создания ПР / Почему это хорошо для игры
Closed: https://canary.discord.com/channels/1100198143456465067/1430200238777565244

## Демонстрация изменений / Тестирование
<img width="544" height="448" alt="image" src="https://github.com/user-attachments/assets/94ff0416-6065-46e1-8b7b-b90762dd1b48" />

<img width="560" height="417" alt="image" src="https://github.com/user-attachments/assets/0233e850-fce8-453e-94c3-695d1b385049" />


## Список изменений

```yml
🆑
add: недостающие атрибуты объектам
/🆑
```
