### PR TITLE
ALPHA-FIX: Замена сбойного шлема М10

### DIFF
--- a/mod_celadon/outfit/code/inteq/_outfit.dm
+++ b/mod_celadon/outfit/code/inteq/_outfit.dm
@@ -157,7 +157,7 @@
 	id_assignment = "Enforcer"
 
 	id = /obj/item/card/id/cel/inteq/enforcer
-	head = /obj/item/clothing/head/helmet/m10/inteq
+	head = /obj/item/clothing/head/helmet/bulletproof/m10
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	belt = /obj/item/storage/belt/security/webbing/inteq
 	mask = /obj/item/clothing/mask/balaclava/inteq


### PR DESCRIPTION
## Описание / Что этот PR делает
Убирает сбойный путь в аутфите на шлем М10

## Причина создания ПР / Почему это хорошо для игры
Альфа не собирается

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
tweak: путь на другой путь к шлему м10
/🆑
```
