### PR TITLE
FIX: Возможность снять проклятую маску бизнесмена у кепори

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -143,6 +143,10 @@
 	//Blocks all items that are equippable to other slots. (block anything with a flag that ISN'T item_slot_mask)
 	if(I.slot_flags && !ITEM_SLOT_KEPORI_BEAK)	// [CELADON-EDIT] - CELADON_FIXES - Было if(I.slot_flags & ~ITEM_SLOT_KEPORI_BEAK)
 		return FALSE
+	// [CELADON-ADD] - FIXES_MASK_ON_KEPORI
+	if(HAS_TRAIT(H.wear_mask, TRAIT_NODROP))
+		return FALSE
+	// [/CELADON-ADD]
 	if(H.wear_mask && !swap)
 		return FALSE
 	if(I.w_class > WEIGHT_CLASS_SMALL)

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -352,6 +352,9 @@ FIXES_CQC_GRAB
 FIXES_DEL_FISH
 - `code/modules/fishing/fish/_fish.dm` : Фиксим удаление рыбы после повторной разделки
 
+FIXES_MASK_ON_KEPORI
+- `code/modules/mob/living/carbon/human/species_types/kepori.dm` : Добавляем проверку на проклятость маски для кепори
+
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Оказывается у кепори не было проверки на трейт NODROP у масок. И кепори мог сломать игру, просто сняв маску применив экипировать предмет

## Причина создания ПР / Почему это хорошо для игры
Closed: https://canary.discord.com/channels/1100198143456465067/1431618237266788492

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: проверка на трейт наличия у масок NODROPE
```
