### PR TITLE
FIX: Стрелы не взрываются более как пули от огня

### DIFF
--- a/mod_celadon/fixes/code/ammo.dm
+++ b/mod_celadon/fixes/code/ammo.dm
@@ -24,3 +24,8 @@
 	var/datum/component/movable_physics/physics = GetComponent(/datum/component/movable_physics)
 	if(physics)
 		qdel(physics)
+
+// FIXES_ARROW_FIRE - Стрелы не должны взрываться в огне как пули
+/obj/item/ammo_casing/caseless/arrow/fire_act(exposed_temperature, exposed_volume)
+	qdel(src)
+	return TRUE


### PR DESCRIPTION
## Описание / Что этот PR делает
Прописываем поведение стрелам, как быть если те попали в огонь. Они сгорают, а не взрываются как пули

## Причина создания ПР / Почему это хорошо для игры
Closed: #2454 

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: act_fire для стрел
/🆑
```
