### PR TITLE
FIX: Сбойный медбот не могущий найти путь до пациента

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -403,7 +403,7 @@
 		return
 
 	//Patient has moved away from us!
-	else if(patient && path && path.len && (get_dist(patient,path[path.len]) > 2))	// [CELADON-EDIT] - FIXES_MEDBOT_RUNTIME_PATH_NULL \\ else if(patient && path.len && (get_dist(patient,path[path.len]) > 2))
+	else if(patient && path && path.len && (get_dist(patient,path[path.len]) > 2))
 		path = list()
 		mode = BOT_IDLE
 		last_found = world.time
@@ -412,12 +412,12 @@
 		soft_reset()
 		return
 
-	if(patient && (!path || path.len == 0) && (get_dist(src,patient) > 1))	// [CELADON-EDIT] - FIXES_MEDBOT_RUNTIME_PATH_NULL \\ if(patient && path.len == 0 && (get_dist(src,patient) > 1))
+	if(patient && (!path || path.len == 0) && (get_dist(src,patient) > 1))	// [CELADON-EDIT] - FIXES_MEDBOT_RUNTIME_PATH_NULL \\ if(patient && path.len == 0 && (get_dist(src,patient) > 1)) \\ ORIGINAL
 		path = get_path_to(src, patient, 30,id=access_card)
 		mode = BOT_MOVING
-		if(!path.len) //try to get closer if you can't reach the patient directly
+		if(path && path.len == 0) 	// [CELADON-EDIT] - FIES_MEDBOT_RUNTIME_PATH_NULL \\ if(!path.len) //try to get closer if you can't reach the patient directly \\ ORIGINAL
 			path = get_path_to(src, patient, 30,1,id=access_card)
-			if(!path.len) //Do not chase a patient we cannot reach.
+			if(path && path.len == 0)	// [CELADON-EDIT] - FIES_MEDBOT_RUNTIME_PATH_NULL \\ if(!path.len) //Do not chase a patient we cannot reach. \\ ORIGINAL
 				soft_reset()
 
 	if(path && path.len > 0 && patient)	// [CELADON-EDIT] - FIXES_MEDBOT_RUNTIME_PATH_NULL \\ if(path.len > 0 && patient)


### PR DESCRIPTION
## Описание / Что этот PR делает
Этому рантайму очень много дней и месяцев. Я его каждый раз вижу и каждый раз забываю его починить. Баг был в тмо что если медбот был заперт и он видел пациента которому нужно было оказать лечение, то он пытался найти путь к нему, но не мог и получал null путь. Из-за чего он спамил рантаймами каждый раз каждый тик.

Теперь не спамит

## Причина создания ПР / Почему это хорошо для игры
Старый баг с медиботом

## Демонстрация изменений / Тестирование

## Список изменений

```yml
🆑
add: проверки на null путь
/🆑
```
