### PR TITLE
FIX: Лагающий карпет в огне

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -326,9 +326,20 @@
  */
 /datum/proc/_SendSignal(sigtype, list/arguments)
 	var/target = comp_lookup[sigtype]
-	if(!length(target))
+	// [CELADON-EDIT] - FIXES_INFINITI_LOOP_CARPET_DEL - Водим проверки на несуществующие списки
+	// if(!length(target))
+	// 	var/datum/listening_datum = target
+	// 	return NONE | call(listening_datum, listening_datum.signal_procs[src][sigtype])(arglist(arguments))	// ORIGINAL
+	if(!target)
+		return NONE
+	if(!islist(target))
 		var/datum/listening_datum = target
-		return NONE | call(listening_datum, listening_datum.signal_procs[src][sigtype])(arglist(arguments))
+		if(listening_datum && listening_datum.signal_procs && listening_datum.signal_procs[src])
+			var/proc_ref = listening_datum.signal_procs[src][sigtype]
+			if(proc_ref)
+				return NONE | call(listening_datum, proc_ref)(arglist(arguments))
+		return NONE
+	// [/CELADON-EDIT]
 	. = NONE
 	// This exists so that even if one of the signal receivers unregisters the signal,
 	// all the objects that are receiving the signal get the signal this final time.
@@ -337,9 +348,19 @@
 	// This should be faster than doing `var/datum/listening_datum as anything in target` as it does not implicitly copy the list
 	for(var/i in 1 to length(target))
 		var/datum/listening_datum = target[i]
-		queued_calls.Add(listening_datum, listening_datum.signal_procs[src][sigtype])
+		// [CELADON-EDIT] - FIXES_INFINITI_LOOP_CARPET_DEL - Проверяем на остаточный сигнал, если там не список пришел
+		// queued_calls.Add(listening_datum, listening_datum.signal_procs[src][sigtype])	// ORIGINAL
+		if(listening_datum && listening_datum.signal_procs && listening_datum.signal_procs[src])
+			var/proc_ref = listening_datum.signal_procs[src][sigtype]
+			if(proc_ref)
+				queued_calls.Add(listening_datum, proc_ref)
+		// [/CELADON-EDIT]
 	for(var/i in 1 to length(queued_calls) step 2)
-		. |= call(queued_calls[i], queued_calls[i + 1])(arglist(arguments))
+		// [CELADON-EDIT] - FIXES_INFINITI_LOOP_CARPET_DEL
+		// . |= call(queued_calls[i], queued_calls[i + 1])(arglist(arguments))	// ORIGINAL
+		if(i + 1 <= length(queued_calls))
+			. |= call(queued_calls[i], queued_calls[i + 1])(arglist(arguments))
+		// [/CELADON-EDIT]
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -215,18 +215,19 @@
 	. = ..()
 	update_appearance()
 
-/turf/open/floor/carpet/update_icon()
-	. = ..()
-	if(!..())
-		return 0
-	if(!broken && !burnt)
-		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
-			QUEUE_SMOOTH(src)
-	else
-		make_plating()
-		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
-			QUEUE_SMOOTH_NEIGHBORS(src)
-
+// [CELADON-REMOVE] - FIXES_INFINITI_LOOP_CARPET_DEL - Убираем, ибо старый метод, берет от родителя который не чуть не хуже работает. Таже трава от него берет
+// /turf/open/floor/carpet/update_icon()
+// 	. = ..()
+// 	if(!..())
+// 		return 0
+// 	if(!broken && !burnt)
+// 		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+// 			QUEUE_SMOOTH(src)
+// 	else
+// 		make_plating()
+// 		if(smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
+// 			QUEUE_SMOOTH_NEIGHBORS(src)
+// [/CELADON-REMOVE]
 ///Carpet variant for mapping aid, functionally the same as parent after smoothing.
 /turf/open/floor/carpet/lone
 	icon_state = "carpet-0"

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -33,6 +33,7 @@ FIXES_MONKEY_STOPPED_DEAD
 FIXES_MONKEY_STOPPED_PICKPOCKET
 FIXES_ANTAG_NINJA
 FIXES_MEDBOT_RUNTIME_PATH_NULL
+FIXES_INFINITI_LOOP_CARPET_DEL
 <!--
   Название модпака прописными буквами, СОЕДИНЁННЫМИ_ПОДЧЁРКИВАНИЕМ,
   которое ты будешь использовать для обозначения файлов.
@@ -359,6 +360,9 @@ FIXES_HOLO_ESWORD
 FIXES_MASK_ON_KEPORI
 - `code/modules/mob/living/carbon/human/species_types/kepori.dm` : Добавляем проверку на проклятость маски для кепори
 
+FIXES_INFINITI_LOOP_CARPET_DEL
+- `code/game/turfs/open/floor/fancy_floor.dm` 	: Убираем, ибо старый метод, берет от родителя который не чуть не хуже работает. Таже трава от него берет
+- `code/datums/components/_component.dm` 		: Обмазываем проверками на bad index который вызывается у всего что горит и не горит
 <!--
   Если вы редактировали какие-либо процедуры или переменные в кор коде,
   они должны быть указаны здесь.


### PR DESCRIPTION
## Описание / Что этот PR делает
Попытка починить лаги при горении ковра он же карпет, когда тот подвергался горению. 
- Вызывал три рантайма с ним, цикл при удалении и вставки объекта карпет туда сюда
- карпет просто не мог выйти из цикла вечного
- бэ индекс карпета, более высокий уровень вызова который выходил за границы всего

Огонь кстати у нас полноценный как у офов, с ним все гуд. По крайней мере, я спавнил 100 партиклов дыма и огня и ничего.

## Причина создания ПР / Почему это хорошо для игры
Попросили починить огонь

## Демонстрация изменений / Тестирование

Внизу показано поэтапное тестирование и изменение того что я делал:

<img width="1647" height="1000" alt="Screenshot_1" src="https://github.com/user-attachments/assets/d090a9cc-f67f-442e-abbe-91e1a3b9e49b" />
<img width="1843" height="993" alt="Screenshot_2" src="https://github.com/user-attachments/assets/b9b79385-ba38-4298-96e7-e6163c98596c" />
<img width="1919" height="995" alt="Screenshot_3" src="https://github.com/user-attachments/assets/71cf2979-c350-4098-b0f1-ffd845c0e8ae" />
<img width="1761" height="969" alt="Screenshot_4" src="https://github.com/user-attachments/assets/e8a14c0c-3108-4dc9-81ec-02e17f73801c" />
<img width="1838" height="989" alt="Screenshot_5" src="https://github.com/user-attachments/assets/ea2e0541-0d97-4386-b496-88a8aa40e249" />
<img width="1847" height="936" alt="Screenshot_6" src="https://github.com/user-attachments/assets/99cac573-2a14-404d-9860-37a047270ce6" />
<img width="1862" height="950" alt="Screenshot_7" src="https://github.com/user-attachments/assets/046c55e3-a34c-4641-9135-87f8c87efc2e" />
<img width="1035" height="667" alt="Screenshot_8" src="https://github.com/user-attachments/assets/40cf0f3a-a2c0-4ace-bd55-fcbdcd660c8b" />

Это финальный тест, снизу, во время теста я получил ошибку стака плазмы, но это из-за асинхронного вызова, которую можно получить во время билд мода админского если быстро кликать по турфам

<img width="1912" height="976" alt="Screenshot_9" src="https://github.com/user-attachments/assets/3f8883e7-c812-4d83-a903-d7a9b2f8a122" />
<img width="1817" height="1022" alt="Screenshot_10" src="https://github.com/user-attachments/assets/0c864e4d-cbee-4428-b038-dd492590aa9a" />

Как видно, никаких рантаймов почти нету

## Список изменений

```yml
🆑
add: проверки на дурака, нет ли пустого списка, пустых элемов и т.д. в компоненте
del: старый метод обновления ковра при горения его. Берет прок от родителя теперь
/🆑
```
