### PR TITLE
FIX MAP: НЛО в космосе около астероидного аванпоста

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -1094,11 +1094,6 @@
 	},
 /turf/open/floor/wood,
 /area/outpost/vacant_rooms/office)
-"aNr" = (
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "aOE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -1337,18 +1332,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned/grid,
 /area/outpost/hallway/fore)
-"aYe" = (
-/obj/item/paper/crumpled{
-	default_raw_text = "Записка содержит небольшую переписку работника дизайнера и боссом компании по выпуску торговых автоматов. Б: Я тебе запрещаю, выпускать такие пузатые автоматы! Они не красивые, уродские! Р: Но вы только посмотрите на этот тонкий арт, цветущая сакура, иероглиф, ну умиротворение же скажите? Б: Нет! И нет! Никакие жирные кабаны не будут на моей территории! Р: А если я скажу что художник готов внести пожертвование в общее дело а? Б: Ааа! Благотворительность, ну что ж ты так сразу н есказал! Давай сюда патент подпишу.";
-	pixel_x = 6;
-	pixel_y = 23;
-	layer = 2.8;
-	name = "Придавленный листок бумажки"
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "aYp" = (
 /obj/effect/turf_decal/number/right_one{
 	icon_state = "6"
@@ -3699,16 +3682,6 @@
 	},
 /turf/open/floor/wood,
 /area/outpost/hallway/central)
-"cxP" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "czl" = (
 /obj/machinery/door/airlock/command{
 	name = "Council Chamber";
@@ -3935,14 +3908,6 @@
 	},
 /turf/open/floor/carpet,
 /area/outpost/crew/library)
-"cFr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "cFz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -4270,27 +4235,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
-"cPA" = (
-/obj/structure/neon_spline/green{
-	dir = 4;
-	opacity = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1;
-	layer = 2.89
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_y = -12
-	},
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_y = -7
-	},
-/obj/structure/sign/flag/elysium/directional/west,
-/turf/open/floor/plating/asteroid/dirt/grass,
-/area/space)
 "cPD" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -5075,11 +5019,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/outpost/security)
-"dom" = (
-/obj/structure/table/scrap,
-/obj/effect/spawner/random/celadon_drink,
-/turf/open/floor/plasteel/tech,
-/area/space)
 "doq" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
@@ -5268,22 +5207,6 @@
 /obj/structure/girder,
 /turf/open/space/basic,
 /area/outpost/external)
-"dwx" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/ywflowers/hell,
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = 10
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/neon_spline/green{
-	opacity = 1
-	},
-/turf/open/floor/plating/asteroid/dirt/grass,
-/area/space)
 "dwF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -7603,20 +7526,6 @@
 /obj/structure/curtain/cloth/elysium,
 /turf/open/floor/wood,
 /area/outpost/crew/library)
-"eQm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "eRe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7777,9 +7686,6 @@
 /area/ruin/beach/complex{
 	name = "Elysium Town"
 	})
-"eXI" = (
-/turf/closed/indestructible/reinforced,
-/area/space)
 "eYi" = (
 /obj/machinery/light/colored/orange{
 	dir = 1;
@@ -11107,9 +11013,6 @@
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
-"hiX" = (
-/turf/closed/indestructible/wood,
-/area/space)
 "hjI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -12407,22 +12310,6 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
-"hZX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light_switch{
-	pixel_y = 23;
-	pixel_x = -10
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "iad" = (
 /obj/effect/turf_decal/corner/opaque/neutral/half,
 /obj/machinery/computer/mission{
@@ -13604,12 +13491,6 @@
 	},
 /turf/open/floor/plasteel/dark_2,
 /area/outpost/fraction/syndi)
-"iOy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "iOC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -15513,17 +15394,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
-"kbw" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "kbD" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -16596,23 +16466,6 @@
 	},
 /turf/open/floor/plating,
 /area/outpost/hallway/central)
-"kFN" = (
-/obj/effect/turf_decal/industrial/warning/fulltile,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass,
-/turf/open/floor/plasteel/tech,
-/area/space)
 "kFR" = (
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning{
 	dir = 9
@@ -17678,13 +17531,6 @@
 /obj/structure/railing/corner/wood,
 /turf/open/floor/concrete/slab_4,
 /area/outpost/hallway/central)
-"lpL" = (
-/obj/structure/table/scrap,
-/obj/item/lighter/zippo/rainbow,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "lpQ" = (
 /obj/effect/turf_decal/elysium_logo/three_three,
 /turf/open/floor/plasteel/dark,
@@ -17834,17 +17680,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/tech/techmaint,
 /area/outpost/engineering/atmospherics)
-"lwm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/scrap,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "lwE" = (
 /obj/structure/closet/secure_closet/ertSec,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -18232,13 +18067,6 @@
 /obj/structure/chair/sofa/red/right/directional/north,
 /turf/open/floor/glass/red_four,
 /area/outpost/fraction/syndi)
-"lKe" = (
-/obj/structure/table/scrap,
-/obj/effect/spawner/random/celadon_drink,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "lKm" = (
 /obj/structure/flora/grass/both,
 /turf/open/floor/grass/snow/safe,
@@ -19327,18 +19155,6 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/central)
-"mrH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera/autoname{
-	dir = 1;
-	pixel_y = -5;
-	network = list("outpostelysium")
-	},
-/obj/machinery/vending/clothing{
-	all_items_free = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "mso" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/wood{
@@ -19529,16 +19345,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/mono/dark,
 /area/outpost/crew/lounge/cab_1)
-"mCl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "mCp" = (
 /obj/structure/table/reinforced,
 /obj/item/trash/chips{
@@ -20746,16 +20552,6 @@
 /obj/machinery/computer/outpost_export_console,
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/nanotrasen)
-"nuC" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/brflowers{
-	opacity = 1
-	},
-/obj/structure/neon_spline/green{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/dirt/grass,
-/area/space)
 "nuK" = (
 /obj/effect/turf_decal/corner/transparent/blue{
 	dir = 6
@@ -21037,14 +20833,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/outpost/fraction/solfed)
-"nFY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "nGr" = (
 /obj/structure/sink/kitchen{
 	pixel_y = -5;
@@ -21460,24 +21248,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/outpost/fraction/nanotrasen)
-"nZk" = (
-/obj/structure/flora/ausbushes/brflowers{
-	pixel_y = -6;
-	pixel_x = 3
-	},
-/obj/structure/flora/ausbushes/ywflowers/hell{
-	pixel_y = -8;
-	pixel_x = 5
-	},
-/obj/structure/railing{
-	dir = 9;
-	layer = 2.89
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/dirt/grass,
-/area/space)
 "nZE" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -23332,14 +23102,6 @@
 	},
 /turf/open/floor/marble,
 /area/outpost/fraction/nanotrasen)
-"pir" = (
-/obj/machinery/airalarm/directional/east{
-	req_access_txt = "8100, 8111"
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "pix" = (
 /obj/effect/spawner/random/waste/mechwreck,
 /turf/open/floor/plating/asteroid/wasteplanet,
@@ -24726,12 +24488,6 @@
 	},
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
-"qdp" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe{
-	pixel_x = -1
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "qdE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -25652,12 +25408,6 @@
 /obj/structure/sign/elysium,
 /turf/closed/indestructible/reinforced,
 /area/outpost/security)
-"qHP" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/space)
 "qIt" = (
 /obj/item/radio/intercom/directional/north{
 	pixel_x = 11
@@ -26427,20 +26177,6 @@
 "rdL" = (
 /turf/open/floor/carpet/cyan,
 /area/outpost/operations)
-"rer" = (
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/apc/auto_name/directional/east{
-	req_access_txt = "8100, 8111"
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "rey" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -26813,12 +26549,6 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/plating,
 /area/outpost/maintenance/aft)
-"rsq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "rsw" = (
 /obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/plating/asteroid/rockplanet/lit,
@@ -27916,15 +27646,6 @@
 "saI" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/outpost/hallway/central)
-"sbv" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/brushed{
-	light_color = "#1B1D2E";
-	light_range = 2
-	},
-/area/space)
 "sbF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -29792,17 +29513,6 @@
 	},
 /turf/open/floor/plating,
 /area/outpost/exterior/ocean)
-"tuH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/machinery/vending/wardrobe/curator_wardrobe{
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "tuK" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -30245,12 +29955,6 @@
 	},
 /turf/open/floor/plasteel/rockvault,
 /area/outpost/hallway/central)
-"tLU" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "tMm" = (
 /obj/structure/railing,
 /obj/effect/decal/fakelattice{
@@ -31836,27 +31540,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
-"uLV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/scanner_gate{
-	locked = 1
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "uMa" = (
 /obj/structure/catwalk/over,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -32089,16 +31772,6 @@
 	},
 /turf/open/floor/concrete/tiles,
 /area/outpost/hallway/central)
-"uUm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 4;
-	pixel_x = -10;
-	network = list("outpostelysium")
-	},
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/tech,
-/area/space)
 "uVb" = (
 /turf/open/floor/wood/ebony,
 /area/outpost/fraction/solfed)
@@ -32313,10 +31986,6 @@
 /obj/machinery/computer/outpost_export_console,
 /turf/open/floor/plasteel/dark,
 /area/outpost/fraction/inteq)
-"vap" = (
-/obj/structure/table/scrap,
-/turf/open/floor/plasteel/tech,
-/area/space)
 "vaC" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 1
@@ -32833,14 +32502,6 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
-"vkI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "vkJ" = (
 /obj/effect/turf_decal/corner/transparent/blue/half,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -33074,12 +32735,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/outpost/fraction/syndi/donkco_shop)
-"vqV" = (
-/obj/machinery/vending/clothing/sakura,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "vrZ" = (
 /obj/effect/turf_decal/industrial/fire{
 	dir = 1
@@ -34181,17 +33836,6 @@
 	},
 /turf/open/floor/concrete/slab_3,
 /area/outpost/hallway/aft)
-"wdz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/obj/machinery/vending/wardrobe/law_wardrobe{
-	pixel_x = -16
-	},
-/obj/machinery/vending/wardrobe/det_wardrobe{
-	pixel_x = 5
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "wdO" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -34470,12 +34114,6 @@
 /area/ruin/beach/complex{
 	name = "Elysium Town"
 	})
-"wpL" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "wpO" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -34568,15 +34206,6 @@
 "wtK" = (
 /turf/closed/indestructible/reinforced,
 /area/outpost/crew/lounge)
-"wua" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/scrap,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "wuf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35156,16 +34785,6 @@
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/outpost/fraction/inteq)
-"wLR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/west,
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "wLW" = (
 /obj/structure/marker_beacon,
 /turf/open/space/basic,
@@ -35190,12 +34809,6 @@
 	},
 /turf/open/floor/plating,
 /area/outpost/exterior/ocean)
-"wNq" = (
-/obj/effect/spawner/structure/window/reinforced/indestructible,
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "wOh" = (
 /obj/machinery/vending/snack,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -35619,15 +35232,6 @@
 	},
 /turf/open/floor/grass,
 /area/outpost/hallway/fore)
-"xdX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/walnut{
-	planetary_atmos = 1
-	},
-/area/space)
 "xej" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 1
@@ -37069,17 +36673,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/outpost/hallway/fore)
-"ygT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/vending/wardrobe/chef_wardrobe{
-	pixel_x = 10
-	},
-/obj/machinery/vending/wardrobe/bar_wardrobe{
-	pixel_x = -11
-	},
-/turf/open/floor/plasteel/tech,
-/area/space)
 "yhB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -40493,14 +40086,14 @@ pdc
 pdc
 pdc
 pdc
-sbv
-nZk
-dwx
-hiX
-hiX
-hiX
-hiX
-eXI
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -40680,14 +40273,14 @@ pdc
 pdc
 pdc
 pdc
-sbv
-cPA
-nuC
-hiX
-vqV
-aYe
-hiX
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -40867,14 +40460,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-hiX
-hiX
-hiX
-hiX
-aNr
-tuH
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41054,14 +40647,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-tLU
-qHP
-wLR
-uUm
-aNr
-wdz
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41241,14 +40834,14 @@ pdc
 pdc
 pdc
 pdc
-wNq
-aNr
-aNr
-aNr
-aNr
-aNr
-qdp
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41428,14 +41021,14 @@ pdc
 pdc
 pdc
 pdc
-wNq
-aNr
-vap
-vap
-dom
-aNr
-mrH
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41615,14 +41208,14 @@ pdc
 pdc
 pdc
 pdc
-wNq
-aNr
-xdX
-rsq
-aNr
-nFY
-ygT
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41802,14 +41395,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-hZX
-mCl
-aNr
-aNr
-vkI
 pdc
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -41989,14 +41582,14 @@ pdc
 pdc
 pdc
 pdc
-kFN
-uLV
-eQm
-kbw
-iOy
-cFr
 pdc
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -42176,14 +41769,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-lpL
-lKe
-wua
-aNr
-aNr
 pdc
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -42363,14 +41956,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-aNr
-aNr
-lwm
-rsq
-aNr
 pdc
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -42550,14 +42143,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-wpL
-pir
-cxP
-rer
-aNr
 pdc
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc
@@ -42737,14 +42330,14 @@ pdc
 pdc
 pdc
 pdc
-hiX
-hiX
-hiX
-hiX
-hiX
-hiX
-hiX
-hiX
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
+pdc
 pdc
 pdc
 pdc


### PR DESCRIPTION
## Описание / Что этот PR делает
С каким-то ПРом наебнулся фикс карты, когда он в ноль ушел изменений. Данный фикс убирает некоторое строение возле аванпоста

## Причина создания ПР / Почему это хорошо для игры
Остатки шаблона плохо

## Демонстрация изменений / Тестирование
Вот это удалено
<img width="619" height="394" alt="image" src="https://github.com/user-attachments/assets/ad8b8018-3b17-4c1a-af17-7b34135f7da6" />


## Список изменений

```yml
🆑
map: Удалил дубликат магазина в космосе на астероидном аванпосту
/🆑
```
