### PR TITLE
FIX: Game Panel - Create Turf

### DIFF
--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -5,6 +5,6 @@
 		turfjs = jointext(typesof(/turf), ";")
 		create_turf_html = file2text('html/create_object.html')
 		create_turf_html = replacetext(create_turf_html, "Create Object", "Create Turf")
-		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
+		create_turf_html = replacetext(create_turf_html, "null; /* object types */", "\"[turfjs]\"")
 
 	user << browse(create_panel_helper(create_turf_html), "window=create_turf;size=425x475")


### PR DESCRIPTION
## Описание / Что этот PR делает
Позволяет спавнить турфы не через билд-мод, но и через гейм-панель.

## Причина создания ПР / Почему это хорошо для игры
Missed `;` in code - Game Panel fix create turf.
Fix PR from Pintest - Admins can look up turfs and spawn them again for reasons.

## Демонстрация изменений / Тестирование
<details><summary>Скриншот</summary>
<img width="412" height="500" alt="image" src="https://github.com/user-attachments/assets/6e6b48dc-1071-4cbb-848f-ba96dd6c4ce4" />
</details>

## Список изменений

```yml
🆑
fix: Game panel create turf list
/🆑
```
