### PR TITLE
ADD: Запрещаем мутантам заходить на корабли элизиумцев

### DIFF
--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -186,6 +186,8 @@
 			var/species_id = user.client?.prefs?.pref_species?.id
 			if(species_id != "human" && species_id != "ipc" && species_id != "lanius")
 				continue
+			if(user.client?.prefs?.features["tail_human"] != "None" || user.client?.prefs?.features["ears"] != "None")
+				continue
 		// [/CELADON-ADD]
 
 		var/list/ship_jobs = list()
@@ -226,6 +228,8 @@
 		if(T.faction.name == FACTION_ELYSIUM)
 			var/species_id = user.client?.prefs?.pref_species?.id
 			if(species_id != "human" && species_id != "ipc" && species_id != "lanius")
+				continue
+			if(user.client?.prefs?.features["tail_human"] != "None" || user.client?.prefs?.features["ears"] != "None")
 				continue
 		var/list/ship_data = list(
 			"name" = T.name,


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет 4 строчки кода, ответственные за запрет выбора корабля любым видом мутанта из человека.
## Причина создания ПР / Почему это хорошо для игры
Попросил Асура.

## Демонстрация изменений / Тестирование
<img width="1341" height="707" alt="image" src="https://github.com/user-attachments/assets/4f283d3d-ac6e-49d0-aa2e-5ab39dfb2aab" />

<details><summary>Детальное описание видов проверки на мутанта. Иншаллах</summary>
Виды "проверок" в книгах:
Физические тесты: Проверка на реакцию на радиацию, ультразвук, определённые химикаты.
Проявление способностей: Внезапное использование суперсилы, телепатии, телекинеза, исцеления.
Внешние признаки: Шрамы, необычные глаза, когти, измененная кожа, как у мутантов в "Метро 2033" или "Сталкерах".
Психологические тесты: Проверка на отсутствие страха, лояльность, способность к эмпатии или, наоборот, бесчувственность.
Социальные маркеры: В комиксах Marvel мутантов выявляют по наличию X-гена и проявлению способностей в подростковом возрасте, часто подвергаясь дискриминации. 
Примеры из литературы/игр:
«Метро 2033» (Дмитрий Глуховский): Проверка через выживание в условиях радиации, «природные» мутации сталкеров и мутантов как врагов.
«Сталкер» (Серия книг, основанная на игре): Зоны с артефактами и аномалиями, где мутация — естественный процесс.
Комиксы/Книги по Marvel: Проверка наличия мутации через обследования или проявление «крыльев»/«когтей» во время стресса.
Как это работает в сюжете:
Проверка на мутантов — это часто конфликт и двигатель сюжета, где герои вынуждены искать, скрывать или уничтожать «других», чтобы выжить. 
</details>

## Список изменений

```yml
🆑
add: мутанты больше не могут заходить на корабли сепаров

/🆑
```
