### PR TITLE
MAP: Add kitchen machine

### DIFF
--- a/_maps/_mod_celadon/shuttles/elysium/elysium_atlas.dmm
+++ b/_maps/_mod_celadon/shuttles/elysium/elysium_atlas.dmm
@@ -1862,13 +1862,14 @@
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/plasma,
 /obj/structure/table,
-/obj/item/melee/knife/kitchen{
-	pixel_x = -2;
-	pixel_y = 3
-	},
+/obj/item/plate/oven_tray,
 /obj/item/kitchen/rollingpin{
 	pixel_x = 4;
 	pixel_y = -4
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_x = -2;
+	pixel_y = 3
 	},
 /turf/open/floor/plating,
 /area/ship/crew)
@@ -2481,9 +2482,7 @@
 "An" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/plasma,
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
+/obj/machinery/griddle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "Av" = (
@@ -4636,6 +4635,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
 /obj/machinery/microwave,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/plating,
 /area/ship/crew)
 "WZ" = (

--- a/_maps/_mod_celadon/shuttles/elysium/elysium_khalifat.dmm
+++ b/_maps/_mod_celadon/shuttles/elysium/elysium_khalifat.dmm
@@ -669,7 +669,21 @@
 /turf/open/floor/plating,
 /area/ship/cargo)
 "dD" = (
-/obj/machinery/vending/boozeomat/syndicate_access,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/storage/box/ingredients/carnivore,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/green,
 /area/ship/crew/canteen)
@@ -1050,6 +1064,9 @@
 	dir = 5
 	},
 /obj/item/kirbyplants/dead,
+/obj/structure/railing{
+	dir = 5
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "fT" = (
@@ -1502,10 +1519,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/boozeomat/syndicate_access{
+	dir = 4;
+	pixel_x = -26;
+	density = 0
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken7";
 	color = "#332521"
@@ -1699,6 +1718,9 @@
 	dir = 4
 	},
 /obj/structure/curtain/cloth/elysium,
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "jr" = (
@@ -3023,22 +3045,8 @@
 /area/ship/science/ai_chamber)
 "qP" = (
 /obj/machinery/light/directional/north,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/storage/box/ingredients/carnivore,
-/obj/item/storage/box/ingredients/vegetarian,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/oven,
 /turf/open/floor/carpet/green,
 /area/ship/crew/canteen)
 "qQ" = (
@@ -5572,6 +5580,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/microwave{
+	pixel_y = 7;
+	pixel_x = -1
+	},
+/obj/structure/table/wood,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Fc" = (
@@ -6230,14 +6243,11 @@
 /turf/open/floor/plating/asteroid/dirt/grass/jungle,
 /area/ship/engineering/engine)
 "Ii" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/griddle,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Ik" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_beluga.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_beluga.dmm
@@ -1126,6 +1126,10 @@
 	dir = 10
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "lj" = (
@@ -1612,14 +1616,38 @@
 /area/ship/security)
 "pn" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 22;
+	pixel_x = -12
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/item/cutting_board{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/food/meat/slab/chicken{
+	pixel_x = -4
+	},
+/obj/item/food/meat/rawcutlet/chicken{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 4;
+	pixel_y = -5
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "pq" = (
@@ -2171,13 +2199,6 @@
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
-"uL" = (
-/obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/ship/crew/canteen)
 "vb" = (
 /obj/effect/turf_decal/steeldecal/steel_decals10{
 	dir = 9
@@ -2555,6 +2576,10 @@
 	pixel_x = -2;
 	pixel_y = 3
 	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 17;
+	pixel_x = -7
+	},
 /turf/open/floor/plasteel/sepia,
 /area/ship/crew/canteen)
 "yk" = (
@@ -2742,30 +2767,7 @@
 /area/ship/crew/canteen)
 "AU" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/item/cutting_board{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/structure/table,
-/obj/item/melee/knife/kitchen{
-	pixel_x = 11;
-	pixel_y = 7
-	},
-/obj/item/food/meat/slab/chicken{
-	pixel_x = -4
-	},
-/obj/item/food/meat/rawcutlet/chicken{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/obj/machinery/light_switch{
-	pixel_y = 22;
-	pixel_x = -12
-	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Bi" = (
@@ -3266,6 +3268,17 @@
 /obj/item/storage/fancy/egg_box{
 	pixel_y = -3;
 	pixel_x = -4
+	},
+/obj/item/sharpener{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -7;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -4090,7 +4103,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -4142,32 +4155,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
 "Nz" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 17;
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -7;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/firealarm/directional/west,
-/obj/item/sharpener{
-	pixel_x = 2
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 4;
-	pixel_y = -5
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "NB" = (
@@ -5784,7 +5777,7 @@ Sv
 Sv
 bD
 AU
-uL
+TQ
 TQ
 Pa
 jd

--- a/_maps/_mod_celadon/shuttles/independent/independent_beluga.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_beluga.dmm
@@ -2768,6 +2768,10 @@
 "AU" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/machinery/oven,
+/obj/item/plate/oven_tray{
+	pixel_x = 0;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Bi" = (
@@ -4843,8 +4847,24 @@
 	},
 /obj/structure/table/wood/reinforced,
 /obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 6;
-	pixel_y = -4
+	pixel_x = 12;
+	pixel_y = -15
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/sepia,
 /area/ship/crew/canteen)

--- a/_maps/_mod_celadon/shuttles/independent/independent_boyardee.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_boyardee.dmm
@@ -228,12 +228,13 @@
 /area/ship/storage)
 "ej" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/turf_decal/corner/opaque/white/half,
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
 "ep" = (
@@ -703,10 +704,9 @@
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/canteen/kitchen)
 "np" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/corner/opaque/white/half,
+/obj/machinery/oven,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen/kitchen)
 "ny" = (
@@ -2272,6 +2272,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/plasteel/mono,
 /area/ship/crew/canteen/kitchen)
 "Qm" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_caravan.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_caravan.dmm
@@ -211,16 +211,6 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -8
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 25
@@ -228,6 +218,8 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/machinery/chem_dispenser/drinks,
+/obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/ship/crew)
 "dQ" = (
@@ -831,11 +823,8 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew)
 "oA" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/item/melee/knife/kitchen,
-/obj/item/kitchen/rollingpin,
+/obj/effect/turf_decal/box,
+/obj/machinery/griddle,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew)
 "oH" = (
@@ -943,7 +932,9 @@
 /area/ship/bridge)
 "qN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave,
+/obj/effect/turf_decal/box,
+/obj/item/melee/knife/kitchen,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew)
 "qP" = (
@@ -1940,11 +1931,11 @@
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "Jy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/effect/turf_decal/box,
+/obj/machinery/oven,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew)
 "JM" = (
@@ -1985,6 +1976,8 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/sugar,
 /obj/item/reagent_containers/condiment/sugar,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/carpet/royalblue,
 /area/ship/crew)
 "JV" = (
@@ -2381,6 +2374,16 @@
 /area/ship/engineering/atmospherics)
 "Rx" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 5
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "Ry" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_junker.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_junker.dmm
@@ -331,6 +331,7 @@
 	dir = 1;
 	pixel_y = -8
 	},
+/obj/item/circuitboard/machine/griddle,
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)
 "gR" = (
@@ -2175,6 +2176,9 @@
 	pixel_y = -18;
 	dir = 1
 	},
+/mob/living/basic/cockroach/glockroach,
+/obj/effect/gibspawner/human/bodypartless,
+/mob/living/basic/cockroach/glockroach,
 /turf/open/floor/pod/light,
 /area/ship/maintenance/aft)
 "Qd" = (
@@ -2356,6 +2360,10 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
+/obj/item/circuitboard/machine/gibber,
+/mob/living/basic/cockroach/glockroach,
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/pod/light,
 /area/ship/maintenance/aft)
 "Vo" = (
@@ -2591,6 +2599,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 10
 	},
+/mob/living/basic/cockroach/glockroach,
+/mob/living/basic/cockroach/glockroach,
+/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/pod/light,
 /area/ship/maintenance/aft)
 "YT" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
@@ -1490,14 +1490,18 @@
 "iR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
-/obj/item/melee/knife/kitchen,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/item/kitchen/rollingpin,
 /obj/item/reagent_containers/condiment/enzyme,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/item/radio/intercom/directional/west,
+/obj/item/pizzabox,
+/obj/item/pizzabox,
+/obj/item/pizzabox,
+/obj/item/pizzabox,
+/obj/item/pizzabox,
+/obj/item/clothing/under/suit/waiter,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "iS" = (
@@ -2878,9 +2882,8 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/port)
 "qM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "qR" = (
@@ -7316,14 +7319,11 @@
 /area/ship/hallway/aft)
 "Sa" = (
 /obj/structure/table/reinforced,
-/obj/item/pizzabox,
-/obj/item/pizzabox,
-/obj/item/pizzabox,
-/obj/item/pizzabox,
-/obj/item/pizzabox,
-/obj/item/clothing/under/suit/waiter,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/machinery/light/directional/west,
+/obj/machinery/reagentgrinder,
+/obj/item/kitchen/rollingpin,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "Sg" = (
@@ -7665,6 +7665,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/ship/crew/chapel)
+"Un" = (
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/griddle,
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen/kitchen)
 "Uq" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9648,7 +9653,7 @@ pl
 Vg
 DB
 rz
-UO
+Un
 An
 bI
 KG

--- a/_maps/_mod_celadon/shuttles/independent/independent_mimos.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_mimos.dmm
@@ -3166,6 +3166,8 @@
 /obj/item/pickaxe/rusted,
 /obj/item/shovel,
 /obj/structure/spider/stickyweb,
+/obj/item/circuitboard/machine/oven,
+/obj/item/circuitboard/machine/griddle,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "JN" = (
@@ -3212,6 +3214,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	color = "#ab9980"
 	},
+/obj/item/plate/oven_tray,
 /turf/open/floor/wood/maple,
 /area/ship/crew/canteen)
 "Kd" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_mudskipper.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_mudskipper.dmm
@@ -192,6 +192,7 @@
 	name = "Engine Shutters"
 	},
 /obj/machinery/cell_charger,
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engine)
 "dN" = (
@@ -1313,6 +1314,7 @@
 	pixel_y = -4
 	},
 /obj/item/kitchen/rollingpin,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "yv" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
@@ -94,20 +94,13 @@
 "aN" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 1;
-	pixel_y = 1
-	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/computer/helm/viewscreen/directional/east{
 	dir = 2;
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/obj/machinery/microwave,
 /turf/open/floor/wood,
 /area/ship/crew/dorm/commad)
 "aP" = (
@@ -2781,16 +2774,13 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm/commad)
 "JG" = (
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/table/reinforced,
 /obj/structure/sign/poster/radio/soft{
 	pixel_y = -32
 	},
+/obj/machinery/oven,
 /turf/open/floor/wood,
 /area/ship/crew/dorm/commad)
 "JL" = (
@@ -2955,6 +2945,17 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 10;
+	pixel_x = -11
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -11;
+	pixel_y = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm/commad)
 "MM" = (
@@ -3232,9 +3233,8 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/security/armory)
 "Oc" = (
-/obj/machinery/microwave,
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/table/reinforced,
+/obj/machinery/griddle,
 /turf/open/floor/wood,
 /area/ship/crew/dorm/commad)
 "Oe" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_ramo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_ramo.dmm
@@ -1108,6 +1108,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "bP" = (
@@ -1760,6 +1761,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
+/obj/item/plate/oven_tray,
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
 "cU" = (
@@ -1917,8 +1919,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "de" = (
-/obj/structure/table/reinforced,
-/obj/structure/showcase/machinery/microwave,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "df" = (
@@ -1933,6 +1934,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/showcase/machinery/microwave,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "dg" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_ramo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_ramo.dmm
@@ -1108,7 +1108,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "bP" = (
@@ -1761,7 +1760,6 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/obj/item/plate/oven_tray,
 /turf/open/floor/carpet,
 /area/ship/crew/canteen)
 "cU" = (
@@ -1919,7 +1917,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "de" = (
-/obj/machinery/griddle,
+/obj/structure/table/reinforced,
+/obj/structure/showcase/machinery/microwave,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "df" = (
@@ -1934,7 +1933,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/showcase/machinery/microwave,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "dg" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
@@ -225,11 +225,16 @@
 /turf/open/floor/plasteel,
 /area/ship/construction)
 "dx" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	populate = 0
+	},
+/obj/item/storage/cans/sixbeer,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "dH" = (
@@ -251,7 +256,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/machinery/firealarm/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "ee" = (
@@ -959,6 +964,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
+/obj/item/circuitboard/machine/oven,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "mz" = (
@@ -1093,10 +1100,9 @@
 /turf/open/floor/plating,
 /area/ship/crew/office)
 "nU" = (
-/obj/structure/table,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/item/storage/cans/sixbeer,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "od" = (
@@ -1165,8 +1171,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "pv" = (
-/obj/structure/table,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/table,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "pD" = (
@@ -2518,14 +2525,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
-"Ei" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=cargo";
-	location = "canteen"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/turf/open/floor/plasteel/white,
-/area/ship/crew/canteen)
 "Em" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -2636,15 +2635,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/office)
 "FJ" = (
-/obj/structure/chair{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/chair/handrail{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/navbeacon/wayfinding/kitchen{
-	location = "Canteen";
-	name = "navigation beacon"
-	},
-/obj/effect/turf_decal/corner/opaque/yellow/diagonal,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "FO" = (
@@ -3381,11 +3380,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)
 "OK" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/effect/spawner/random/vending/snack,
+/obj/structure/table,
+/obj/item/storage/box/cups,
+/obj/machinery/newscaster/directional/west,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "ON" = (
@@ -3473,10 +3472,11 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ship/crew/canteen)
 "PA" = (
-/obj/structure/table,
-/obj/machinery/newscaster/directional/west,
-/obj/item/storage/box/cups,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "PB" = (
@@ -3484,11 +3484,11 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/medical)
 "PF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/table,
+/obj/item/cutting_board,
+/obj/item/kitchen/rollingpin,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "PV" = (
@@ -3629,7 +3629,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/chair/handrail{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "Ru" = (
@@ -3868,6 +3871,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/chair,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "TR" = (
@@ -4169,11 +4174,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "WO" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/structure/chair,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "WS" = (
@@ -4292,6 +4295,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
+/obj/effect/turf_decal/industrial/warning,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "YC" = (
@@ -4400,9 +4404,14 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/corner/opaque/yellow/diagonal,
-/obj/item/radio/intercom/directional/south,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -14
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "ZE" = (
@@ -4529,12 +4538,12 @@ gc
 Fu
 Ce
 aD
-db
+PF
 pv
 nU
 PA
-WO
 db
+WO
 OK
 tT
 rZ
@@ -4564,10 +4573,10 @@ bZ
 Ce
 dx
 Cc
-PF
-PF
-FJ
-Ei
+db
+db
+db
+db
 TO
 ZB
 tT
@@ -4599,7 +4608,7 @@ xR
 ab
 Rt
 dU
-IV
+FJ
 IV
 oV
 ID

--- a/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
@@ -2258,6 +2258,7 @@
 /obj/structure/curtain/cloth{
 	pixel_y = -32
 	},
+/obj/item/reagent_containers/glass/filter,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "HB" = (
@@ -2383,14 +2384,13 @@
 /turf/open/floor/carpet/blue,
 /area/ship/crew)
 "KO" = (
-/obj/item/reagent_containers/glass/filter,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/table,
 /obj/structure/curtain/cloth{
 	pixel_y = -32
 	},
+/obj/machinery/griddle,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "KS" = (
@@ -3159,7 +3159,6 @@
 /turf/open/floor/concrete/slab_3,
 /area/ship/crew/canteen)
 "WY" = (
-/obj/structure/table,
 /obj/structure/railing/wood{
 	color = "#543C30"
 	},
@@ -3170,6 +3169,7 @@
 	color = "#543C30";
 	dir = 8
 	},
+/obj/machinery/oven,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "Xc" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_shetland.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_shetland.dmm
@@ -420,10 +420,9 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
 "dD" = (
-/obj/machinery/vending/coffee{
-	all_items_free = 1
-	},
 /obj/machinery/light/directional/west,
+/obj/machinery/microwave,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "dK" = (
@@ -1890,14 +1889,21 @@
 /turf/open/floor/plasteel/sepia,
 /area/ship/engineering/engines/starboard)
 "td" = (
-/obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "th" = (
 /obj/structure/table,
 /obj/item/melee/knife/kitchen,
 /obj/item/cutting_board,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "ts" = (
@@ -2448,8 +2454,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	name = "Reactor";
-
+	name = "Reactor"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -4160,15 +4165,7 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "Ql" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -5;
-	pixel_y = 10
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Qm" = (
@@ -4549,9 +4546,7 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/hydroponics)
 "Tc" = (
-/obj/effect/spawner/random/vending/cola{
-
-	},
+/obj/effect/spawner/random/vending/cola,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Td" = (
@@ -4704,6 +4699,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/fore)
+"Ux" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/vending/coffee{
+	all_items_free = 1
+	},
+/turf/open/floor/plasteel,
+/area/ship/crew/canteen)
 "Uy" = (
 /obj/docking_port/stationary{
 	dwidth = 15;
@@ -6101,7 +6103,7 @@ kL
 zV
 Cs
 Ty
-vt
+Ux
 OK
 OK
 OK

--- a/_maps/_mod_celadon/shuttles/independent/independent_tranquility.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_tranquility.dmm
@@ -637,11 +637,17 @@
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -6;
-	pixel_y = 4
+/obj/item/cutting_board{
+	pixel_x = 3
 	},
-/obj/item/reagent_containers/glass/rag,
+/obj/item/kitchen/rollingpin{
+	pixel_y = -6;
+	pixel_x = 9
+	},
+/obj/item/melee/knife/butcher{
+	pixel_x = -10;
+	pixel_y = 13
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "fH" = (
@@ -1193,19 +1199,8 @@
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/melee/knife/butcher{
-	pixel_x = -10;
-	pixel_y = 13
-	},
 /obj/machinery/light/directional/west,
-/obj/item/cutting_board{
-	pixel_x = 3
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_y = -6;
-	pixel_x = 9
-	},
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "lk" = (
@@ -1505,6 +1500,15 @@
 	},
 /turf/open/floor/wood,
 /area/ship/crew/dorm/dormfive)
+"nV" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/wood,
+/area/ship/crew/canteen)
 "nX" = (
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/random/five,
@@ -1978,24 +1982,15 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/toilet)
 "rq" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 8
 	},
-/obj/structure/sink/chem{
-	dir = 1;
-	pixel_y = 4;
-	pixel_x = 2
-	},
-/obj/structure/sink/chem{
-	dir = 1;
-	pixel_y = -4;
-	pixel_x = 2
-	},
 /obj/machinery/light/directional/west,
+/obj/machinery/microwave,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "rs" = (
@@ -2225,13 +2220,13 @@
 /turf/open/floor/wood,
 /area/ship/crew/dorm/dormfive)
 "tE" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 8
 	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "tF" = (
@@ -3826,6 +3821,13 @@
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 8
 	},
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = -3
+	},
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "Fg" = (
@@ -4429,12 +4431,10 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/bag/tray/cafeteria{
-	pixel_y = -3
-	},
-/obj/item/storage/bag/tray/cafeteria,
-/obj/item/storage/bag/tray/cafeteria{
-	pixel_y = 3
+/obj/structure/sink/chem{
+	dir = 1;
+	pixel_y = -4;
+	pixel_x = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
@@ -4828,8 +4828,6 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Mi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave,
 /obj/effect/turf_decal/corner/transparent/bar{
 	dir = 4
 	},
@@ -4839,6 +4837,7 @@
 /obj/structure/sign/poster/official/moth{
 	pixel_x = -32
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen)
 "Mn" = (
@@ -7067,7 +7066,7 @@ Fq
 aA
 DV
 Cd
-Cd
+nV
 Cd
 Cd
 Cd

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm
@@ -2324,6 +2324,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "nZ" = (
@@ -6012,6 +6013,8 @@
 /obj/effect/turf_decal/corner/opaque/brown{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/plate/oven_tray,
 /obj/item/toy/figure/inteq{
 	pixel_x = -8
 	},
@@ -6019,7 +6022,6 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "IC" = (

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_hammerhead.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_hammerhead.dmm
@@ -606,7 +606,10 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/engine)
 "cD" = (
-/obj/machinery/deepfryer,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)
 "cM" = (
@@ -5102,10 +5105,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "FB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plastic,
 /area/ship/crew/canteen/kitchen)
 "FD" = (

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_talos.dmm
@@ -1776,6 +1776,7 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "hZ" = (
@@ -10726,6 +10727,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/light/directional/west,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "Yb" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_bolide.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_bolide.dmm
@@ -749,7 +749,7 @@
 /area/ship/engineering/engines/port)
 "gg" = (
 /obj/machinery/light/directional/south,
-/obj/structure/table/reinforced,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/ccommons)
 "gj" = (
@@ -4178,6 +4178,8 @@
 	pixel_x = -15
 	},
 /obj/structure/table/reinforced,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/ccommons)
 "Dd" = (
@@ -6805,8 +6807,8 @@
 /area/ship/crew/office)
 "Vd" = (
 /obj/structure/closet/wall/white/directional/south,
-/obj/item/storage/ration/crayons,
 /obj/structure/table/reinforced,
+/obj/item/storage/ration/crayons,
 /turf/open/floor/plasteel/mono/white,
 /area/ship/crew/ccommons)
 "Ve" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -1794,6 +1794,7 @@
 	pixel_x = 22;
 	pixel_y = 25
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "kF" = (
@@ -3352,8 +3353,8 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "tc" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "td" = (
@@ -4083,7 +4084,6 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "yh" = (
-/obj/structure/closet/secure_closet/freezer/meat,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
 /obj/item/reagent_containers/condiment/flour,
@@ -4091,6 +4091,7 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/milk,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "yj" = (
@@ -4158,7 +4159,6 @@
 "yD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
-/obj/item/melee/knife/butcher,
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable{
@@ -5931,6 +5931,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/item/cutting_board,
+/obj/item/melee/knife/butcher,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "JI" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_chariot.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_chariot.dmm
@@ -79,16 +79,16 @@
 /turf/open/floor/hangar/plasteel,
 /area/ship/hallway/central)
 "aJ" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/structure/table/reinforced,
+/obj/item/cutting_board{
+	pixel_x = -3;
+	pixel_y = 1
 	},
-/obj/structure/showcase/machinery/microwave{
-	pixel_x = 0;
-	pixel_y = 5;
-	name = "Ultra deluxe Nanotrasen-brand microwave"
+/obj/item/food/meat/slab/chicken{
+	pixel_x = -4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "aL" = (
 /obj/effect/turf_decal/industrial/warning,
@@ -2305,16 +2305,14 @@
 /area/ship/hangar)
 "un" = (
 /obj/machinery/light/directional/east,
-/obj/structure/table/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/item/melee/knife,
 /obj/item/kitchen/rollingpin{
 	pixel_x = 4;
 	pixel_y = -5
 	},
-/obj/item/melee/knife,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "uq" = (
 /obj/effect/turf_decal/siding/red{
@@ -2366,10 +2364,8 @@
 /turf/open/floor/plating/ship,
 /area/ship/engineering/atmospherics)
 "uL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "uN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -2858,11 +2854,12 @@
 "yH" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = 8;
-	pixel_y = 6
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/showcase/machinery/microwave{
+	pixel_x = 0;
+	pixel_y = 5;
+	name = "Ultra deluxe Nanotrasen-brand microwave"
+	},
 /turf/open/floor/wood,
 /area/ship/crew)
 "yM" = (
@@ -3243,10 +3240,8 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/flour,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "Cp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3265,21 +3260,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hangar)
 "Cv" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/item/food/meat/slab/chicken{
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/griddle,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "CD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/oven,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "CI" = (
 /obj/structure/cable{
@@ -3925,12 +3914,16 @@
 	pixel_y = 0
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = -2;
 	pixel_y = 11
+	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /turf/open/floor/carpet/green,
 /area/ship/crew)
@@ -4309,6 +4302,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating/ship,
 /area/ship/general/engineering/engineering_1)
+"Kp" = (
+/obj/machinery/griddle,
+/turf/template_noop,
+/area/template_noop)
 "Kv" = (
 /obj/effect/turf_decal/corner/opaque/mauve{
 	dir = 10
@@ -4443,10 +4440,8 @@
 	pixel_y = 8
 	},
 /obj/machinery/light/dim/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
 /area/ship/crew)
 "Li" = (
 /obj/effect/turf_decal/corner/opaque/mauve{
@@ -7324,7 +7319,7 @@ jU
 (31,1,1) = {"
 jU
 jU
-jU
+Kp
 jU
 jU
 jU

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_delta.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_delta.dmm
@@ -703,10 +703,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/port)
 "da" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "db" = (
@@ -1425,6 +1422,9 @@
 	pixel_y = 0;
 	density = 0;
 	all_items_free = 1
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
@@ -4917,13 +4917,13 @@
 /area/ship/security)
 "sb" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "sc" = (
@@ -5520,11 +5520,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/science/ai_chamber)
 "tG" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/processor,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "tI" = (
@@ -8057,6 +8057,10 @@
 "Dh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /obj/item/food/pie/cream,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
@@ -9612,20 +9616,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
 "Ip" = (
-/obj/structure/table,
-/obj/item/food/mint,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/condiment/sugar{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/beaker,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "Ix" = (
@@ -11582,12 +11576,26 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/aft)
 "Qg" = (
-/obj/machinery/processor,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/sugar{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/melee/knife/butcher{
+	pixel_x = 13
+	},
+/obj/item/melee/knife/kitchen,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "Qi" = (
@@ -12567,6 +12575,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
+/obj/item/food/dough,
+/obj/item/food/dough,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "TI" = (
@@ -13443,21 +13453,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "WX" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/food/dough,
-/obj/item/food/dough,
-/obj/item/kitchen/rollingpin,
-/obj/item/melee/knife/butcher{
-	pixel_x = 13
-	},
-/obj/item/melee/knife/kitchen,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen/kitchen)
 "WY" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_meta.dmm
@@ -2611,14 +2611,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo/office)
 "qh" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 11
-	},
 /obj/effect/turf_decal/corner/transparent/bar/diagonal,
-/obj/item/melee/knife{
-	pixel_x = 15;
-	pixel_y = 2
+/obj/structure/table,
+/obj/item/storage/box/cups{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 18;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 9;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/crew)
@@ -2668,22 +2673,14 @@
 /turf/template_noop,
 /area/template_noop)
 "qA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22";
-	pixel_y = 11;
-	pixel_x = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/wood/yew,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/transparent/bar/diagonal,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/crew)
 "qI" = (
 /obj/structure/cable{
@@ -2917,16 +2914,10 @@
 "ti" = (
 /obj/structure/table,
 /obj/effect/turf_decal/corner/transparent/bar/diagonal,
-/obj/item/storage/box/cups{
-	pixel_x = -4;
-	pixel_y = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/light/dim/directional/north,
-/obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_x = 9;
-	pixel_y = 4
-	},
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel/white,
 /area/ship/crew)
 "tl" = (
@@ -3793,11 +3784,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "CM" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
 /obj/effect/turf_decal/corner/transparent/bar/diagonal,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/ship/crew)
 "CO" = (
@@ -4394,16 +4382,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "Jc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	color = "#E3994E"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	color = "#E3994E"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood/yew,
+/obj/effect/turf_decal/corner/transparent/bar/diagonal,
+/turf/open/floor/plasteel/white,
 /area/ship/crew)
 "Jk" = (
 /obj/structure/curtain/cloth/grey,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_osprey.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_osprey.dmm
@@ -1226,16 +1226,13 @@
 /turf/open/floor/plasteel,
 /area/ship/hallway/central)
 "iD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 8
 	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "iI" = (
@@ -1771,10 +1768,6 @@
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/engineering/atmospherics)
 "lY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 4
 	},
@@ -1782,6 +1775,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "mf" = (
@@ -2231,6 +2225,7 @@
 /obj/item/clothing/under/nanotrasen,
 /obj/item/clothing/under/nanotrasen,
 /obj/item/clothing/under/nanotrasen,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/wood,
 /area/ship/crew/dorm)
 "oF" = (
@@ -4532,12 +4527,15 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "CT" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/opaque/white{
 	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
@@ -5571,6 +5569,9 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/glass/rag,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "JN" = (
@@ -7644,6 +7645,7 @@
 	dir = 8
 	},
 /obj/item/reagent_containers/glass/bowl,
+/obj/item/cutting_board,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "XK" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skipper.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skipper.dmm
@@ -1660,11 +1660,8 @@
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "kL" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/corner/opaque/green/mono,
-/obj/machinery/reagentgrinder{
-	pixel_y = 11
-	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "kM" = (
@@ -3058,6 +3055,9 @@
 /obj/item/seeds/potato{
 	pixel_x = -1;
 	pixel_y = 4
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 11
 	},
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -1563,8 +1563,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/structure/table/reinforced/titaniumglass,
-/obj/machinery/microwave,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "uu" = (
@@ -2542,6 +2541,8 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/drinkingglasses,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "Iz" = (
@@ -3174,18 +3175,7 @@
 	pixel_x = -5;
 	pixel_y = 3
 	},
-/obj/item/food/burger{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/food/burger/baconburger{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/food/burger/baconburger{
-	pixel_x = -3;
-	pixel_y = -4
-	},
+/obj/machinery/microwave,
 /turf/open/floor/plasteel/tech,
 /area/ship/crew/cryo)
 "Qv" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -257,9 +257,12 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo/port)
 "bk" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/thinplating/light,
-/obj/machinery/reagentgrinder,
+/obj/machinery/oven,
+/obj/item/plate/oven_tray{
+	pixel_x = 0;
+	pixel_y = 11
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "bo" = (
@@ -2372,6 +2375,20 @@
 	id = "delta2_cafe";
 	name = "window shutters"
 	},
+/obj/item/plate/large,
+/obj/item/plate,
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "xs" = (
@@ -3380,6 +3397,10 @@
 /obj/structure/sign/poster/official/focus{
 	pixel_x = -32;
 	pixel_y = 0
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -11;
+	pixel_y = 11
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -258,8 +258,8 @@
 /area/ship/cargo/port)
 "bk" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "bo" = (
@@ -2272,14 +2272,8 @@
 /turf/open/floor/plasteel/white,
 /area/ship/science)
 "wh" = (
-/obj/structure/table/reinforced,
-/obj/item/cutting_board{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/melee/knife/butcher,
 /obj/effect/turf_decal/siding/thinplating/light,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "wE" = (
@@ -2951,6 +2945,7 @@
 /obj/effect/turf_decal/siding/thinplating/light/corner{
 	dir = 4
 	},
+/obj/machinery/dish_drive,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Du" = (
@@ -3101,7 +3096,12 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/dish_drive,
+/obj/item/melee/knife/butcher,
+/obj/item/cutting_board{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "Gj" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_crying_sun.dmm
@@ -2493,7 +2493,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/frame/machine,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "wz" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -1662,6 +1662,9 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/circuitboard/machine/griddle,
+/obj/item/plate/oven_tray,
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/cargo)
 "SA" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_rondo.dmm
@@ -3769,6 +3769,9 @@
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 1
 	},
+/obj/item/circuitboard/machine/griddle,
+/obj/item/circuitboard/machine/oven,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "Zx" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_santiana.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_santiana.dmm
@@ -199,6 +199,7 @@
 /area/ship/cargo)
 "ax" = (
 /obj/effect/decal/cleanable/shreds,
+/obj/machinery/oven,
 /turf/open/floor/plasteel,
 /area/ship/crew/toilet)
 "ay" = (
@@ -227,35 +228,19 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/crew/toilet)
 "aB" = (
-/obj/structure/table,
-/obj/item/melee/knife/kitchen,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/condiment/soysauce{
-	pixel_x = 9
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/condiment/bbqsauce{
-	pixel_x = -8;
-	pixel_y = -5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/griddle,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "aC" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_x = 0;
 	pixel_y = 12
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "aD" = (
@@ -642,6 +627,14 @@
 	pixel_x = 1;
 	pixel_y = 15
 	},
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/melee/knife/kitchen,
+/obj/item/reagent_containers/condiment/soysauce{
+	pixel_x = 9
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "bl" = (
@@ -790,6 +783,14 @@
 	pixel_y = 16
 	},
 /obj/item/spacecash/bundle/c100,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -10;
+	pixel_y = -1
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "bu" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_stingray.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_stingray.dmm
@@ -2276,6 +2276,14 @@
 	pixel_x = 2;
 	pixel_y = 1
 	},
+/obj/item/storage/bag/tray,
+/obj/item/melee/knife/kitchen{
+	pixel_y = 9
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_y = 4;
+	pixel_x = 7
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/central)
 "uE" = (
@@ -3591,6 +3599,8 @@
 	pixel_y = 5;
 	pixel_x = 4
 	},
+/obj/item/circuitboard/machine/oven,
+/obj/item/plate/oven_tray,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/port)
 "JU" = (
@@ -4136,20 +4146,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/item/storage/bag/tray{
-	pixel_y = 18
-	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 9
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_y = 4;
-	pixel_x = 7
-	},
+/obj/machinery/griddle,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/hallway/central)
 "Qk" = (

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_tortuga.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_tortuga.dmm
@@ -2185,6 +2185,9 @@
 	pixel_y = 2;
 	pixel_x = -3
 	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/canteen)
 "CG" = (
@@ -2541,6 +2544,7 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 4
 	},
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/tech,
 /area/ship/maintenance/port)
 "Hk" = (
@@ -2839,14 +2843,11 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen)
 "Lb" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 5
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/patterned/grid,
 /area/ship/crew/canteen)
 "Ld" = (
@@ -3953,6 +3954,7 @@
 	},
 /area/ship/maintenance)
 "XM" = (
+/obj/item/plate/oven_tray,
 /obj/structure/table,
 /obj/item/food/nachos{
 	desc = "You're pretty sure these are stolen from an outpost."

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_cepheus.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_cepheus.dmm
@@ -2051,14 +2051,14 @@
 /area/ship/engineering/electrical)
 "zc" = (
 /obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27";
 	dir = 6
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "zn" = (
@@ -2550,6 +2550,9 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27"
 	},
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
+/obj/structure/table/wood,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "EB" = (
@@ -3628,6 +3631,15 @@
 	pixel_x = 8;
 	pixel_y = 22
 	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
+	pixel_x = -8;
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "Rt" = (
@@ -3900,9 +3912,6 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/atmospherics)
 "Vj" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
 /obj/structure/sink/kitchen{
 	dir = 1;
 	pixel_y = -12;
@@ -3911,6 +3920,7 @@
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27"
 	},
+/obj/machinery/griddle,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "Vl" = (
@@ -3984,30 +3994,21 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/dorm)
 "WN" = (
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27";
 	dir = 4
 	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "WQ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/condiment/peppermill{
-	desc = "Often used to flavor food or make people sneeze. Fashionably moved to the left side of the table.";
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 10
-	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27"
 	},
+/obj/machinery/oven,
 /turf/open/floor/wood/mahogany,
 /area/ship/hallway/central)
 "WU" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_chronicle.dmm
@@ -4871,7 +4871,6 @@
 /obj/structure/sign/poster/solgov/random{
 	pixel_x = -29
 	},
-/obj/structure/table,
 /obj/item/reagent_containers/glass/bowl{
 	pixel_y = 2;
 	pixel_x = -6
@@ -4913,6 +4912,7 @@
 	pixel_x = 8
 	},
 /obj/structure/closet/wall/white/directional/north,
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/canteen)
 "UH" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
@@ -4836,34 +4836,9 @@
 /turf/open/floor/plating,
 /area/ship/engineering/communications)
 "Fc" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab/chicken{
-	pixel_x = -4
-	},
-/obj/item/food/meat/slab/chicken{
-	pixel_x = -4
-	},
-/obj/item/food/meat/slab/chicken{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/griddle,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Fe" = (
@@ -6603,11 +6578,32 @@
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Tq" = (
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_x = 0;
-	pixel_y = 12
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/food/meat/slab/chicken{
+	pixel_x = -4
 	},
-/obj/structure/table/wood/fancy/blue,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/food/meat/slab/chicken{
+	pixel_x = -4
+	},
+/obj/item/food/meat/slab/chicken{
+	pixel_x = -4
+	},
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
 /turf/open/floor/wood,
 /area/ship/crew/canteen)
 "Tr" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
@@ -126,8 +126,13 @@
 /turf/open/floor/carpet/royalblue,
 /area/ship/bridge)
 "dD" = (
-/obj/machinery/vending/boozeomat/all_access,
+/obj/machinery/vending/boozeomat/all_access{
+	pixel_x = 25;
+	dir = 8
+	},
 /obj/machinery/light/directional/north,
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen/kitchen)
 "dH" = (
@@ -1110,9 +1115,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/hallway/central)
 "yl" = (
-/obj/structure/table/wood,
-/obj/item/melee/knife/kitchen,
-/obj/item/cutting_board,
+/obj/machinery/griddle,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen/kitchen)
 "yw" = (
@@ -1680,8 +1683,7 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering)
 "GT" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
+/obj/machinery/oven,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen/kitchen)
 "GY" = (
@@ -1750,9 +1752,14 @@
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen/kitchen)
 "HY" = (
-/obj/machinery/reagentgrinder,
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 18
+	},
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/wood/mahogany,
 /area/ship/crew/canteen/kitchen)
 "Ip" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
@@ -480,20 +480,23 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/crew/dorm/dormtwo)
 "dE" = (
-/obj/structure/railing/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/button/door{
 	dir = 8;
-	pixel_x = 22;
-	pixel_y = 10;
+	id = "sgi_cafeteria";
 	name = "external shutters control";
-	id = "sgi_cafeteria"
+	pixel_x = 22;
+	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
+/obj/machinery/oven,
+/obj/item/plate/oven_tray{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "dH" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
@@ -1518,6 +1521,7 @@
 "jX" = (
 /obj/structure/chair/sofa/brown/left/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood,
 /turf/open/floor/carpet/blue,
 /area/ship/crew/canteen/kitchen)
 "ka" = (
@@ -2495,6 +2499,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "qp" = (
@@ -3289,7 +3294,9 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "uS" = (
-/obj/machinery/griddle,
+/obj/structure/table/wood,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "uT" = (
@@ -3311,6 +3318,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "vf" = (
@@ -4134,6 +4144,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
+"AI" = (
+/obj/structure/table/wood,
+/obj/structure/railing/wood,
+/turf/open/floor/carpet/blue,
+/area/ship/crew/canteen/kitchen)
 "AM" = (
 /obj/machinery/light/floor,
 /turf/open/floor/engine/hull,
@@ -4524,9 +4539,36 @@
 /area/ship/crew/canteen)
 "CM" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/oven,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -9;
+	pixel_y = 18
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "CN" = (
@@ -4829,10 +4871,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "ET" = (
@@ -5202,7 +5244,6 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "HM" = (
-/obj/structure/railing/corner/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -5212,10 +5253,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "HT" = (
@@ -5262,6 +5306,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/corner/wood,
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "Ik" = (
@@ -5648,8 +5693,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "KK" = (
@@ -6694,14 +6741,11 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/cryo)
 "St" = (
-/obj/structure/railing/wood,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/obj/machinery/griddle,
+/turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "Sw" = (
 /obj/effect/turf_decal/spline/fancy/transparent/solgovblue{
@@ -6844,24 +6888,21 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "Tt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/railing/wood{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
@@ -6974,13 +7015,8 @@
 /area/ship/crew/office)
 "UF" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "UM" = (
@@ -7365,16 +7401,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -17
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -10;
-	pixel_y = 6
-	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "XQ" = (
@@ -8836,7 +8862,7 @@ bU
 EF
 FC
 AU
-pS
+AI
 St
 UF
 Tk

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_inkwell.dmm
@@ -3289,16 +3289,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/cargo)
 "uS" = (
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -17
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -10;
-	pixel_y = 6
-	},
+/obj/machinery/griddle,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "uT" = (
@@ -3313,9 +3304,6 @@
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "uX" = (
-/obj/structure/railing/wood{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -4538,8 +4526,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder,
+/obj/machinery/oven,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "CN" = (
@@ -6873,6 +6860,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/railing/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "Tv" = (
@@ -6989,6 +6979,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "UM" = (
@@ -7373,6 +7365,16 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/item/cutting_board,
+/obj/item/melee/knife/kitchen,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -17
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -10;
+	pixel_y = 6
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen/kitchen)
 "XQ" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_paracelsus.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_paracelsus.dmm
@@ -3094,7 +3094,7 @@
 	pixel_x = -20;
 	pixel_y = 7
 	},
-/obj/structure/table/wood,
+/obj/machinery/oven,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Eh" = (
@@ -3548,7 +3548,7 @@
 "IO" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder{
-	pixel_y = 8;
+	pixel_y = 21;
 	pixel_x = -7
 	},
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -3559,6 +3559,9 @@
 	pixel_x = 10;
 	pixel_y = 10
 	},
+/obj/item/cutting_board,
+/obj/item/kitchen/rollingpin,
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "IP" = (
@@ -4733,11 +4736,8 @@
 /area/ship/hallway/starboard)
 "SP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/item/cutting_board,
-/obj/item/melee/knife/kitchen,
-/obj/item/kitchen/rollingpin,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/griddle,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen)
 "Tc" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_saber.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_saber.dmm
@@ -580,14 +580,12 @@
 /area/ship/crew/office)
 "en" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing/wood{
 	dir = 8
 	},
+/obj/machinery/griddle,
 /turf/open/floor/wood/walnut,
 /area/ship/hallway/central)
 "eo" = (
@@ -747,18 +745,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/microwave{
-	pixel_y = 2
-	},
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/railing/wood{
 	dir = 8
 	},
+/obj/machinery/oven,
 /turf/open/floor/wood/walnut,
 /area/ship/hallway/central)
 "fg" = (
@@ -1022,6 +1013,7 @@
 /obj/machinery/jukebox/boombox{
 	pixel_y = 5
 	},
+/obj/item/lighter/greyscale,
 /turf/open/floor/plasteel/grimy,
 /area/ship/hallway/central)
 "hE" = (
@@ -1732,6 +1724,10 @@
 /obj/item/toy/cards/deck,
 /obj/item/storage/box/cups{
 	pixel_x = -14
+	},
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/hallway/central)
@@ -4385,10 +4381,6 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Hy" = (
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -4396,10 +4388,14 @@
 	color = "#c1b6a5"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/lighter/greyscale,
 /obj/structure/sign/solfed{
 	pixel_y = 32
 	},
+/obj/machinery/microwave{
+	pixel_y = 2
+	},
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
 /turf/open/floor/plasteel/grimy,
 /area/ship/hallway/central)
 "HF" = (

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tethra.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tethra.dmm
@@ -688,19 +688,11 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "jT" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7;
-	pixel_x = 9
-	},
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_y = 1;
-	pixel_x = -4
-	},
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/griddle,
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "jU" = (
@@ -1545,6 +1537,10 @@
 	pixel_x = 5
 	},
 /obj/machinery/light/directional/east,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 1;
+	pixel_x = -4
+	},
 /turf/open/floor/wood,
 /area/ship/crew/canteen/kitchen)
 "si" = (
@@ -3157,6 +3153,7 @@
 "Ps" = (
 /obj/structure/table/reinforced/titaniumglass,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/tech,
 /area/ship/hallway/aft)
 "Pz" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gec_lugol.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gec_lugol.dmm
@@ -559,11 +559,12 @@
 	dir = 4;
 	pixel_y = 2
 	},
+/obj/structure/table/wood,
+/obj/item/plate/oven_tray,
 /obj/item/reagent_containers/glass/rag{
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/canteen)
 "fV" = (
@@ -1554,6 +1555,11 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 30
 	},
+/obj/item/circuitboard/machine/griddle{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/machine/oven,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "pl" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -440,11 +440,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/airalarm/directional/west,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/condiment/sugar,
@@ -457,6 +455,7 @@
 /obj/item/food/meat/slab,
 /obj/item/storage/fancy/egg_box,
 /obj/item/storage/fancy/egg_box,
+/obj/structure/closet/secure_closet/freezer/wall/directional/west,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "gX" = (
@@ -2103,6 +2102,7 @@
 /area/ship/engineering)
 "Er" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "Et" = (
@@ -2417,8 +2417,9 @@
 	},
 /obj/machinery/button/door{
 	dir = 4;
-	pixel_x = -24;
-	id = "okno_crew1"
+	pixel_x = -19;
+	id = "okno_crew1";
+	pixel_y = 3
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood/ebony,
@@ -2957,9 +2958,14 @@
 /obj/structure/chair/handrail{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/trimline/opaque/inteqbrown/filled/corner{
 	color = "#332521"
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -7
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 6
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -444,6 +444,19 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "gX" = (
@@ -2196,19 +2209,7 @@
 /turf/open/floor/marble/black,
 /area/ship/hallway/central)
 "GG" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/flour,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/condiment/milk,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
+/obj/machinery/griddle,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
 "GJ" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_krait.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_krait.dmm
@@ -836,6 +836,10 @@
 	pixel_y = 7
 	},
 /obj/structure/table/wood,
+/obj/item/storage/cans/sixbeer{
+	pixel_x = -1;
+	pixel_y = -7
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "gE" = (
@@ -1031,6 +1035,7 @@
 /obj/effect/turf_decal/spline/plain/opaque/syndiered{
 	dir = 1
 	},
+/obj/item/circuitboard/machine/griddle,
 /turf/open/floor/plasteel/tech,
 /area/ship/cargo)
 "ib" = (
@@ -1654,14 +1659,14 @@
 	},
 /obj/item/reagent_containers/condiment/saltshaker,
 /obj/item/food/onigiri{
-	pixel_y = 16;
-	pixel_x = -7
-	},
-/obj/item/food/onigiri{
 	pixel_y = 4;
 	pixel_x = -10
 	},
 /obj/structure/table/wood,
+/obj/item/food/onigiri{
+	pixel_y = 16;
+	pixel_x = -7
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "nq" = (
@@ -3160,6 +3165,18 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/lighter/clockwork{
+	pixel_y = -6;
+	pixel_x = -4
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "Ak" = (
@@ -4572,18 +4589,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "NC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 13;
-	pixel_x = -3
-	},
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/obj/item/melee/knife/kitchen{
-	pixel_y = 4;
-	pixel_x = 12
-	},
+/obj/machinery/oven,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/canteen)
 "NE" = (
@@ -4949,7 +4958,22 @@
 /area/ship/cargo)
 "Su" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/cans/sixbeer,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -4;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/cutting_board{
+	pixel_x = 4
+	},
+/obj/item/food/nigiri_sushi,
+/obj/item/food/nigiri_sushi{
+	pixel_x = 6
+	},
+/obj/item/melee/knife/kitchen,
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)
 "SA" = (
@@ -5502,28 +5526,8 @@
 "Xs" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wood,
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = 10;
-	pixel_y = 17
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = 6;
-	pixel_y = 14
-	},
-/obj/item/lighter/clockwork{
-	pixel_y = 15
-	},
-/obj/item/food/nigiri_sushi,
-/obj/item/food/nigiri_sushi{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -4;
-	pixel_y = 9
+/obj/machinery/microwave{
+	pixel_y = 1
 	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/canteen)

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
@@ -273,7 +273,15 @@
 "eX" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/machinery/vending/boozeomat/all_access{
+	default_price = 0;
+	extra_price = 0;
+	all_items_free = 1;
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
@@ -736,9 +744,15 @@
 "mA" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
-	dir = 8
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/reagentgrinder{
+	pixel_x = -10;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "mB" = (
@@ -912,7 +926,8 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/storage)
 "oW" = (
-/obj/machinery/chem_master/condimaster,
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "pa" = (
@@ -1108,11 +1123,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/engineering)
 "sM" = (
-/obj/machinery/vending/boozeomat/all_access{
-	default_price = 0;
-	extra_price = 0;
-	all_items_free = 1
-	},
+/obj/machinery/griddle,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "sX" = (
@@ -1830,9 +1841,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/hallway/central)
 "Ip" = (
-/obj/structure/table,
-/obj/machinery/microwave,
 /obj/machinery/light/directional/south,
+/obj/machinery/oven,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "IA" = (
@@ -1874,13 +1884,10 @@
 /area/ship/cargo)
 "IJ" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/item/melee/knife/kitchen{
-	pixel_x = -8
+	pixel_x = -2
 	},
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = 10
-	},
+/obj/item/cutting_board,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "IL" = (
@@ -2565,6 +2572,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table,
 /obj/item/radio/intercom/directional/east,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/crew/canteen)
 "Wo" = (

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_panacea.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_panacea.dmm
@@ -1931,13 +1931,10 @@
 /area/ship/crew/ccommons)
 "lT" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder/constructed{
-	pixel_y = 4;
-	pixel_x = -7
-	},
 /obj/effect/turf_decal/suns/line/marble/fill/corner{
 	dir = 4
 	},
+/obj/machinery/microwave,
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
 "lU" = (
@@ -4533,9 +4530,16 @@
 /area/ship/crew/office/lobby)
 "Bk" = (
 /obj/structure/table,
-/obj/machinery/microwave,
 /obj/effect/turf_decal/suns/line/marble/fill{
 	dir = 5
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/machinery/reagentgrinder/constructed{
+	pixel_y = 9;
+	pixel_x = -6
 	},
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
@@ -4727,6 +4731,14 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/item/storage/fancy/donut_box,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -2;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 8;
+	pixel_x = -8
+	},
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
 "BY" = (
@@ -5613,12 +5625,24 @@
 	},
 /obj/item/table_bell/brass{
 	pixel_y = 9;
-	pixel_x = 6
+	pixel_x = -8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/item/reagent_containers/condiment/mayonnaise{
+	pixel_x = 8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/condiment/hotsauce{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_x = 10;
+	pixel_y = 6
+	},
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
 "GJ" = (
@@ -6534,25 +6558,13 @@
 	},
 /area/ship/crew/dorm/dormtwo)
 "LY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -2;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_y = 8;
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_y = 14;
-	pixel_x = 14
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/griddle,
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
 "LZ" = (
@@ -6823,25 +6835,13 @@
 	},
 /area/ship/crew/office)
 "Nz" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/mayonnaise{
-	pixel_x = 2;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/condiment/ketchup{
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/condiment/hotsauce{
-	pixel_y = 16;
-	pixel_x = -8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/machinery/oven,
 /turf/open/floor/suns/dark/plain,
 /area/ship/crew/canteen/kitchen)
 "NA" = (
@@ -8117,7 +8117,9 @@
 /turf/open/floor/pod/dark,
 /area/ship/crew/cryo)
 "VW" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/dinnerware{
+	all_items_free = 1
+	},
 /obj/effect/turf_decal/suns/line/marble/fill{
 	dir = 9
 	},

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
@@ -3457,7 +3457,6 @@
 /obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
 	dir = 8
 	},
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/closet/wall/white/directional/north{
 	name = "fridge"
 	},
@@ -3491,6 +3490,7 @@
 	pixel_x = -9
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/griddle,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "Jw" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет новые машинерии на кухни почти всех кораблей.
## Причина создания ПР / Почему это хорошо для игры
Необходимо было обновить кухни что бы они подходили под новые реалии.
## Демонстрация изменений / Тестирование
посмотрите карты
## Список изменений
Добавлены машины/платы новой кухонной машинерии на буквально каждый шип(если у вас нету какой-то машинерии, то идите и купите это в карго или найдите у себя плату).
```yml
🆑
map: 47 изменённых карт.
/🆑
```
