### PR TITLE
[MAP]: Возвращает Riot underbarrel для Вакьеро.

### DIFF
--- a/_maps/_mod_celadon/shuttles/inteq/inteq_vaquero.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_vaquero.dmm
@@ -159,6 +159,10 @@
 	pixel_x = 11;
 	pixel_y = -7
 	},
+/obj/item/attachment/gun/riot{
+	pixel_x = -4;
+	pixel_y = -10
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "bj" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Возвращает подствольный гранатомет раундстартом для Вакьеро.
## Причина создания ПР / Почему это хорошо для игры
То, что было удалено в позапрошлом обновлении было возвращено.
## Демонстрация изменений / Тестирование
Не было, но и не нужно.
## Список изменений

```yml
🆑
add: Вернулся подствольный гранатомет на Вакьеро.

/🆑
```
