### PR TITLE
[MAP] Colossus fix and up

### DIFF
--- a/_maps/_mod_celadon/configs/inteq_colossus.json
+++ b/_maps/_mod_celadon/configs/inteq_colossus.json
@@ -6,7 +6,7 @@
 	"map_path": "_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm",
 	"enabled": true,
 	"limit": 1,
-	"sensor_range": 4,
+	"sensor_range": 6,
 	"prefix": "BIQSV",
 	"faction": "/datum/faction/inteq",
 	"tags": [

--- a/_maps/_mod_celadon/configs/inteq_colossus.json
+++ b/_maps/_mod_celadon/configs/inteq_colossus.json
@@ -6,7 +6,7 @@
 	"map_path": "_maps/_mod_celadon/shuttles/inteq/inteq_colossus.dmm",
 	"enabled": true,
 	"limit": 1,
-	"sensor_range": 6,
+	"sensor_range": 5,
 	"prefix": "BIQSV",
 	"faction": "/datum/faction/inteq",
 	"tags": [

--- a/_maps/_mod_celadon/configs/inteq_colossus.json
+++ b/_maps/_mod_celadon/configs/inteq_colossus.json
@@ -40,7 +40,7 @@
 			"slots": 2
 		},
 		"Corpsman": {
-			"outfit": "/datum/outfit/job/cel/inteq/cmo",
+			"outfit": "/datum/outfit/job/cel/inteq/paramedic",
 			"slots": 1
 		},
 		"Enforcer": {


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксит Хонорабл Корпсманов вместо обычных. Теперь там обычные.
Дает 5 sensor_range вместо 4. 
## Причина создания ПР / Почему это хорошо для игры
Фиксы это хорошо.
Насчет сенсоров. Корабль был слишком медлителен, а 4 сенсора делали из него не очень привлекательным для поиска планет. Суб же для этого не подходит, ибо у субов сейчас 2 сенсор ренжа.
## Демонстрация изменений / Тестирование
Не нужно.
## Список изменений

```yml
🆑
balance: Сенсоры колосса с 5->6
fix: Слоты профессий для колосса. Вместо СМО обычный корпсман.


/🆑
```
