### PR TITLE
ADD: Chat Filter - Braindead System

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -30,6 +30,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/requests,
 	/client/proc/fax_panel, /*send a paper to fax*/
 	/client/proc/show_all_verbs, // [CELADON-ADD] - ADMIN-PANEL - Black Reality
+	/client/proc/manage_chatfilter,
+	/client/proc/toggle_chatfilter_hardcore,
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -29,9 +29,9 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/revokebunkerbypass,
 	/client/proc/requests,
 	/client/proc/fax_panel, /*send a paper to fax*/
-	/client/proc/show_all_verbs, // [CELADON-ADD] - ADMIN-PANEL - Black Reality
-	/client/proc/manage_chatfilter,
-	/client/proc/toggle_chatfilter_hardcore,
+	/client/proc/show_all_verbs,				// [CELADON-ADD] - ADMIN-PANEL - Black Reality
+	/client/proc/manage_chatfilter,				// [CELADON-ADD] - BRAINDEAD-SYSTEM
+	/client/proc/toggle_chatfilter_hardcore,	// [CELADON-ADD] - BRAINDEAD-SYSTEM
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/mod_celadon/_secrets/__secret_public.dme
+++ b/mod_celadon/_secrets/__secret_public.dme
@@ -25,3 +25,9 @@
 		spawned_player.ckey = user.key
 
 	spawned_player.forceMove(get_turf(user))
+
+GLOBAL_LIST_INIT(ic_autoemote, list())
+/client/proc/manage_chatfilter()
+/client/proc/toggle_chatfilter_hardcore()
+/mob/proc/check_for_brainrot(message)
+	return message

--- a/mod_celadon/qol/code/mob_say2.dm
+++ b/mod_celadon/qol/code/mob_say2.dm
@@ -34,6 +34,10 @@
 	//queue this message because verbs are scheduled to process after SendMaps in the tick and speech is pretty expensive when it happens.
 	//by queuing this for next tick the mc can compensate for its cost instead of having speech delay the start of the next tick
 	if(message)
+		if(stat != DEAD)
+			if(GLOB.ic_autoemote[message])
+				message = "*[GLOB.ic_autoemote[message]]"
+			message = check_for_brainrot(message)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), message), SSspeech_controller)
 
 // Overrides proc to use _char variants of findtext and copytext


### PR DESCRIPTION
## Описание / Что этот PR делает
Чат фильтр - Инструмент для модерации и администрирования.
- Может заменять текст на эмоуты по заранее прописанному словарю:
`хз = пожимает плечами, лол = смеется`
- Может заменять тест на другой текст по заранее прописанному словарю:
`шипе = корабле`
- Проверяет сейлог на предмет плохих слов. Слово он найдет даже если оно часть другого.
`Например при бане слова Чай он не пропустит и Чайник. Если хотите забанить ваш любимый гоооол, то баните "оол" (до сих пор не вкуриваю этот мем).`
- Если продолжают обходить используя левые символы, то это уже прямое нарушение правил а не проблема кода.
- Есть словарь исключений которые будут игнорироваться:
`Например слово "Чай" забанено, "Чайковский" добавлено в исключения.`
При нахождении плохого слова он в зависимости от выбранной строгости поведения:
  - **`Мягкий режим:`** Ругает космонавтика в чатике на предмет чтобы он так больше не делал + стучит в админ чат + ведет счет нарушений у этого тела за раунд
  - **`Строгий режим:`** вышеперечисленное + блокирует это сообщение
  - **`Жестокий режим:`** вышеперечисленное + автоматический выдает смайты (от лайтовых к более жестким, по мере рецедива)
- Все элементы редактируется с клиента, на горячую во вкладке Админ - Чат Фильтр (редактирование строго по шаблону)

## Демонстрация изменений / Тестирование
<img width="320" height="325" alt="image" src="https://github.com/user-attachments/assets/ea7cee3c-a4dc-44a2-b4a2-c0f9c6c6e30b" />
<img width="614" height="818" alt="image" src="https://github.com/user-attachments/assets/2feb6067-6f34-4fa1-badc-e0390c4bc552" />


## Список изменений

```yml
🆑
add: Страдания брейнротам
admin: Добавляет двухкомпонентный Чат Фильтр
/🆑
```
