### PR TITLE
REMOVE: Equipment-swap - Abuse

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -103,6 +103,7 @@
 	slot_item_name = "suit storage slot item"
 	keybind_signal = COMSIG_KB_HUMAN_SUITEQUIP_DOWN
 
+/* // [CELADON-REMOVE] - Equipment-swap - Abuse
 /datum/keybinding/human/equipment_swap
 	hotkey_keys = list("V")
 	name = "equipment_swap"
@@ -117,3 +118,4 @@
 	var/mob/living/carbon/human/H = user.mob
 	H.equipment_swap()
 	return TRUE
+*/ // [/CELADON-REMOVE]

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -455,6 +455,7 @@
 	if (I)
 		I.equip_to_best_slot(src)
 
+/* // [CELADON-REMOVE] - Equipment-swap - Abuse
 /mob/verb/equipment_swap()
 	set name = "equipment-swap"
 	set hidden = TRUE
@@ -469,6 +470,7 @@
 			dropItemToGround(I)
 			return
 		I.equip_to_best_slot(src, TRUE)
+*/ // [/CELADON-REMOVE]
 
 //used in code for items usable by both carbon and drones, this gives the proper back slot for each mob.(defibrillator, backpack watertank, ...)
 /mob/proc/getBackSlot()


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправление давнего бага связанного с быстрой сменой одежды и не только путем замены их на другую.

## Причина создания ПР / Почему это хорошо для игры
ТМ от модсьютов наглядно показал  это, плюс некоторые личности начали всем говорить на публику абузить эту "фичу".
И нет Ройси к сожалению это не фича.

Слишком легко обойти проверки на то что ты НЕ МОЖЕШЬ носить, или ТО ЧТО НЕЛЬЗЯ СНЯТЬ.
Пример: Моды, либо же настакивание хадов у очков.
На **TG-Station**, это уже давно удалили. Думаю этот ответ исчерпывающий.

## Список изменений

```yml
🆑
del: Хоткей на замену предмета/одежду
/🆑
```
