### PR TITLE
MAP: Pangolier fix

### DIFF
--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
@@ -142,7 +142,6 @@
 /obj/effect/turf_decal/industrial/warning/fulltile,
 /obj/structure/crate_shelf,
 /obj/structure/closet/crate{
-	icon_state = "scicrate";
 	name = "AI Assembly crate"
 	},
 /obj/item/stack/sheet/plasteel/five{
@@ -2655,7 +2654,8 @@
 	name = "Captain's locker";
 	pixel_y = 31;
 	dir = 1;
-	req_access = list(20)
+	req_access = list(20);
+	req_ship_access = 1
 	},
 /obj/item/clothing/gloves/combat{
 	pixel_y = -8;
@@ -3605,7 +3605,8 @@
 	anchored = 1;
 	icon_state = "syndicate";
 	name = "lieutenant's locker";
-	req_access = list(19)
+	req_access = list(19);
+	req_ship_access = 1
 	},
 /obj/item/clothing/shoes/combat{
 	pixel_x = 9;
@@ -4711,12 +4712,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
-"UQ" = (
-/obj/structure/safe{
-	tumblers = list(24, 16)
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/external/dark)
 "US" = (
 /obj/machinery/door/airlock/vault{
 	req_access = list(19)
@@ -5029,7 +5024,8 @@
 	name = "Emergency locker";
 	pixel_y = 31;
 	dir = 1;
-	req_access = list(20)
+	req_access = list(20);
+	req_ship_access = 1
 	},
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
 	pixel_x = -9;
@@ -6610,7 +6606,7 @@ An
 An
 An
 An
-UQ
+JN
 An
 An
 An

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_pangolier.dmm
@@ -371,13 +371,17 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/newscaster/directional/east,
 /obj/item/toy/cards/deck/syndicate{
 	pixel_y = -8
 	},
 /obj/item/reagent_containers/food/drinks/coffee{
 	pixel_y = 10;
 	pixel_x = 11
+	},
+/obj/structure/painting{
+	icon_state = "Kate";
+	paint = "Kate";
+	pixel_x = 32
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
@@ -495,7 +499,14 @@
 /obj/effect/turf_decal/spline/plain/opaque/syndiered{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = -10;
+	pixel_x = -19
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/general/command_crew)
 "eG" = (
@@ -791,11 +802,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = -15
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security)
 "ic" = (
@@ -958,10 +964,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = 12
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/general/command_crew)
@@ -1179,9 +1181,6 @@
 	},
 /obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
 	dir = 1
-	},
-/obj/machinery/firealarm/directional/west{
-	pixel_y = -10
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/plastitanium,
@@ -1679,6 +1678,7 @@
 	layer = 2.1
 	},
 /obj/effect/turf_decal/corner/opaque/syndiered/half,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/general/command_crew)
 "qX" = (
@@ -1692,7 +1692,7 @@
 /area/ship/science)
 "qZ" = (
 /obj/structure/safe{
-	tumblers = list(24, 16)
+	tumblers = list(25, 75)
 	},
 /obj/item/clothing/accessory/holster,
 /obj/item/codespeak_manual/unlimited,
@@ -2522,11 +2522,6 @@
 /obj/machinery/light/small/directional/west{
 	pixel_y = -7
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = -17
-	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/toilet)
 "Ai" = (
@@ -3056,6 +3051,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = -10;
+	pixel_x = -19
+	},
 /turf/open/floor/plasteel/stairs{
 	icon = 'icons/obj/stairs.dmi'
 	},
@@ -3131,6 +3131,11 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = 13;
+	pixel_x = -19
 	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/crew/toilet)
@@ -3661,15 +3666,16 @@
 /obj/item/megaphone/sec{
 	name = "syndicate megaphone"
 	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_y = -11
-	},
 /obj/structure/sign/poster/bay/bay_3{
 	pixel_y = 32
 	},
 /obj/item/clothing/head/warden/drill{
 	name = "lieutenant's hat";
 	pixel_y = -1
+	},
+/obj/item/clothing/mask/gas/sechailer/sec{
+	pixel_y = -11;
+	pixel_x = -5
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
@@ -4190,12 +4196,7 @@
 	dir = 4
 	},
 /obj/structure/showcase/cyborg/assault,
-/obj/structure/neon_spline/red{
-	dir = 6
-	},
-/obj/structure/neon_spline/red{
-	dir = 9
-	},
+/obj/structure/neon_spline/red/three_quarters,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/general/command_crew)
 "Pb" = (
@@ -4251,7 +4252,7 @@
 	},
 /obj/item/paper/paperslip/corporate{
 	pixel_y = -26;
-	default_raw_text = "Lieutenant's Safe Code - Date of Syndicate Logo Appearance."
+	default_raw_text = "Lieutenant's Safe Code is the date of the Syndicate's formation."
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4283,12 +4284,7 @@
 	dir = 4
 	},
 /obj/structure/showcase/cyborg/old/medical,
-/obj/structure/neon_spline/red{
-	dir = 9
-	},
-/obj/structure/neon_spline/red{
-	dir = 6
-	},
+/obj/structure/neon_spline/red/three_quarters,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ship/security)
 "PQ" = (
@@ -4311,11 +4307,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = -25
-	},
 /turf/open/floor/plasteel/tech,
 /area/ship/bridge)
 "Qn" = (
@@ -4526,6 +4517,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_y = 11;
+	pixel_x = -19
+	},
 /turf/open/floor/plasteel/tech,
 /area/ship/security)
 "Tx" = (
@@ -4715,6 +4711,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
+"UQ" = (
+/obj/structure/safe{
+	tumblers = list(24, 16)
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ship/external/dark)
 "US" = (
 /obj/machinery/door/airlock/vault{
 	req_access = list(19)
@@ -4738,11 +4740,7 @@
 	pixel_y = 6;
 	pixel_x = -3
 	},
-/obj/structure/painting{
-	icon_state = "Kate";
-	paint = "Kate";
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/crew)
 "UZ" = (
@@ -6612,7 +6610,7 @@ An
 An
 An
 An
-JN
+UQ
 An
 An
 An

--- a/mod_celadon/outfit/code/syndicate/gorlex_outfit.dm
+++ b/mod_celadon/outfit/code/syndicate/gorlex_outfit.dm
@@ -32,8 +32,19 @@
 	suit = /obj/item/clothing/suit/armor/hardliners/sergeant
 	shoes = /obj/item/clothing/shoes/combat
 
-/datum/outfit/job/cel/syndicate/hos/gorlex/lieutenant
+/datum/outfit/job/cel/syndicate/hos/gorlex/lieutenant	// Pangolier
 	name = "Syndi Gorlex - Lieutenant"
+	id_assignment = null
+
+	ears = /obj/item/radio/headset/syndicate/alt
+	uniform = /obj/item/clothing/under/syndicate/hardliners/officer
+	suit = null
+	mask = /obj/item/clothing/mask/breath/facemask
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	gloves = /obj/item/clothing/gloves/combat
+	head = /obj/item/clothing/head/beret/sec/officer
+
+	l_pocket = /obj/item/flashlight/seclite
 
 //MARK: Crew
 /datum/outfit/job/cel/syndicate/doctor/gorlex
@@ -61,9 +72,19 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	shoes = /obj/item/clothing/shoes/combat
 
-/datum/outfit/job/cel/syndicate/security/gorlex/commando
+/datum/outfit/job/cel/syndicate/security/gorlex/commando	// Pangolier
 	name = "Syndi Gorlex - Commando"
-	id_assignment = "Commando"
+	id_assignment = null
+
+	ears = /obj/item/radio/headset/syndicate/alt
+	uniform = /obj/item/clothing/under/syndicate/hardliners
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/color/black
+	mask = /obj/item/clothing/mask/breath/facemask
+	head = /obj/item/clothing/head/beret/black
+
+	r_pocket = /obj/item/restraints/handcuffs
+	l_pocket = /obj/item/flashlight/seclite
 
 /datum/outfit/job/cel/syndicate/security/gorlex/pilot	// Не юзается
 	name = "Syndi Gorlex - Pilot"
@@ -105,5 +126,14 @@
 	uniform = /obj/item/clothing/under/syndicate/hardliners
 	alt_uniform = /obj/item/clothing/under/syndicate/hardliners/jumpsuit
 
-/datum/outfit/job/cel/syndicate/assistant/gorlex/operative
+/datum/outfit/job/cel/syndicate/assistant/gorlex/operative	//Pangolier
 	name = "Syndi Gorlex - Operative"
+	id_assignment = null
+
+	uniform = /obj/item/clothing/under/syndicate/hardliners
+	shoes = /obj/item/clothing/shoes/combat
+	ears = /obj/item/radio/headset/syndicate
+	gloves = /obj/item/clothing/gloves/color/black
+
+	r_pocket = /obj/item/assembly/flash/handheld
+	l_pocket = /obj/item/flashlight/seclite


### PR DESCRIPTION
## Описание / Что этот PR делает
Возвращение аутфитов для пангольера, очень мелкая репланировка, актуализация кода для сейфа под текущий лор.
## Причина создания ПР / Почему это хорошо для игры
Криво перенесенные аутфиты - не круто.
Неправильный код из-за смены лора - не круто.
Кнопки для включения света в углу от входа в комнату - не круто.
## Демонстрация изменений / Тестирование
Смотреть коммиты
## Список изменений

```yml
🆑
add: Аутфиты для пангольера.
map: Новый код для сейфа под текущий лор, кнопки у входа в комнату.
/🆑
```
