### PR TITLE
FIX: Kepori and Vox gun sprite offsets

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -368,10 +368,10 @@
 
 	var/icon/human_clothing_icon = icon(file2use, state2use)
 
-	if("[layer]" in mob_species.offset_clothing)
+	var/list/shifts = get_species_worn_offsets(layer, mob_species)	// [CELADON-EDIT] - Get species-specific offsets
+	if(shifts)														// [/CELADON-EDIT]
 		// This code taken from Baystation 12
 		var/icon/final_I = icon('icons/blanks/64x64.dmi', "nothing")
-		var/list/shifts = mob_species.offset_clothing["[layer]"]
 
 		// Apply all pixel shifts for each direction.
 		for(var/shift_facing in shifts)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -383,11 +383,26 @@
 			final_I.Insert(canvas, dir = use_dir)
 
 		final_I = fcopy_rsc(final_I)
-		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]"] = final_I
+
+		// DEBUG: Track GLOB updates
+		var/glob_key = "[file2use]-[state2use]-[layer]"
+		var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
+		var/offsets_text = ""
+		for(var/dir in shifts)
+			var/list/offset_data = shifts[dir]
+			offsets_text += " [dir]:(x=[offset_data["x"]],y=[offset_data["y"]])"
+		log_game("GLOB DEBUG [existing]: Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use] Offsets:[offsets_text]")
+
+		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = final_I
 		return TRUE
 
 	if(!greyscale_colors || !greyscale_icon_state)
-		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]"] = human_clothing_icon
+		// DEBUG: Track GLOB updates
+		var/glob_key = "[file2use]-[state2use]-[layer]"
+		var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
+		log_game("GLOB DEBUG [existing] (No Offsets): Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use]")
+
+		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = human_clothing_icon
 		return
 
 	if(!icon_exists(mob_species.species_clothing_path, greyscale_icon_state))
@@ -407,7 +422,13 @@
 
 	species_icon.MapColors(final_list[1], final_list[2], final_list[3])
 	species_icon = fcopy_rsc(species_icon)
-	GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]"] = species_icon
+
+	// DEBUG: Track GLOB updates
+	var/glob_key = "[file2use]-[state2use]-[layer]"
+	var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
+	log_game("GLOB DEBUG [existing] (Greyscale): Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use]")
+
+	GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = species_icon
 
 	return TRUE
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -368,7 +368,7 @@
 
 	var/icon/human_clothing_icon = icon(file2use, state2use)
 
-	var/list/shifts = get_species_worn_offsets(layer, mob_species)	// [CELADON-EDIT] - Get species-specific offsets
+	var/list/shifts = get_species_worn_offsets(layer, mob_species)	// [CELADON-EDIT] - SPECIES_OFFSETS - Get species-specific offsets
 	if(shifts)														// [/CELADON-EDIT]
 		// This code taken from Baystation 12
 		var/icon/final_I = icon('icons/blanks/64x64.dmi', "nothing")
@@ -384,7 +384,7 @@
 
 		final_I = fcopy_rsc(final_I)
 
-		// DEBUG: Track GLOB updates
+		// [CELADON-ADD] - SPECIES_OFFSETS - DEBUG: Track GLOB updates
 		var/glob_key = "[file2use]-[state2use]-[layer]"
 		var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
 		var/offsets_text = ""
@@ -394,15 +394,17 @@
 		log_game("GLOB DEBUG [existing]: Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use] Offsets:[offsets_text]")
 
 		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = final_I
+		// [/CELADON-ADD]
 		return TRUE
 
 	if(!greyscale_colors || !greyscale_icon_state)
-		// DEBUG: Track GLOB updates
+		// [CELADON-ADD] - SPECIES_OFFSETS - DEBUG: Track GLOB updates
 		var/glob_key = "[file2use]-[state2use]-[layer]"
 		var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
 		log_game("GLOB DEBUG [existing] (No Offsets): Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use]")
 
 		GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = human_clothing_icon
+		// [/CELADON-ADD]
 		return
 
 	if(!icon_exists(mob_species.species_clothing_path, greyscale_icon_state))
@@ -423,12 +425,13 @@
 	species_icon.MapColors(final_list[1], final_list[2], final_list[3])
 	species_icon = fcopy_rsc(species_icon)
 
-	// DEBUG: Track GLOB updates
+	// [CELADON-ADD] - SPECIES_OFFSETS - DEBUG: Track GLOB updates
 	var/glob_key = "[file2use]-[state2use]-[layer]"
 	var/existing = GLOB.species_clothing_icons[mob_species.id][glob_key] ? "UPDATING" : "CREATING"
 	log_game("GLOB DEBUG [existing] (Greyscale): Species=[mob_species.id] Layer=[layer] State=[state2use] File=[file2use]")
 
 	GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] = species_icon
+	// [/CELADON-ADD] - SPECIES OFFSETS END
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -111,10 +111,10 @@
 							"[WEST]" = list("x" =  -3, "y" = -3)
 							),
 		"[SUIT_STORE_LAYER]" = list(
-							"[NORTH]" = list("x" = 8, "y" = -1),
-							"[EAST]" = list("x" = 8, "y" = -1),
-							"[SOUTH]" = list("x" = 8, "y" = -1),
-							"[WEST]" = list("x" =  -8, "y" = -1),
+							"[NORTH]" = list("x" = 9, "y" = -3),
+							"[EAST]" = list("x" = 16, "y" = -3),
+							"[SOUTH]" = list("x" = 9, "y" = -3),
+							"[WEST]" = list("x" =  0, "y" = -3)
 							),
 		"[BACK_LAYER]" = list(
 							"[NORTH]" = list("x" = 9, "y" = -3),

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -114,7 +114,13 @@
 							"[NORTH]" = list("x" = 8, "y" = -1),
 							"[EAST]" = list("x" = 8, "y" = -1),
 							"[SOUTH]" = list("x" = 8, "y" = -1),
-							"[WEST]" = list("x" =  -8, "y" = -1)
+							"[WEST]" = list("x" =  -8, "y" = -1),
+							),
+		"[BACK_LAYER]" = list(
+							"[NORTH]" = list("x" = 8, "y" = -1),
+							"[EAST]" = list("x" = 16, "y" = -1),
+							"[SOUTH]" = list("x" = 8, "y" = -1),
+							"[WEST]" = list("x" =  0, "y" = -1)
 							),
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -111,7 +111,7 @@
 							"[WEST]" = list("x" =  -3, "y" = -3)
 							),
 		"[SUIT_STORE_LAYER]" = list(
-							"[NORTH]" = list("x" = 9, "y" = -3),
+							"[NORTH]" = list("x" = 9, "y" = -3), // [CELADON-ADD] - SPECIES OFFSETS
 							"[EAST]" = list("x" = 16, "y" = -3),
 							"[SOUTH]" = list("x" = 9, "y" = -3),
 							"[WEST]" = list("x" =  0, "y" = -3)
@@ -120,7 +120,7 @@
 							"[NORTH]" = list("x" = 9, "y" = -3),
 							"[EAST]" = list("x" = 16, "y" = -3),
 							"[SOUTH]" = list("x" = 9, "y" = -3),
-							"[WEST]" = list("x" =  0, "y" = -3)
+							"[WEST]" = list("x" =  0, "y" = -3) // [/CELADON-ADD] - SPECIES OFFSETS
 							),
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/kepori.dm
+++ b/code/modules/mob/living/carbon/human/species_types/kepori.dm
@@ -117,10 +117,10 @@
 							"[WEST]" = list("x" =  -8, "y" = -1),
 							),
 		"[BACK_LAYER]" = list(
-							"[NORTH]" = list("x" = 8, "y" = -1),
-							"[EAST]" = list("x" = 16, "y" = -1),
-							"[SOUTH]" = list("x" = 8, "y" = -1),
-							"[WEST]" = list("x" =  0, "y" = -1)
+							"[NORTH]" = list("x" = 9, "y" = -3),
+							"[EAST]" = list("x" = 16, "y" = -3),
+							"[SOUTH]" = list("x" = 9, "y" = -3),
+							"[WEST]" = list("x" =  0, "y" = -3)
 							),
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -95,7 +95,13 @@
 							"[NORTH]" = list("x" = 8, "y" = 0),
 							"[EAST]" = list("x" = 8, "y" = 0),
 							"[SOUTH]" = list("x" = 8, "y" = 0),
-							"[WEST]" = list("x" =  -8, "y" = 0)
+							"[WEST]" = list("x" =  -8, "y" = 0),
+							),
+		"[BACK_LAYER]" = list(
+							"[NORTH]" = list("x" = 8, "y" = 0),
+							"[EAST]" = list("x" = 16, "y" = 0),
+							"[SOUTH]" = list("x" = 8, "y" = 0),
+							"[WEST]" = list("x" =  0, "y" = 0)
 							),
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -103,7 +103,6 @@
 							"[SOUTH]" = list("x" = 8, "y" = 0),
 							"[WEST]" = list("x" =  0, "y" = 0)
 							), // [CELADON-ADD] - SPECIES OFFSETS
-							),
 	)
 
 /datum/species/vox/random_name(gender,unique,lastname)

--- a/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -86,10 +86,10 @@
 	// BYOND will try to make it an ordered list. So, we have to use a string. This is annoying, but it's the only way to do it smoothly.
 	offset_clothing = list(
 		"[SUIT_STORE_LAYER]" = list(
-							"[NORTH]" = list("x" = 9, "y" = -3),
+							"[NORTH]" = list("x" = 9, "y" = -3), // [CELADON-ADD] - SPECIES OFFSETS
 							"[EAST]" = list("x" = 16, "y" = -3),
 							"[SOUTH]" = list("x" = 9, "y" = -3),
-							"[WEST]" = list("x" =  0, "y" = -3)
+							"[WEST]" = list("x" =  0, "y" = -3) // [CELADON-ADD] - SPECIES OFFSETS
 							),
 		"[EARS_LAYER]" = list(
 							"[NORTH]" = list("x" = 8, "y" = 0),
@@ -97,11 +97,12 @@
 							"[SOUTH]" = list("x" = 8, "y" = 0),
 							"[WEST]" = list("x" =  -8, "y" = 0)
 							),
-		"[BACK_LAYER]" = list(
+		"[BACK_LAYER]" = list( // [CELADON-ADD] - SPECIES OFFSETS
 							"[NORTH]" = list("x" = 8, "y" = 0),
 							"[EAST]" = list("x" = 16, "y" = 0),
 							"[SOUTH]" = list("x" = 8, "y" = 0),
 							"[WEST]" = list("x" =  0, "y" = 0)
+							), // [CELADON-ADD] - SPECIES OFFSETS
 							),
 	)
 

--- a/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -86,16 +86,16 @@
 	// BYOND will try to make it an ordered list. So, we have to use a string. This is annoying, but it's the only way to do it smoothly.
 	offset_clothing = list(
 		"[SUIT_STORE_LAYER]" = list(
-							"[NORTH]" = list("x" = 8, "y" = 0),
-							"[EAST]" = list("x" = 8, "y" = 0),
-							"[SOUTH]" = list("x" = 8, "y" = 0),
-							"[WEST]" = list("x" =  -8, "y" = 0)
+							"[NORTH]" = list("x" = 9, "y" = -3),
+							"[EAST]" = list("x" = 16, "y" = -3),
+							"[SOUTH]" = list("x" = 9, "y" = -3),
+							"[WEST]" = list("x" =  0, "y" = -3)
 							),
 		"[EARS_LAYER]" = list(
 							"[NORTH]" = list("x" = 8, "y" = 0),
 							"[EAST]" = list("x" = 8, "y" = 0),
 							"[SOUTH]" = list("x" = 8, "y" = 0),
-							"[WEST]" = list("x" =  -8, "y" = 0),
+							"[WEST]" = list("x" =  -8, "y" = 0)
 							),
 		"[BACK_LAYER]" = list(
 							"[NORTH]" = list("x" = 8, "y" = 0),

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -478,7 +478,7 @@ There are several things that need to be remembered:
 				handled_by_bodytype = TRUE
 
 			var/use_autogen = handled_by_bodytype ? dna.species : null
-			suit_store_overlay = I.build_worn_icon(default_layer = -SUIT_STORE_LAYER, default_icon_file = icon_file, override_file = icon_file, isinhands = FALSE, override_file = icon_file, mob_species = use_autogen)
+			suit_store_overlay = I.build_worn_icon(default_layer = SUIT_STORE_LAYER, default_icon_file = icon_file, override_file = icon_file, isinhands = FALSE, override_file = icon_file, mob_species = use_autogen)
 
 			if(!suit_store_overlay)
 				return
@@ -890,11 +890,11 @@ There are several things that need to be remembered:
 /obj/item/proc/wear_species_version(file2use, state2use, layer, datum/species/mob_species)
 	if(!slot_flags) // If it's not wearable, don't try
 		return FALSE
-	var/icon/species_clothing_icon = GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]"]
+	var/icon/species_clothing_icon = GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"]
 	if(!species_clothing_icon) 	//Create standing/laying icons if they don't exist
 		if(!generate_species_clothing(file2use, state2use, layer, mob_species))
 			return FALSE
-	return mutable_appearance(GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]"], layer = -layer)
+	return mutable_appearance(GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"], layer = -layer)
 
 /mob/living/carbon/human/proc/get_overlays_copy(list/unwantedLayers)
 	var/list/out = new

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -478,7 +478,7 @@ There are several things that need to be remembered:
 				handled_by_bodytype = TRUE
 
 			var/use_autogen = handled_by_bodytype ? dna.species : null
-			suit_store_overlay = I.build_worn_icon(default_layer = SUIT_STORE_LAYER, default_icon_file = icon_file, override_file = icon_file, isinhands = FALSE, override_file = icon_file, mob_species = use_autogen)
+			suit_store_overlay = I.build_worn_icon(default_layer = SUIT_STORE_LAYER, default_icon_file = icon_file, override_file = icon_file, isinhands = FALSE, override_file = icon_file, mob_species = use_autogen) // [CELADON-ADD] - SPECIES OFFSETS
 
 			if(!suit_store_overlay)
 				return
@@ -890,11 +890,11 @@ There are several things that need to be remembered:
 /obj/item/proc/wear_species_version(file2use, state2use, layer, datum/species/mob_species)
 	if(!slot_flags) // If it's not wearable, don't try
 		return FALSE
-	var/icon/species_clothing_icon = GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"]
+	var/icon/species_clothing_icon = GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"] // [CELADON-ADD] - SPECIES OFFSETS
 	if(!species_clothing_icon) 	//Create standing/laying icons if they don't exist
 		if(!generate_species_clothing(file2use, state2use, layer, mob_species))
 			return FALSE
-	return mutable_appearance(GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"], layer = -layer)
+	return mutable_appearance(GLOB.species_clothing_icons[mob_species.id]["[file2use]-[state2use]-[layer]"], layer = -layer) // [CELADON-ADD] - SPECIES OFFSETS
 
 /mob/living/carbon/human/proc/get_overlays_copy(list/unwantedLayers)
 	var/list/out = new

--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -30,6 +30,7 @@
 #include "code/shutters.dm"
 #include "code/simple_mobs.dm"
 #include "code/species_moth.dm"
+#include "code/species_sprite_helper.dm"
 #include "code/status_effects.dm"
 #include "code/TEG_pipes.dm"
 #include "code/tesla.dm"

--- a/mod_celadon/fixes/code/species_sprite_helper.dm
+++ b/mod_celadon/fixes/code/species_sprite_helper.dm
@@ -1,0 +1,34 @@
+/obj/item
+	/// Per-species sprite offsets. Format: list("species_id" = list("NORTH" = list("x" = 0, "y" = 0), "SOUTH" = ..., etc.))
+	var/list/species_offsets
+	/* EXAMPLE:
+	species_offsets = list(
+		SPECIES_KEPORI = list(
+			"[NORTH]" = list("x" = 10, "y" = -2),
+			"[EAST]" = list("x" = 12, "y" = -1),
+			"[SOUTH]" = list("x" = 10, "y" = -2),
+			"[WEST]" = list("x" = -10, "y" = -1)
+		)
+	)
+	*/
+
+/**
+ * Helper proc to get species-specific sprite offsets for worn clothing
+ * Checks item-specific offsets first, then falls back to species layer offsets
+ *
+ * Arguments:
+ * * layer - The layer the item is being worn on
+ * * mob_species - The species datum of the wearer
+ *
+ * Returns: List of directional offsets, or null if none apply
+ */
+/obj/item/proc/get_species_worn_offsets(layer, datum/species/mob_species)
+	// Item-specific offsets take priority
+	if(species_offsets && (mob_species.id in species_offsets))
+		return species_offsets[mob_species.id]
+
+	// Fall back to species layer offsets
+	if("[layer]" in mob_species.offset_clothing)
+		return mob_species.offset_clothing["[layer]"]
+
+	return null

--- a/mod_celadon/fixes/code/species_sprite_helper.dm
+++ b/mod_celadon/fixes/code/species_sprite_helper.dm
@@ -1,34 +1,20 @@
-/obj/item
-	/// Per-species sprite offsets. Format: list("species_id" = list("NORTH" = list("x" = 0, "y" = 0), "SOUTH" = ..., etc.))
-	var/list/species_offsets
-	/* EXAMPLE:
-	species_offsets = list(
-		SPECIES_KEPORI = list(
-			"[NORTH]" = list("x" = 10, "y" = -2),
-			"[EAST]" = list("x" = 12, "y" = -1),
-			"[SOUTH]" = list("x" = 10, "y" = -2),
-			"[WEST]" = list("x" = -10, "y" = -1)
-		)
-	)
-	*/
-
 /**
  * Helper proc to get species-specific sprite offsets for worn clothing
- * Checks item-specific offsets first, then falls back to species layer offsets
+ * Uses species-level offset definitions
  *
  * Arguments:
- * * layer - The layer the item is being worn on
+ * * layer - The layer the item is being worn on (may be negative for rendering order)
  * * mob_species - The species datum of the wearer
  *
  * Returns: List of directional offsets, or null if none apply
  */
-/obj/item/proc/get_species_worn_offsets(layer, datum/species/mob_species)
-	// Item-specific offsets take priority
-	if(species_offsets && (mob_species.id in species_offsets))
-		return species_offsets[mob_species.id]
 
-	// Fall back to species layer offsets
-	if("[layer]" in mob_species.offset_clothing)
-		return mob_species.offset_clothing["[layer]"]
+/obj/item/proc/get_species_worn_offsets(layer, datum/species/mob_species)
+	// Use absolute value since some layers are passed as negative
+	var/abs_layer = abs(layer)
+
+	// Check species layer offsets
+	if("[abs_layer]" in mob_species.offset_clothing)
+		return mob_species.offset_clothing["[abs_layer]"]
 
 	return null


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправление отображение оружия на кепори с Pentest (Really Cool, and special thanks Pentest)
Достаточно подробно описанное в оригинальном посте, кто захочет тот перейдет и почитает.
- https://github.com/PentestSS13/Pentest/pull/504

## Причина создания ПР / Почему это хорошо для игры
> No more floating guns on backs of Kepori
> I expected shiptest to eventually fix this. But since they wont, I will.

## Демонстрация изменений / Тестирование
https://github.com/user-attachments/assets/9d9864c9-f08c-4cd2-ab36-a26f01b7bd73

## Список изменений

```yml
🆑
fix: Кепори и Воксы научились носить оружие за спиной, как и другие.
/🆑
```
