### PR TITLE
FIX: Vox scream emote sound

### DIFF
--- a/mod_celadon/emotes/code/species.dm
+++ b/mod_celadon/emotes/code/species.dm
@@ -249,6 +249,8 @@
 	autohiss_exempt = list("Vox-pidgin")
 
 	scream_verb = "скрипит"
+	male_scream_sound = 'mod_celadon/_storage_sounds/sound/plushes/emotes/voxscream.ogg')
+	female_scream_sound = 'mod_celadon/_storage_sounds/sound/plushes/emotes/voxscream.ogg')
 	suicide_messages = list(
 		"пытается откусить себе язык!",
 		"вонзает когти себе в глазницы!",


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет путь к ogg файлу крика вокса в код эмоут панели целадона, возвращая классический крик вокса.

## Причина создания ПР / Почему это хорошо для игры
Багфикс.

## Список изменений

```yml
🆑
sound: Добавлен путь к звуку крика вокса в код эмоут панели целадона
/🆑
```
