### PR TITLE
[FIX] Fixing faction relationships in the ship purchase menu

### DIFF
--- a/tgui/packages/tgui/interfaces/FactionButtons.js
+++ b/tgui/packages/tgui/interfaces/FactionButtons.js
@@ -61,9 +61,7 @@ const CENTRAL_FACTION = {
 // Легенда типов отношений
 const RELATION_TYPES = {
   union: { name: 'Союз', color: '#2ECC71' }, // Зеленый
-  positive: { name: 'Положительные', color: '#87CEEB' }, // Светло-синий
-  neutral: { name: 'Нейтральные', color: '#808080' }, // Серый
-  negative: { name: 'Отрицательные', color: '#FFA500' }, // Оранжевый
+  neutral: { name: 'Нейтральные', color: '#ffd902' }, // Серый
   war: { name: 'Война', color: '#FF0000' }, // Красный
 };
 
@@ -71,7 +69,7 @@ const RELATION_TYPES = {
 const FACTION_RELATIONS = [
   // Nanotrasen отношения
   { from: 'nanotrasen', to: 'solfed', type: 'union' },
-  { from: 'nanotrasen', to: 'elysium', type: 'negative' },
+  { from: 'nanotrasen', to: 'elysium', type: 'war' },
   { from: 'nanotrasen', to: 'inteq', type: 'neutral' },
   { from: 'nanotrasen', to: 'syndicate', type: 'war' },
   { from: 'nanotrasen', to: 'pirates', type: 'war' },
@@ -80,13 +78,13 @@ const FACTION_RELATIONS = [
   // SolFed отношения
   { from: 'solfed', to: 'elysium', type: 'war' },
   { from: 'solfed', to: 'inteq', type: 'neutral' },
-  { from: 'solfed', to: 'syndicate', type: 'negative' },
+  { from: 'solfed', to: 'syndicate', type: 'war' },
   { from: 'solfed', to: 'pirates', type: 'war' },
   { from: 'solfed', to: 'independent', type: 'neutral' },
 
   // Elysium отношения
   { from: 'elysium', to: 'inteq', type: 'neutral' },
-  { from: 'elysium', to: 'syndicate', type: 'positive' },
+  { from: 'elysium', to: 'syndicate', type: 'union' },
   { from: 'elysium', to: 'pirates', type: 'war' },
   { from: 'elysium', to: 'independent', type: 'neutral' },
 

--- a/tgui/packages/tgui/interfaces/FactionButtons.js
+++ b/tgui/packages/tgui/interfaces/FactionButtons.js
@@ -60,9 +60,9 @@ const CENTRAL_FACTION = {
 
 // Легенда типов отношений
 const RELATION_TYPES = {
-  union: { name: 'Союз', color: '#2ECC71' }, // Зеленый
-  neutral: { name: 'Нейтральные', color: '#ffd902' }, // Серый
-  war: { name: 'Война', color: '#FF0000' }, // Красный
+  union: { name: 'Союз', color: '#2ECC71' },
+  neutral: { name: 'Нейтральные', color: '#ffd902' },
+  war: { name: 'Война', color: '#FF0000' },
 };
 
 // Полная система отношений между всеми 7 фракциями (21 линия)

--- a/tgui/packages/tgui/interfaces/ShipSelect.js
+++ b/tgui/packages/tgui/interfaces/ShipSelect.js
@@ -312,15 +312,9 @@ export const ShipSelect = (props, context) => {
                     Цветные линии показывают отношения между фракциями:
                     <br />
                     <br />
-                    <div style={{ color: '#38A169' }}>Зелёный — Союз</div>
-                    <div style={{ color: '#60A5FA' }}>
-                      Синий — Положительные
-                    </div>
-                    <div style={{ color: '#9CA3AF' }}>Серый — Нейтральные</div>
-                    <div style={{ color: '#F59E0B' }}>
-                      Оранжевый — Отрицательные
-                    </div>
-                    <div style={{ color: '#EF4444' }}>Красный — Война</div>
+                    <div style={{ color: '#2ECC71' }}>Зелёный — Союз</div>
+                    <div style={{ color: '#ffd902' }}>Жёлтый — Нейтральные</div>
+                    <div style={{ color: '#FF0000' }}>Красный — Война</div>
                   </>
                 }
               />


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляем отношения фракций в меню покупке кораблей.

## Причина создания ПР / Почему это хорошо для игры
Убран серый свет, которого изначально не должно вообще быть.
Теперь отношения фракций соответствуют отношениям на википедии.

## Демонстрация изменений / Тестирование
### Было:

<img width="855" height="582" alt="image" src="https://github.com/user-attachments/assets/de7d3d86-6a83-4967-9855-9d09b5a681b2" />

### Стало:

<img width="857" height="583" alt="image" src="https://github.com/user-attachments/assets/ba655e0b-40ac-42a9-8a1a-c3bdc9ed2ce5" /> 

## Список изменений

```yml
🆑
fix: Исправлено отношений фракций в игре.
/🆑
```
