### PR TITLE
MAP: Beach Ruins

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_surface_frontie_moat.dmm
+++ b/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_surface_frontie_moat.dmm
@@ -1,0 +1,6787 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"an" = (
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/dorm)
+"au" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Corpse Storage"
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"av" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-10"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"aC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"aM" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"aW" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"aZ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/emptysandbags{
+	pixel_x = -10;
+	pixel_y = 1
+	},
+/obj/item/storage/box/emptysandbags{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"be" = (
+/obj/effect/turf_decal/stairs_wood{
+	dir = 5;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"bf" = (
+/obj/structure/chair/sofa/brown/old/right/directional/east,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"bg" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"bo" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"bp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"bs" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"bG" = (
+/obj/structure/railing/wood,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"bS" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"bW" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/structure/closet/wall/red/directional/west{
+	name = "armor closet"
+	},
+/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
+/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
+/obj/item/clothing/suit/armor/vest/frontier,
+/obj/item/clothing/suit/armor/vest/frontier,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"cd" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ck" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/dorm)
+"cl" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/obj/item/clothing/head/soft/frontiersmen{
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/duffelbag,
+/obj/item/storage/fancy/cigarettes/derringer,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"cx" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/armory)
+"cK" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"cT" = (
+/obj/effect/decal/cleanable/food/flour,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/condiment/milk{
+	pixel_x = -12;
+	pixel_y = -8;
+	list_reagents = null
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"cU" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"cV" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"cZ" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "s";
+	pixel_y = 13;
+	pixel_x = 14
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"df" = (
+/obj/structure/chair/comfy/beige/old/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/ruin/beach/village/officers)
+"di" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"dl" = (
+/obj/machinery/vending/cola/starkist,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/ruin/beach/village/dorm)
+"dq" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"dN" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"ed" = (
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 7;
+	pixel_y = 33
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/item/clothing/head/chefhat{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"ee" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/fish/lanternfish,
+/obj/item/fish/lanternfish,
+/obj/item/fish/lanternfish,
+/obj/item/fish/lanternfish,
+/obj/item/fish/pufferfish,
+/obj/item/fish/bass,
+/obj/item/fish/bass,
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/item/fish/donkfish,
+/obj/item/fish/emulsijack,
+/obj/item/fish/salmon,
+/obj/item/fish/salmon,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"eh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"ei" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/power/rtg/geothermal,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"ew" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/beach/village/dorm)
+"eW" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer,
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/ruin/beach/village/officers)
+"fa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"fh" = (
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"fr" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"ft" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/surgeon/neuter,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"fC" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals2,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"fR" = (
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"fU" = (
+/obj/machinery/door/airlock/wood/glass{
+	dir = 4;
+	name = "Dormitory"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"gh" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"gj" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/black{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"go" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/infirmary)
+"gr" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"gz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/armory)
+"gE" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "getout";
+	pixel_y = -3;
+	pixel_x = -5
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"gK" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"gM" = (
+/obj/structure/table,
+/obj/item/food/candyheart{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"gX" = (
+/obj/structure/railing/wood{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"hv" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/cm23{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/cm23{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/stock_parts/cell/gun,
+/obj/effect/turf_decal/siding/thinplating/corner,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"hy" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/infirmary)
+"hD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"hF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/wood{
+	dir = 4;
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"hG" = (
+/obj/structure/dresser{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"hR" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "o";
+	pixel_y = 12;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "shotgun";
+	pixel_y = -6;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "h";
+	pixel_y = 14;
+	pixel_x = -7
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"hV" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"hY" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4;
+	name = "Head Boss Bedroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"iE" = (
+/obj/structure/rack,
+/obj/item/pickaxe{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/pickaxe{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/pickaxe,
+/obj/item/pickaxe{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"iF" = (
+/obj/structure/chair/sofa/brown/old/right{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/dorm)
+"iG" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"iN" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/beach/village/officers)
+"iQ" = (
+/obj/machinery/door/airlock/wood{
+	name = "Boss Bedroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"iR" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"iU" = (
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"iZ" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"jb" = (
+/obj/machinery/door/airlock/wood{
+	name = "Deck"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"jd" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"je" = (
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"jm" = (
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/ruin/beach/village/armory)
+"jn" = (
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/carpet/orange,
+/area/ruin/beach/village/dorm)
+"jD" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"jH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"jS" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"kc" = (
+/obj/machinery/power/terminal,
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"ki" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"kr" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"kA" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"kI" = (
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"kL" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"lc" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"le" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"lf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ll" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/beach/village/kitchen)
+"lm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"lw" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"lx" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"ly" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"lz" = (
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"lB" = (
+/turf/open/water/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"lC" = (
+/obj/structure/platform/wood{
+	dir = 10
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"lM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"lR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"mb" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"mh" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"mi" = (
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/armory)
+"mm" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"mn" = (
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"mw" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"mG" = (
+/obj/effect/turf_decal/road,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"mK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"mM" = (
+/obj/structure/table/reinforced,
+/obj/item/defibrillator/loaded{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"mQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/ruin/beach/village/officers)
+"ng" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"nu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"nL" = (
+/turf/open/floor/carpet/black,
+/area/ruin/beach/village/officers)
+"nM" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"nQ" = (
+/obj/item/clothing/head/chefhat{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"nT" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"nV" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ol" = (
+/obj/structure/platform/wood/corner,
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"op" = (
+/obj/structure/chair/plastic,
+/obj/effect/mapping_helpers/chair/tim_buckley,
+/obj/effect/mob_spawn/human/corpse/frontier/fake,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ot" = (
+/obj/structure/table/wood/fancy,
+/obj/item/paper_bin{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"oz" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"oH" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"oK" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"oM" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "o";
+	pixel_y = 12;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "t";
+	pixel_y = 12;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "e";
+	pixel_y = -5;
+	pixel_x = 9
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "m";
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"oR" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"oU" = (
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"pg" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ph" = (
+/obj/structure/chair/comfy/beige/old/directional/north,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/officers)
+"pl" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/medical{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/obj/item/screwdriver/power{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/gear_pack/anglegrinder{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"pm" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"pI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"pJ" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"pK" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"pQ" = (
+/obj/structure/table,
+/obj/item/clothing/mask/cigarette,
+/obj/item/clothing/mask/cigarette{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/cigarette{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/lighter{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/officers)
+"qa" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"qe" = (
+/obj/effect/mob_spawn/human/corpse/solfed/marine/pistol,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"qk" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/power/rtg/geothermal,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"qp" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"qq" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"qF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"qI" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"qK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"qO" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/fax/ruin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"qZ" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"rb" = (
+/turf/template_noop,
+/area/template_noop)
+"rn" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"rv" = (
+/obj/structure/chair/plastic,
+/mob/living/simple_animal/hostile/human/frontier/ranged,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"rz" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/human/corpse/solfed/marine,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"rA" = (
+/obj/structure/platform/wood,
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"rB" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/obj/item/clothing/head/soft/frontiersmen{
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/duffelbag,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"rD" = (
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"rI" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/item/clothing/under/clip/minutemen{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"sh" = (
+/obj/structure/chair/comfy/beige/old/directional/east,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"si" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"sq" = (
+/obj/machinery/door/airlock/maintenance/external/glass{
+	name = "Armory"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"st" = (
+/obj/structure/chair/sofa/brown/old/directional/east,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"sU" = (
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/mask/cigarette/rollie/trippy{
+	pixel_x = 6;
+	pixel_y = -9
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"sY" = (
+/obj/structure/chair/sofa/brown/old/left{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4;
+	pixel_x = -2;
+	pixel_y = -11
+	},
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/dorm)
+"sZ" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"tc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ts" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"tw" = (
+/obj/structure/table,
+/obj/item/storage/box/fishing_hooks{
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/bait_can/worm/premium{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/item/bait_can/worm/premium{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"tN" = (
+/obj/structure/closet,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"uc" = (
+/obj/structure/platform/wood,
+/obj/structure/platform/wood{
+	dir = 10
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"uk" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals2,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"uw" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"uE" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"uF" = (
+/obj/structure/table,
+/obj/item/storage/cans/sixbeer{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/fishing_rod,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"uJ" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/heart_box{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"uP" = (
+/obj/structure/chair/sofa/brown/old/right{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"uS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"uU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"uV" = (
+/turf/closed/wall/mineral/wood,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"vd" = (
+/obj/effect/turf_decal/siding/thinplating/corner,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"vm" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"vn" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"vv" = (
+/obj/item/kitchen/rollingpin{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/food/flour,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"vB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Medical"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/infirmary)
+"vK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"vP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"vR" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"vU" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/item/clothing/head/helmet/m10/clip_vc{
+	pixel_x = -10;
+	pixel_y = -9;
+	desc = "A special, lightweight and padded helmet issued to Vehicle Crewmen of the SolFed. Features noise-reducing technology and a microphone that automatically connects with worn headsets. Hopefully protects you from bumpy rides.";
+	name = "\improper SolFed CM-12 Helmet"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"vV" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"vX" = (
+/obj/effect/spawner/bunk_bed,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"wk" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"wo" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"wx" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"wA" = (
+/turf/closed/wall/mineral/sandstone,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"wK" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/officers)
+"wP" = (
+/obj/structure/table,
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"wT" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib4";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"wW" = (
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xc" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"xe" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"xi" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xj" = (
+/obj/structure/table/chem,
+/obj/item/reagent_containers/glass/beaker/large/napalm{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"xm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xs" = (
+/obj/structure/punji_sticks,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xy" = (
+/obj/item/restraints/legcuffs/beartrap{
+	armed = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xC" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/obj/item/clothing/head/soft/frontiersmen{
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/duffelbag,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_x = -10;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_x = 13;
+	pixel_y = 13
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"xN" = (
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/mob_spawn/human/corpse/solfed/marine/melee,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"xO" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered/sentry,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xR" = (
+/obj/effect/turf_decal/road,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"xS" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/beach/village/dorm)
+"xU" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"yb" = (
+/obj/effect/mob_spawn/animal_corpse/wolf,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"ym" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"yx" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/f4_308/empty{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/f4_308/empty{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"yR" = (
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/effect/mob_spawn/human/corpse/solfed/marine/sniper,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"yT" = (
+/obj/structure/chair/office,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"za" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"zp" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "!";
+	pixel_y = -4;
+	pixel_x = -10
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"zw" = (
+/obj/structure/table/reinforced,
+/obj/item/cutting_board,
+/obj/item/food/pancakes,
+/obj/item/food/pancakes{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/melee/knife/butcher{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/food/grown/banana{
+	pixel_x = 10;
+	pixel_y = -8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"zy" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/beach/village/infirmary)
+"zK" = (
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Am" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Aq" = (
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"Ay" = (
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"AA" = (
+/obj/structure/table/chem,
+/obj/item/reagent_containers/glass/beaker/plastic{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/bodybag{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/item/bodybag{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"AC" = (
+/obj/structure/chair/sofa/brown/old/left/directional/west,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"AF" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"AP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"AV" = (
+/obj/machinery/griddle,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"Ba" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/obj/item/clothing/head/soft/frontiersmen{
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/duffelbag,
+/obj/effect/turf_decal/siding/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Bd" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4;
+	name = "Officers Quarters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/officers)
+"Bh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"Bk" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Bx" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"BH" = (
+/turf/open/floor/carpet/red,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"BK" = (
+/obj/structure/table,
+/obj/item/fishing_rod{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"BP" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/f3/sentry{
+	weapon_drop_chance = 100;
+	desc = "A member of the brutal Frontiersman terrorist fleet! Bedecked in military-grade armor, they steadily hold their well-kept DMR in your direction."
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Ca" = (
+/obj/structure/table/glass,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"Cf" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4;
+	name = "Kitchen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"Cn" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Cw" = (
+/obj/structure/table/glass,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"CK" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"CM" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"CP" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"De" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Df" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"Dg" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/storage/box/ammo/a8_50r,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/item/storage/box/ammo/c10mm,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/item/storage/box/ammo/a308,
+/obj/item/storage/box/ammo/a308,
+/obj/item/storage/box/ammo/c9mm,
+/obj/item/storage/box/ammo/c9mm,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Dn" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Dp" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/officer,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"Dq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"Dt" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"Dv" = (
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"Dy" = (
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"DG" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"DJ" = (
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -22;
+	id = "villagesecure";
+	name = "Shed Door"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"DK" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"DQ" = (
+/obj/structure/chair/bench/beige/directional/east,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"DT" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"DU" = (
+/turf/open/floor/carpet/red,
+/area/ruin/beach/village/officers)
+"Eb" = (
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"Ef" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Eg" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "floor4"
+	},
+/obj/item/clothing/head/helmet/bulletproof/x11/clip{
+	pixel_x = 6;
+	pixel_y = -5;
+	name = "\improper SolFed CM-11 Helmet";
+	desc = "A large, bulky bulletproof helmet in the distinctive blue coloring of the SolFed. Features a little attachment rail on the side where you can mount a flashlight."
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Eo" = (
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Er" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Es" = (
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"EG" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "getout";
+	pixel_y = 1;
+	pixel_x = 2
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"EK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"ER" = (
+/obj/structure/flora/tree/dead/barren,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"EU" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/gas/frontiersmen,
+/obj/item/clothing/mask/gas/frontiersmen,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/item/clothing/mask/gas/solfed,
+/obj/item/clothing/mask/gas/solfed,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Fa" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper{
+	retreat_distance = 0;
+	minimum_distance = 0
+	},
+/obj/structure/chair/bench/beige/directional/west,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"Fp" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Fw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"FD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"FJ" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"FL" = (
+/mob/living/basic/cow{
+	faction = list("Frontiersmen");
+	name = "frontiersmen cow";
+	desc = "You get the feeling that somehow, this cow wishes they'd hit Luna-Town again."
+	},
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"FM" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"FT" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"FV" = (
+/obj/structure/railing/corner/wood,
+/obj/structure/railing/corner/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"FX" = (
+/turf/open/floor/carpet/orange,
+/area/ruin/beach/village/dorm)
+"FY" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"Gj" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/beach/village/infirmary)
+"Gl" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Gn" = (
+/obj/effect/spawner/bunk_bed,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Gs" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"GB" = (
+/obj/structure/railing/corner,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"GE" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/beach/village/officers)
+"GM" = (
+/obj/effect/mob_spawn/animal_corpse/wolf,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"GN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"GP" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Hk" = (
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 7;
+	pixel_y = 33
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"Hn" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Hq" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/beach/village/officers)
+"Ht" = (
+/obj/machinery/firealarm/directional/south{
+	pixel_x = 8;
+	pixel_y = -32
+	},
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = -6;
+	pixel_y = -28
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/beach/village/dorm)
+"HA" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"HB" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"HI" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"HK" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"HP" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"HR" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 2;
+	id = "villagesecure";
+	name = "Shed Override"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"HS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/beach/village/dorm)
+"If" = (
+/turf/closed/wall/concrete,
+/area/ruin/beach/village/armory)
+"Ig" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Iw" = (
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Iz" = (
+/obj/structure/fluff/hedge/opaque,
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"IM" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"IO" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"IU" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Generator"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Jk" = (
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Jr" = (
+/obj/structure/curtain/cloth/grey,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"JV" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"Kc" = (
+/obj/structure/table,
+/obj/item/gun_maint_kit{
+	uses = 2;
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/binoculars{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Kd" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Kh" = (
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Kk" = (
+/obj/item/gun/ballistic/automatic/pistol/cm23,
+/obj/structure/guncloset,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Ko" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"Kp" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/wasp,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/village/dorm)
+"Kv" = (
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"KS" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"KT" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Lu" = (
+/obj/structure/dresser{
+	dir = 8;
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"LH" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"LN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "villagesecure"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"LR" = (
+/obj/structure/urinal{
+	dir = 4;
+	pixel_x = -18;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/village/armory)
+"LS" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"Mq" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"Mt" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/beach/village/dorm)
+"ML" = (
+/mob/living/simple_animal/hostile/human/frontier{
+	name = "Frontiersman Chef";
+	desc = "A member of the brutal Frontiersman terrorist fleet! This one clutches an average looking kitchen knife, and seems quite frustrated."
+	},
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"MW" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"MX" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"MY" = (
+/obj/structure/table/reinforced,
+/obj/item/shovel{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shovel{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/shovel{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/hatchet/wooden{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/hatchet/wooden{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/molotov/full{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/lighter/greyscale{
+	pixel_x = 2;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/beach/village/armory)
+"Nq" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Ns" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"Nu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Ny" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/ruin/beach/village/armory)
+"NB" = (
+/turf/open/floor/concrete/slab_2,
+/area/ruin/beach/village/officers)
+"NC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"NN" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/ruin/beach/village/officers)
+"NU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"NV" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/red,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"NZ" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Bathroom"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Oc" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/beach/village/kitchen)
+"Oi" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Oj" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/frontier,
+/obj/item/clothing/under/frontiersmen/officer,
+/obj/item/clothing/head/frontier/peaked,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/under/shorts/jorts,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"Ol" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"Ow" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Oy" = (
+/obj/structure/ore_box,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"OB" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"ON" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"OY" = (
+/obj/structure/railing/wood{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Pe" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/rations,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Pl" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Pm" = (
+/obj/structure/chair/sofa/brown/old/left/directional/east,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"Pu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Py" = (
+/mob/living/basic/cow{
+	faction = list("Frontiersmen");
+	name = "frontiersmen cow";
+	desc = "You get the feeling that somehow, this cow wishes they'd hit Luna-Town again. They also have a pancake in their mouth."
+	},
+/obj/item/grown/bananapeel{
+	pixel_x = -8;
+	pixel_y = -13
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"PK" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"PT" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"PZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/beach/village/armory)
+"Qe" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"Qf" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"QA" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"QB" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/cigarette/rollie/trippy{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"QO" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/ruin/beach/village/officers)
+"QP" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Rx" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/sand/dense/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"RE" = (
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"RP" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 8;
+	name = "Engineering"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Sg" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Sp" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"Su" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Sw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/ruin/beach/village/officers)
+"SE" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"SP" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/kitchen)
+"SU" = (
+/obj/machinery/door/airlock/wood/glass{
+	dir = 4;
+	name = "Dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"Tj" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/shoes/combat{
+	pixel_y = -10
+	},
+/obj/item/clothing/head/soft/frontiersmen{
+	pixel_y = 5
+	},
+/obj/item/storage/backpack/duffelbag,
+/obj/item/clothing/under/shorts/jorts,
+/obj/item/clothing/under/shorts/jorts,
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Tr" = (
+/obj/structure/fluff/beach_umbrella,
+/turf/open/floor/carpet/red,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Tv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Ty" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/black{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"Tz" = (
+/obj/structure/rack,
+/obj/item/towel{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/towel{
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/obj/item/towel{
+	pixel_x = 9;
+	pixel_y = 1
+	},
+/obj/item/towel{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/towel{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/item/towel{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"TA" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/siding/thinplating,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/effect/spawner/random/trash/ghetto_containers,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"TD" = (
+/obj/structure/curtain/cloth/grey,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"TP" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"TR" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"TV" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/f3/sentry,
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Ud" = (
+/turf/open/floor/wood,
+/area/ruin/beach/village/dorm)
+"Uh" = (
+/obj/effect/turf_decal/road,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/ruin/beach/village/armory)
+"Uj" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/frontier,
+/obj/item/clothing/under/frontiersmen/officer,
+/obj/item/clothing/head/frontier/peaked,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/under/shorts/dolphin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"Ul" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "villagesecure"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Ut" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/ruin/beach/village/officers)
+"Uw" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"UB" = (
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/obj/structure/table/reinforced,
+/obj/structure/sink/kitchen{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"UD" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4;
+	name = "Dormitory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/dorm)
+"UK" = (
+/obj/item/storage/toolbox/fishing{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/storage/backpack/duffelbag{
+	pixel_x = -17;
+	pixel_y = -11
+	},
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"UM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"UX" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"Vg" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Vt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Vu" = (
+/obj/structure/window/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/beach/village/officers)
+"VF" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ruin/beach/village/infirmary)
+"VN" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"VV" = (
+/obj/structure/curtain/cloth/grey,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/armory)
+"Wa" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"WC" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"WO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/kitchen)
+"WR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/orange,
+/area/ruin/beach/village/dorm)
+"Xg" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/beach/village/infirmary)
+"Xt" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/kitchen)
+"Xv" = (
+/obj/structure/railing/corner/wood{
+	dir = 1
+	},
+/obj/structure/railing/corner/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Xz" = (
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/village/officers)
+"XF" = (
+/obj/structure/table,
+/obj/item/food/candyheart{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/asteroid/sand/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Ya" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/infirmary)
+"Ye" = (
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/village/armory)
+"Yf" = (
+/mob/living/basic/cow{
+	faction = list("Frontiersmen");
+	name = "frontiersmen cow";
+	desc = "You get the feeling that somehow, this cow wishes they'd hit Luna-Town again."
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Yv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/village/armory)
+"Yz" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/village/armory)
+"YG" = (
+/obj/effect/turf_decal/road,
+/turf/open/floor/concrete/pavement/beachplanet/lit,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"YV" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/armor/frontier,
+/obj/item/clothing/under/frontiersmen/officer,
+/obj/item/clothing/head/frontier/peaked,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/under/shorts/jorts,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/beach/village/officers)
+"YW" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+"Za" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/village/armory)
+"Zs" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	populate = 0
+	},
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/food/cheese/wheel,
+/obj/item/food/cheese/wheel,
+/obj/machinery/light/directional/north,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/village/kitchen)
+"ZA" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/beach/village/officers)
+"ZI" = (
+/obj/structure/platform/wood{
+	dir = 9
+	},
+/turf/open/water/beach/deep,
+/area/overmap_encounter/planetoid/beachplanet/explored)
+
+(1,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(2,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(3,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(4,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(5,1,1) = {"
+rb
+rb
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(6,1,1) = {"
+rb
+rb
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(7,1,1) = {"
+rb
+rb
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(8,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(9,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+"}
+(10,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+fh
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(11,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+lB
+lB
+Jk
+Jk
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+lB
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(12,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+ng
+ng
+ng
+ng
+ng
+vm
+lB
+lB
+lB
+ol
+ng
+ng
+ng
+ng
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+fh
+fh
+Dy
+fh
+fh
+fh
+fh
+fh
+rb
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+le
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(13,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+lB
+lB
+lB
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+oU
+oU
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(14,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+lB
+lB
+lB
+rA
+fh
+fh
+fh
+fh
+fh
+Dy
+xs
+oU
+Dy
+fh
+fh
+fh
+Dy
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+nu
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(15,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+lB
+lB
+rA
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+fh
+oU
+oU
+oU
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(16,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+ZI
+CP
+CP
+CP
+CP
+CP
+ym
+Jk
+lB
+Jk
+HK
+CP
+CP
+CP
+CP
+lC
+Dy
+Dy
+ZI
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+lC
+Dy
+xy
+ZI
+CP
+lC
+oU
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(17,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+ZI
+ym
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+rA
+oU
+Dy
+QP
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+rA
+Dy
+Dy
+QP
+Jk
+HK
+lC
+oU
+oU
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+"}
+(18,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+ol
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+qI
+xs
+Dy
+HB
+ng
+ng
+ng
+ng
+vm
+Jk
+ol
+ng
+ng
+ng
+ng
+qI
+xy
+Dy
+HB
+vm
+Jk
+rA
+oU
+oU
+nu
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+"}
+(19,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+TR
+fh
+fh
+fh
+fh
+Dy
+Dy
+fh
+fh
+fh
+fh
+fh
+HB
+ng
+qI
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+fh
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+oU
+rb
+oU
+oU
+rb
+rb
+"}
+(20,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+zy
+Gj
+Gj
+Gj
+zy
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+fh
+fh
+Dy
+OB
+OB
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+oU
+nu
+oU
+rb
+rb
+rb
+"}
+(21,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+zy
+lw
+vn
+SE
+zy
+zy
+zy
+fh
+Dy
+Dy
+Dy
+Dy
+oU
+FM
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+cd
+TR
+Dy
+vR
+OB
+QP
+Jk
+rA
+oU
+oU
+oU
+Kd
+oU
+oU
+oU
+oU
+rb
+rb
+"}
+(22,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+Dy
+zy
+oK
+oK
+fr
+NC
+mw
+zy
+Dy
+Dy
+Dy
+oU
+oU
+oU
+oU
+oU
+iZ
+oU
+Es
+Es
+Es
+ZI
+CP
+lC
+fh
+fh
+Dy
+cd
+Dy
+Dy
+QB
+OB
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+oU
+Dy
+Dy
+Dy
+rb
+rb
+"}
+(23,1,1) = {"
+rb
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+Dy
+zy
+Xg
+cK
+Sp
+Ya
+QA
+zy
+hy
+Dy
+oU
+oU
+oU
+iZ
+oU
+oU
+oU
+oU
+oU
+oU
+Es
+QP
+Jk
+rA
+fh
+fh
+fh
+Dy
+Dy
+nV
+OB
+OB
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+rb
+rb
+"}
+(24,1,1) = {"
+rb
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+Dy
+Gj
+ft
+Dp
+Sp
+hV
+Bh
+vB
+go
+Dy
+oU
+oU
+oU
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+fh
+fh
+Dy
+Dy
+fh
+fh
+fh
+QP
+gE
+rA
+fh
+Bk
+oU
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+rb
+"}
+(25,1,1) = {"
+rb
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+Dy
+zy
+Dt
+cK
+lx
+JV
+NC
+zy
+hy
+za
+oU
+oU
+oU
+If
+tN
+Tz
+If
+LR
+LR
+LR
+If
+gz
+Jr
+Hn
+If
+fh
+Es
+Dy
+Ef
+cZ
+OB
+OB
+QP
+Jk
+rA
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+rb
+"}
+(26,1,1) = {"
+rb
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+Dy
+zy
+mM
+pl
+VF
+uw
+xj
+zy
+oU
+pI
+oU
+oU
+If
+If
+bs
+Fp
+VV
+GN
+AP
+Yv
+TD
+cx
+If
+If
+If
+Es
+Es
+Dy
+Dy
+hR
+EG
+OB
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+"}
+(27,1,1) = {"
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+oU
+zy
+zy
+Ol
+av
+yT
+AA
+zy
+Dy
+pI
+oU
+oU
+If
+Aq
+PZ
+Mq
+If
+Kv
+ON
+UB
+If
+gz
+Jr
+dN
+If
+Es
+Es
+Es
+Dy
+oM
+op
+OB
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+"}
+(28,1,1) = {"
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+oU
+oU
+zy
+zy
+zy
+zy
+zy
+zy
+Dy
+PT
+oU
+Su
+If
+uk
+pm
+fC
+If
+Ye
+Ye
+UB
+If
+If
+If
+If
+If
+If
+Es
+Dy
+oU
+zp
+OB
+OB
+rI
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+"}
+(29,1,1) = {"
+fh
+fh
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+oU
+oU
+FL
+oU
+oU
+oU
+bG
+oU
+Dy
+pI
+oU
+oU
+If
+If
+If
+If
+If
+NZ
+If
+If
+If
+Pe
+wx
+TA
+iE
+If
+Nq
+Dy
+oU
+oU
+fh
+fh
+FT
+ng
+qI
+fh
+fh
+fh
+fh
+oU
+oU
+oU
+oU
+oU
+oU
+"}
+(30,1,1) = {"
+fh
+fh
+fh
+fh
+fh
+oU
+QP
+Jk
+rA
+oU
+oU
+Ay
+oU
+Yf
+nu
+bG
+oU
+oU
+pI
+iZ
+oU
+If
+hv
+bW
+Vg
+If
+Df
+DQ
+lc
+nM
+IO
+vd
+pK
+rD
+Ul
+jm
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+xm
+xm
+Kh
+Kh
+Kh
+oU
+"}
+(31,1,1) = {"
+fh
+fh
+fh
+fh
+fh
+oU
+QP
+Jk
+rA
+oU
+oU
+Ay
+oU
+oU
+oU
+bG
+oU
+Su
+tc
+oU
+oU
+If
+Dg
+gz
+gz
+Gs
+aC
+HI
+lc
+If
+Fw
+Iw
+cV
+Nu
+LN
+Uh
+xR
+YG
+YG
+mG
+mG
+mG
+mG
+mG
+YG
+YG
+YG
+mG
+mG
+YG
+YG
+YG
+YG
+oU
+"}
+(32,1,1) = {"
+rb
+fh
+fh
+fh
+oU
+oU
+QP
+Jk
+rA
+oU
+oU
+FL
+oU
+nu
+oU
+bG
+oU
+oU
+tc
+oU
+oU
+If
+yx
+gz
+mi
+sq
+mm
+Yz
+DJ
+If
+fR
+Iw
+jD
+Tv
+Ul
+Ny
+dq
+Wa
+Wa
+LH
+LH
+LH
+LH
+LH
+Wa
+Wa
+Wa
+Wa
+LH
+LH
+LH
+LH
+oU
+oU
+"}
+(33,1,1) = {"
+rb
+rb
+fh
+fh
+oU
+oU
+QP
+Jk
+rA
+fh
+fh
+OY
+kr
+FV
+xi
+gX
+oU
+Dy
+jS
+oU
+oU
+If
+Kk
+Bx
+Cn
+Gs
+hD
+Fa
+di
+xe
+Za
+Dn
+gK
+Tv
+Ul
+jm
+uU
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+Kh
+xm
+xm
+Kh
+Kh
+Kh
+oU
+oU
+oU
+oU
+"}
+(34,1,1) = {"
+rb
+rb
+rb
+oU
+oU
+oU
+QP
+Jk
+rA
+fh
+fh
+fh
+oU
+Xv
+Dy
+oU
+oU
+Eo
+oU
+oU
+oU
+If
+If
+If
+If
+If
+RP
+If
+If
+If
+mn
+VN
+EU
+Oy
+If
+Nq
+fa
+fh
+fh
+fh
+fh
+ZI
+CP
+lC
+fh
+fh
+fh
+oU
+oU
+oU
+oU
+oU
+oU
+fh
+"}
+(35,1,1) = {"
+rb
+rb
+oU
+oU
+oU
+oU
+QP
+Jk
+rA
+fh
+fh
+IM
+Dy
+oU
+oU
+oU
+oU
+Dy
+DT
+Dy
+oU
+If
+ei
+NU
+Gl
+If
+uS
+MY
+aZ
+If
+If
+If
+If
+If
+If
+Dy
+tc
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+"}
+(36,1,1) = {"
+rb
+rb
+oU
+oU
+oU
+oU
+QP
+ol
+qI
+fh
+fh
+fh
+Dy
+Dy
+oU
+oU
+oU
+oU
+oU
+qZ
+oU
+If
+qk
+si
+KT
+IU
+FY
+lM
+ts
+If
+qe
+GM
+wT
+If
+Es
+Dy
+jS
+fh
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+"}
+(37,1,1) = {"
+rb
+rb
+oU
+oU
+oU
+fh
+QP
+rA
+fh
+HP
+fh
+fh
+fh
+Dy
+oU
+oU
+oU
+oU
+oU
+Dy
+za
+If
+If
+Pl
+jd
+If
+Ty
+HA
+gj
+au
+vU
+GP
+rz
+If
+Es
+YW
+oU
+oU
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+bg
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+"}
+(38,1,1) = {"
+rb
+rb
+fh
+oU
+fh
+fh
+QP
+rA
+rv
+gM
+fh
+fh
+fh
+Dy
+oU
+Su
+oU
+oU
+oU
+oU
+tc
+Dy
+If
+kc
+bS
+If
+FJ
+gh
+AF
+If
+Eg
+xN
+yb
+If
+Rx
+wA
+nV
+wA
+fh
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+"}
+(39,1,1) = {"
+rb
+rb
+fh
+fh
+fh
+fh
+QP
+rA
+pg
+XF
+fh
+Tr
+fh
+Dy
+uV
+cU
+cU
+cU
+cU
+uV
+tc
+Dy
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+If
+Ow
+wA
+fh
+fh
+OB
+OB
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+"}
+(40,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+rA
+fh
+Er
+fh
+BH
+fh
+Dy
+uV
+oU
+oU
+xO
+oU
+uV
+tc
+Dy
+Es
+Es
+Es
+Es
+Es
+Es
+Es
+oU
+QP
+Jk
+rA
+oU
+pI
+wA
+DK
+nV
+TV
+OB
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+yR
+lf
+fh
+fh
+rb
+"}
+(41,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+HK
+lC
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+oU
+oU
+oU
+oU
+tc
+Es
+Es
+Es
+Es
+Es
+Es
+Es
+Dy
+oU
+QP
+Jk
+rA
+oU
+pI
+wA
+DK
+fh
+OB
+cU
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+"}
+(42,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+tc
+Es
+Es
+wA
+Es
+Es
+MX
+cU
+Dy
+Dy
+QP
+Jk
+rA
+oU
+pI
+wA
+oU
+wA
+oU
+oU
+fh
+QP
+Jk
+rA
+fh
+Tr
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+"}
+(43,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+fh
+BH
+fh
+Dy
+oU
+uV
+Dy
+Dy
+Dy
+Dy
+uV
+tc
+Dy
+Es
+wA
+Es
+Es
+Kc
+cU
+Dy
+Dy
+QP
+Jk
+rA
+oU
+qa
+oU
+Dy
+oU
+oU
+fh
+fh
+QP
+Jk
+rA
+fh
+BH
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+"}
+(44,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+fh
+BH
+fh
+Dy
+oU
+cU
+xU
+Dy
+oU
+xU
+cU
+tc
+Dy
+Es
+wA
+Es
+Es
+BP
+cU
+Dy
+Dy
+QP
+Jk
+rA
+Ig
+oU
+oU
+oU
+Sg
+oU
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+iR
+fh
+fh
+fh
+fh
+rb
+rb
+"}
+(45,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+Dy
+oU
+oU
+cU
+xU
+cU
+cU
+oU
+tc
+Dy
+Es
+wA
+Dy
+Es
+cU
+cU
+oU
+Dy
+QP
+Jk
+rA
+pI
+Bk
+oU
+FM
+Dy
+oU
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+fh
+fh
+oU
+oU
+oU
+rb
+rb
+"}
+(46,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+Dy
+Dy
+Dy
+oU
+oU
+oU
+oU
+oU
+jS
+Dy
+wW
+Es
+Dy
+oU
+oU
+oU
+Dy
+Dy
+QP
+Jk
+rA
+pI
+oU
+oU
+Dy
+Dy
+oU
+fh
+fh
+QP
+Jk
+rA
+bg
+fh
+fh
+fh
+fh
+fh
+fh
+oU
+oU
+rb
+"}
+(47,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+fh
+fh
+fh
+oU
+oU
+Dy
+Dy
+oU
+oU
+oU
+zK
+Dy
+Dy
+Dy
+Dy
+Dy
+oU
+Sg
+oU
+Dy
+Dy
+HB
+ng
+qI
+pI
+Sg
+oU
+Dy
+oU
+Su
+oU
+fh
+HB
+ng
+qI
+fh
+fh
+fh
+fh
+fh
+Dy
+Dy
+Dy
+oU
+oU
+"}
+(48,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+fh
+fh
+oU
+oU
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+Dy
+za
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+jS
+WC
+Dy
+Dy
+Dy
+Dy
+Dy
+fh
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+oU
+rb
+"}
+(49,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+oU
+oU
+CK
+Ko
+Ns
+Ns
+bp
+Vt
+pJ
+Dy
+Dy
+Uw
+Dy
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+aW
+De
+Dy
+Dy
+WC
+Dy
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+oU
+oU
+rb
+rb
+"}
+(50,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+oU
+oU
+ll
+hF
+ll
+Cf
+ll
+oU
+oU
+oz
+Vt
+Vt
+lm
+mK
+mK
+mK
+vP
+eh
+vP
+Vt
+mK
+Qf
+Dy
+kL
+TP
+Dy
+Dy
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+Dy
+oU
+oU
+oU
+oU
+oU
+rb
+"}
+(51,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+ll
+ll
+ll
+qF
+je
+je
+ll
+ll
+ll
+oU
+oU
+oU
+oU
+ZA
+ZA
+ZA
+ZA
+Bd
+ZA
+ZA
+oU
+ZI
+CP
+uc
+oU
+qZ
+Dy
+Dy
+Dy
+Dy
+oU
+Dy
+ZI
+CP
+lC
+oU
+oU
+oU
+Dy
+Dy
+Dy
+Dy
+oU
+rb
+rb
+"}
+(52,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+ll
+oR
+ad
+nT
+UM
+Eb
+FD
+sZ
+ll
+ZI
+CP
+lC
+ZA
+ZA
+uJ
+ot
+ZA
+lR
+wo
+ZA
+ZA
+QP
+Jk
+rA
+oU
+Qe
+aM
+RE
+RE
+RE
+Qe
+oU
+QP
+Jk
+rA
+oU
+oU
+Dy
+Dy
+oU
+oU
+oU
+oU
+rb
+rb
+"}
+(53,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+ll
+GB
+vV
+qp
+KS
+DG
+gr
+Oc
+ll
+QP
+Jk
+rA
+ZA
+Oj
+DU
+iN
+ZA
+iG
+bo
+wK
+ZA
+QP
+Jk
+rA
+ew
+ew
+fU
+xS
+xS
+SU
+ew
+ew
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+"}
+(54,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+QP
+Jk
+rA
+ll
+mb
+SP
+MW
+vv
+DG
+gr
+wk
+ll
+QP
+Jk
+rA
+ZA
+YV
+Sw
+QO
+ZA
+Hk
+wo
+pQ
+ZA
+QP
+Jk
+rA
+ew
+kA
+Mt
+ck
+ck
+HS
+Ht
+ew
+QP
+Jk
+rA
+oU
+oU
+nu
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(55,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+ll
+Dq
+zw
+PK
+KS
+DG
+wP
+wk
+ll
+QP
+Jk
+rA
+Vu
+Dv
+Sw
+DU
+iQ
+NN
+wo
+ph
+ZA
+QP
+Jk
+rA
+ew
+CM
+Kp
+sU
+Cw
+lz
+ly
+ew
+QP
+Jk
+rA
+ER
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(56,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+rA
+ll
+ed
+ML
+Py
+Xt
+jH
+jH
+jH
+ll
+QP
+Jk
+rA
+Vu
+Dv
+ki
+df
+ZA
+Hq
+GE
+NB
+ZA
+QP
+Jk
+rA
+ew
+Oi
+EK
+uP
+AC
+EK
+dl
+ew
+QP
+Jk
+rA
+oU
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(57,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+ll
+Zs
+AV
+cT
+nQ
+WO
+iU
+LS
+ll
+QP
+Jk
+rA
+ZA
+NV
+hG
+ZA
+ZA
+ZA
+hY
+ZA
+ZA
+QP
+Jk
+rA
+ew
+ew
+UD
+ew
+ew
+UD
+ew
+ew
+QP
+Jk
+rA
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(58,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+rA
+ll
+ll
+Iz
+Iz
+xc
+be
+ee
+ll
+ll
+QP
+Jk
+rA
+ZA
+ZA
+ZA
+ZA
+Uj
+HR
+Dv
+sh
+ZA
+QP
+Jk
+rA
+ew
+Ba
+ck
+sY
+iF
+an
+xC
+ew
+QP
+Jk
+rA
+oU
+oU
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(59,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+HK
+CP
+lC
+Pm
+st
+bf
+iU
+uF
+ZI
+CP
+ym
+Jk
+rA
+Xz
+uE
+kI
+jb
+nL
+mQ
+mQ
+Dv
+ZA
+QP
+Jk
+rA
+ew
+vX
+Am
+jn
+FX
+qK
+Gn
+ew
+QP
+Jk
+rA
+oU
+nu
+oU
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(60,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+fh
+QP
+Jk
+Jk
+Jk
+rA
+Ca
+Ca
+iU
+iU
+iU
+QP
+Jk
+Jk
+Jk
+rA
+Xz
+vK
+vK
+ZA
+eW
+Ut
+mQ
+mh
+ZA
+QP
+Jk
+rA
+ew
+Tj
+Pu
+WR
+WR
+Ud
+rn
+ew
+QP
+Jk
+rA
+oU
+oU
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+"}
+(61,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+Jk
+Jk
+HK
+CP
+CP
+CP
+CP
+CP
+ym
+Jk
+Jk
+Jk
+rA
+Xz
+vK
+tw
+ZA
+qO
+ot
+Lu
+UX
+ZA
+QP
+Jk
+rA
+ew
+ew
+qq
+cl
+rB
+qq
+ew
+ew
+QP
+Jk
+rA
+oU
+oU
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+"}
+(62,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+rA
+UK
+oH
+BK
+ZA
+ZA
+Vu
+Vu
+ZA
+ZA
+QP
+Jk
+HK
+lC
+ew
+xS
+ew
+ew
+xS
+ew
+ZI
+ym
+Jk
+rA
+oU
+oU
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+"}
+(63,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+QP
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+HK
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+CP
+ym
+Jk
+Jk
+HK
+CP
+CP
+CP
+CP
+CP
+CP
+ym
+Jk
+Jk
+rA
+oU
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+"}
+(64,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+HB
+vm
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+Jk
+ol
+qI
+oU
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+"}
+(65,1,1) = {"
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+HB
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+ng
+qI
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+"}
+(66,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(67,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+fh
+fh
+fh
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(68,1,1) = {"
+rb
+rb
+rb
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+fh
+fh
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}
+(69,1,1) = {"
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+fh
+fh
+fh
+fh
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+rb
+"}

--- a/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_underground_gunsmith.dmm
+++ b/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_underground_gunsmith.dmm
@@ -1,0 +1,8012 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"af" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"ai" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"ak" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"al" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/ballistic/automatic/pistol/rattlesnake/cottonmouth,
+/obj/item/ammo_box/magazine/m10mm_cottonmouth,
+/obj/item/ammo_box/magazine/m10mm_cottonmouth,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"am" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/structure/mirror{
+	pixel_x = 25;
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/beach/gunsmith/bathroom)
+"ao" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/stock_parts/micro_laser/high{
+	pixel_x = 5;
+	pixel_y = 14
+	},
+/obj/item/stack/tape/industrial{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"aw" = (
+/obj/structure/platform{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"aA" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"aC" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "officeshutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms/officer)
+"aP" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony{
+	icon_state = "wood-broken"
+	},
+/area/ruin/beach/gunsmith/dorms/officer)
+"aT" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 10
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/sign/warning{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"aW" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"bc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"bh" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/fax/ramzi,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"bq" = (
+/obj/machinery/porta_turret/ruin/ramzi/light,
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith)
+"bv" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "storage"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"by" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"bB" = (
+/turf/open/floor/plasteel/stairs/wood/walnut/left{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"bQ" = (
+/obj/structure/railing/thin/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"bW" = (
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plating/asteroid/sand/dense,
+/area/ruin/beach/gunsmith)
+"bZ" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"ca" = (
+/obj/structure/closet/secure_closet/wall/directional/south{
+	name = "supply cabinet"
+	},
+/obj/item/cutting_board{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/melee/knife/kitchen{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -8
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/item/plate{
+	pixel_x = 10;
+	pixel_y = -12
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/obj/item/plate/small{
+	pixel_x = -6;
+	pixel_y = -11
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/kitchen)
+"cc" = (
+/obj/structure/platform{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith/workshop)
+"cd" = (
+/obj/structure/railing/thin,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"cf" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"ci" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith)
+"cj" = (
+/obj/structure/platform,
+/turf/open/floor/plating/asteroid/sand/dense,
+/area/ruin/beach/gunsmith)
+"cl" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/rd{
+	name = "double purple bedsheet";
+	desc = "A large, comfy bedsheet."
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"cq" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"cr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"cC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	pixel_x = -9;
+	pixel_y = 21
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"cF" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"cI" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"cJ" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"cN" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521";
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/obj/item/sign/flag/ngr,
+/obj/item/desk_flag/ngr,
+/obj/item/paper/crumpled{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/paper/crumpled{
+	pixel_x = 7;
+	pixel_y = -10
+	},
+/obj/item/paper/crumpled{
+	pixel_x = -6;
+	pixel_y = -9
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"cU" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/crewquarters)
+"dc" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"dn" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/kitchen)
+"ds" = (
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"dx" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"dD" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/electrical)
+"dF" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"dO" = (
+/obj/machinery/washing_machine{
+	layer = 3.08
+	},
+/obj/structure/platform/ship_three{
+	dir = 1;
+	layer = 3.09
+	},
+/obj/structure/bedsheetbin{
+	pixel_y = 15;
+	pixel_x = 0;
+	layer = 3.1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/beach/gunsmith/bathroom)
+"dV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#332521"
+	},
+/obj/structure/table/wood,
+/obj/item/food/crab_rangoon{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/food/crab_rangoon{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/food/crab_rangoon{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/food/lifosa/homemade{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/food/dofi_nari{
+	pixel_x = 6;
+	pixel_y = 8;
+	layer = 2.9
+	},
+/obj/item/plate/large{
+	layer = 2.8;
+	pixel_x = 0;
+	pixel_y = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"dW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "storage"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"ec" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"eu" = (
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	id_tag = "officelock"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/dorms/officer)
+"ez" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-9"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"eB" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"eC" = (
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"eD" = (
+/obj/machinery/door/airlock/security,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/workshop)
+"eO" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "engishutter"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/electrical)
+"eT" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"fd" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"fk" = (
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"fr" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms/officer)
+"fu" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"fz" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/kitchen)
+"fI" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"fQ" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith)
+"fU" = (
+/obj/structure/platform,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"fZ" = (
+/obj/structure/bookcase/random{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms/officer)
+"gk" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = 26;
+	pixel_y = -6
+	},
+/obj/item/geiger_counter{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"go" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"gs" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/crewquarters)
+"gw" = (
+/obj/structure/platform/corner,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"gz" = (
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"gJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"gO" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"gT" = (
+/obj/structure/chair/comfy/grey,
+/obj/machinery/button/door{
+	pixel_x = 9;
+	pixel_y = 21;
+	name = "privacy shutters";
+	id = "officeshutters"
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"gY" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/rust,
+/area/ruin/beach/gunsmith/workshop)
+"gZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#D2BC9D"
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"ha" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"hl" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"hr" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/gunsmith/electrical)
+"hs" = (
+/obj/item/clothing/shoes/sandal{
+	pixel_x = 4;
+	pixel_y = -12
+	},
+/obj/item/clothing/shoes/sandal{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/clothing/under/pants/pajamared{
+	pixel_x = 11;
+	pixel_y = 15
+	},
+/obj/item/clothing/under/pants/pajamared{
+	pixel_x = 9;
+	pixel_y = 13
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"hA" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"hV" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/stack/ore/salvage/scrapmetal/twenty{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/stack/ore/salvage/scrapmetal/twenty{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/stack/ore/salvage/scrapsilver/five{
+	pixel_x = -11;
+	pixel_y = -3
+	},
+/obj/item/stack/ore/salvage/scrapsilver/five{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/stack/ore/salvage/scrapsilver/five{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/item/stack/ore/salvage/scrapsilver/five{
+	pixel_x = -11;
+	pixel_y = 12
+	},
+/obj/item/weaponcrafting/receiver{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/weaponcrafting/receiver{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/weaponcrafting/receiver{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/weaponcrafting/stock{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/obj/item/weaponcrafting/stock{
+	pixel_x = 6;
+	pixel_y = -10
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"ib" = (
+/obj/structure/chair/sofa/red/old/left{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"ii" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"io" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/crewquarters)
+"ip" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/warning/nosmoking/burnt{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"it" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"iv" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/gunsmith/electrical)
+"iA" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/item/clothing/head/ramzi/beret{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/ramzi{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/armor/ramzi/officer{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/obj/item/clothing/under/syndicate/ramzi/officer{
+	pixel_x = -10;
+	pixel_y = -12
+	},
+/obj/item/clothing/head/ngr{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/ngr/lieutenant{
+	pixel_x = 9;
+	pixel_y = -5
+	},
+/obj/item/clothing/under/syndicate/ngr/officer{
+	pixel_x = 9;
+	pixel_y = -12
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 12
+	},
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/dorms/officer)
+"iE" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"iT" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"iW" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/electrical)
+"jb" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"jc" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/workshop)
+"jj" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"jm" = (
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/beach/gunsmith)
+"jp" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "bedroomshutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms)
+"jz" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/beach/gunsmith/workshop)
+"jD" = (
+/obj/structure/platform/wood,
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"jI" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"jK" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"jV" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/clothing/shoes/sandal{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/sandal{
+	pixel_x = 4;
+	pixel_y = -7
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/crewquarters)
+"kd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker/premium,
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521";
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"ke" = (
+/obj/structure/guncloset,
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/item/gun/ballistic/automatic/pistol/asp,
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"kf" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/attachment/scope{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/attachment/scope{
+	pixel_x = -7;
+	pixel_y = -10
+	},
+/obj/item/attachment/energy_bayonet{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/item/attachment/gun/flamethrower,
+/obj/item/attachment/gun/ballistic/shotgun{
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"km" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"kn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"kq" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/item/storage/cans/sixbeer{
+	pixel_x = 11;
+	pixel_y = 3;
+	layer = 3.09
+	},
+/obj/structure/railing/thin{
+	dir = 9
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"kw" = (
+/obj/structure/platform{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"kz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"kL" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"kN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"kR" = (
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/kitchen)
+"kT" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"kV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"lb" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"lj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"lm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"lo" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/chair{
+	layer = 3.09
+	},
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"lp" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/stack/sheet/plastic/twenty{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty{
+	pixel_x = -9;
+	pixel_y = -10
+	},
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"lq" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/dorms/officer)
+"ls" = (
+/obj/effect/turf_decal/industrial/warning{
+	color = "#912a2a";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"lt" = (
+/obj/structure/table/reinforced,
+/obj/structure/closet/secure_closet/wall/directional/south{
+	name = "kitchen cabinet"
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/condiment/sugar{
+	pixel_x = 11;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/condiment/rice{
+	pixel_x = 11;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/condiment/rice{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/mayonnaise{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/hotsauce{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521";
+	dir = 2
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"lO" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521";
+	dir = 8
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -9;
+	id = "officelock";
+	name = "bedroom lock <3";
+	specialfunctions = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"ml" = (
+/obj/structure/hazard_shutoff/electrical_shutoff{
+	id = "engineeringmoat";
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"mo" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/dorms)
+"mq" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/kitchen)
+"mv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"mC" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"mD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"nb" = (
+/obj/structure/platform,
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"nm" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/knife/butcher,
+/obj/item/stack/rods/ten{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"nn" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"nu" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"nB" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"nE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/ruin/beach/gunsmith)
+"nF" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"nJ" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"nT" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/bathroom)
+"nZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"oe" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	layer = 2.040
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/item/clothing/under/syndicate/ramzi{
+	pixel_x = 6;
+	pixel_y = -10
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/clothing/under/syndicate/ramzi/overalls{
+	pixel_x = -8;
+	pixel_y = -10
+	},
+/obj/item/clothing/suit/ramzi{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/ramzi{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/ramzi{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms)
+"ol" = (
+/obj/machinery/recharger{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/paper_bin{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/radio/old{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"os" = (
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/kitchen)
+"ov" = (
+/mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"ow" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#332521"
+	},
+/obj/structure/noticeboard{
+	pixel_x = -28;
+	pixel_y = -1;
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/item/paper/fluff/ruins{
+	pixel_x = -11;
+	pixel_y = 5;
+	default_raw_text = "<h1>TODO:</h1>-Remind the new people that love is one of us<br>-Negotiate hydra shipment proceeds with love's boss<br>-See about getting a new salt supplier<br>-Plaster more warning signs by the explosives";
+	name = "To-Do List"
+	},
+/obj/item/paper/fluff/ruins{
+	pixel_x = -11;
+	pixel_y = -9;
+	default_raw_text = "remind rei to replace my damn stash floorboards by the south wall";
+	name = "reminder"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"oz" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/ruin/beach/gunsmith)
+"oB" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 7;
+	layer = 3.3
+	},
+/obj/item/lipstick/black{
+	pixel_x = 9;
+	pixel_y = 10;
+	layer = 3.3
+	},
+/obj/item/lipstick{
+	pixel_x = 11;
+	pixel_y = 12;
+	layer = 3.3
+	},
+/obj/item/clothing/under/shorts/dolphin{
+	pixel_x = 7;
+	pixel_y = 9;
+	layer = 3.4
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"oL" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"oN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"oT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken"
+	},
+/area/ruin/beach/gunsmith)
+"oU" = (
+/obj/effect/turf_decal/corner_steel_grid/full{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 6;
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"oY" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"pa" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"pg" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"ph" = (
+/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/left,
+/area/ruin/beach/gunsmith/electrical)
+"ps" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/storage/toolbox/syndicate,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/item/storage/box/stockparts/t2{
+	pixel_x = -1;
+	pixel_y = -5
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"pA" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"pE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#332521"
+	},
+/obj/structure/chair/bench/orange{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth{
+	wander = 0
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"pG" = (
+/turf/template_noop,
+/area/template_noop)
+"pT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"qe" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/techfloor,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/officer/ngr{
+	wander = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"qj" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"ql" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"qo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/obj/structure/chair/bench/orange{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"qr" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"qv" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "bedroomshutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms)
+"qw" = (
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/reagent_containers/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/structure/platform/ship_three/corner{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/closet/secure_closet/freezer,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"qC" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/storage/box/ammo/c10mm,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"qI" = (
+/obj/machinery/light/dim/directional/south,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"qS" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 4
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"qT" = (
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"qV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"rb" = (
+/obj/machinery/light/small/directional/west,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth/scout,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"rc" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"rt" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/crewquarters)
+"ry" = (
+/obj/structure/chair{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"rA" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"rN" = (
+/obj/structure/platform{
+	dir = 5
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"rX" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/crewquarters)
+"sa" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 8
+	},
+/obj/structure/closet/crate/secure/weapon{
+	opened = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"sb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"sd" = (
+/obj/structure/platform{
+	dir = 6
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"sh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"so" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"sA" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"sK" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"sQ" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"sW" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/kitchen)
+"td" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/item/storage/toolbox/ammo/c10mm{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/storage/toolbox/ammo/c556{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/ammo/c57{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/gun_maint_kit{
+	pixel_x = -4;
+	pixel_y = -9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"tf" = (
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
+"tg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"tn" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	layer = 2.040
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/obj/item/clothing/neck/shemagh/ramzi{
+	pixel_x = -8;
+	pixel_y = -11
+	},
+/obj/item/clothing/mask/breath/facemask{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/breath/facemask{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/breath/facemask{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/breath/facemask{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/storage/belt/security/webbing/ramzi{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/storage/belt/security/webbing/ramzi/alt{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/obj/item/storage/belt/security/webbing/ramzi/alt{
+	pixel_x = 6;
+	pixel_y = -9
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = -16
+	},
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms)
+"tt" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"ty" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8;
+	color = "#912a2a"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_x = -9;
+	pixel_y = -20;
+	dir = 1;
+	id = "engishutter"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"tz" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"tH" = (
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"tL" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
+"tT" = (
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/ruin/beach/gunsmith)
+"ub" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/yellow,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"uj" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"uo" = (
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 7;
+	pixel_y = 39
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = 7;
+	pixel_y = 25
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	pixel_x = -9;
+	pixel_y = 21;
+	id = "engishutter"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/electrical)
+"ut" = (
+/obj/machinery/light/dim/directional/east,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"uz" = (
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken"
+	},
+/area/ruin/beach/gunsmith)
+"uE" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"uV" = (
+/turf/open/floor/plasteel/stairs/wood/walnut/right{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"uW" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"vg" = (
+/obj/machinery/door/airlock/security,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/workshop)
+"vi" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"vj" = (
+/obj/structure/platform/wood,
+/obj/machinery/light/dim/directional/north,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"vl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/kitchen)
+"vy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"vH" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-10";
+	layer = 3.1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"vI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"vL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"vS" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith/workshop)
+"vY" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/coffee_condi_display{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/storage/box/coffeepack/arabica{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521";
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"vZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"wb" = (
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"wi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"ww" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"wz" = (
+/obj/structure/platform/wood{
+	dir = 10
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"wF" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"wJ" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/crewquarters)
+"wV" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 4
+	},
+/area/ruin/beach/gunsmith)
+"wZ" = (
+/obj/structure/rack,
+/obj/item/gun_maint_kit{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/gun_maint_kit/small{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"xk" = (
+/obj/item/restraints/legcuffs/beartrap{
+	armed = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"xC" = (
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/beach/gunsmith)
+"xP" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"xU" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/stack/cable_coil/red,
+/obj/item/stack/cable_coil/red{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"xW" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/workshop)
+"xY" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"yb" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-10";
+	layer = 3.1
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"yd" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/dotusira{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"yg" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/item/fishing_rod{
+	pixel_x = 11;
+	pixel_y = 20;
+	layer = 3.09
+	},
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/obj/item/bait_can/worm{
+	pixel_x = 18;
+	pixel_y = 5
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"yj" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"yk" = (
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"yH" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"yJ" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-05";
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"yL" = (
+/obj/structure/salvageable/machine,
+/obj/structure/hazard_shutoff/electrical_shutoff{
+	id = "bunkermoat";
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"yQ" = (
+/obj/structure/platform,
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"yR" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"yX" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"zj" = (
+/obj/structure/fermenting_barrel/gunpowder,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 10
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/structure/sign/warning{
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"zp" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"zv" = (
+/turf/open/floor/plasteel/stairs/wood/walnut/right,
+/area/ruin/beach/gunsmith)
+"zB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"zE" = (
+/obj/machinery/door/window/northright,
+/obj/structure/closet/secure_closet/wall/directional/south,
+/obj/item/soap{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/soap{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/towel{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/towel{
+	pixel_x = -8;
+	pixel_y = -9
+	},
+/obj/item/towel{
+	pixel_x = -8;
+	pixel_y = -11
+	},
+/obj/item/pushbroom{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/mop{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/bathroom)
+"zF" = (
+/obj/structure/closet/crate/secure/weapon{
+	opened = 1
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
+"zK" = (
+/obj/structure/rack,
+/obj/item/storage/box/ammo/a65clip/trac,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"zN" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"zV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/obj/structure/chair/office/dark,
+/obj/item/radio/intercom/wideband/directional/west,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"zW" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/red/corner{
+	dir = 4;
+	layer = 2.04
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"Aa" = (
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"Ad" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Ag" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"Ao" = (
+/obj/structure/platform/wood,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Aq" = (
+/obj/effect/turf_decal/corner_steel_grid/full{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 5;
+	layer = 2.040
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"Ar" = (
+/obj/structure/platform,
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"At" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#332521"
+	},
+/obj/structure/chair/bench/orange{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"Au" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/magazine/boomslang/empty{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/boomslang/empty{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 6
+	},
+/obj/item/storage/box/ammo/a65clip,
+/obj/item/storage/box/ammo/a65clip,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"AC" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 31;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"Bd" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"Bj" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Bq" = (
+/obj/structure/platform{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"Bu" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"Bv" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 31;
+	pixel_y = 6
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31;
+	pixel_y = -17
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"Bx" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/spacecash/bundle/c1000{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/stamp/ngr/ensign{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/obj/item/documents/syndicate/ngr{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"BE" = (
+/obj/machinery/griddle,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"BF" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/structure/rack,
+/obj/item/clothing/head/ramzi/flap{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/ramzi/flap{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/ramzi/flap{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/ramzi{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/ramzi{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/crewquarters)
+"BT" = (
+/obj/item/ammo_box/magazine/m10mm_ringneck{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/m10mm_ringneck{
+	pixel_x = -11;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/ammo_box/magazine/m57_39_asp{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/item/ammo_box/magazine/m57_39_asp{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/ammo_box/magazine/m10mm_cottonmouth{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/item/ammo_box/magazine/m10mm_cottonmouth{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"BU" = (
+/turf/open/floor/plating/asteroid/sand/dense,
+/area/ruin/beach/gunsmith)
+"BW" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/crewquarters)
+"BY" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/red/corner{
+	dir = 1;
+	layer = 2.04
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"Cd" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/kitchen)
+"Ch" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"Cj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"Cm" = (
+/turf/closed/mineral/random/beach,
+/area/ruin/beach/gunsmith)
+"Cp" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/kitchen)
+"Cu" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"CB" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/ramzi{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"CN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#332521"
+	},
+/obj/structure/chair/bench/orange{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"CS" = (
+/obj/structure/platform{
+	dir = 6
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"CX" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521";
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"CY" = (
+/obj/structure/dresser,
+/obj/item/clothing/under/shorts/explorer{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/clothing/under/shorts/dolphin{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/lipstick/black{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"CZ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"Dc" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Dp" = (
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Dr" = (
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/stairs/right{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"Dy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -10;
+	pixel_y = 6
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"DL" = (
+/obj/effect/turf_decal/corner_steel_grid/full{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloor/corner,
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 9;
+	layer = 2.04
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"DM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"DV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Ef" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"Em" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"EC" = (
+/obj/structure/cable{
+	icon_state = "1-10";
+	layer = 3.1
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"EE" = (
+/obj/structure/toilet{
+	pixel_x = 0;
+	pixel_y = 20
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/beach/gunsmith/bathroom)
+"Fc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Fp" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "exchangewindows"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"Fq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"Fv" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"FI" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/obj/item/pickaxe/drill/jackhammer/old{
+	pixel_x = 9;
+	pixel_y = 15
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"FQ" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/kitchen)
+"FU" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 1
+	},
+/area/ruin/beach/gunsmith)
+"Gb" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/beach/gunsmith/electrical)
+"Gc" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith/workshop)
+"Gn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"Gu" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith)
+"Gw" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"GB" = (
+/obj/structure/chair/bench/beige{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"GC" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521"
+	},
+/obj/structure/table/wood,
+/obj/item/cutting_board{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/food/nigiri_sushi{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/food/nigiri_sushi{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/food/nigiri_sushi{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 10;
+	pixel_y = 2;
+	layer = 3.1
+	},
+/obj/item/reagent_containers/condiment/soysauce{
+	pixel_x = 11;
+	pixel_y = 13
+	},
+/obj/item/food/onigiri{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/food/onigiri{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/food/onigiri{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"GJ" = (
+/obj/structure/chair/sofa/brown/old/left{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"GK" = (
+/obj/structure/table,
+/obj/item/binoculars,
+/obj/item/reagent_containers/glass/mortar{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/cigbutt{
+	pixel_x = -10;
+	pixel_y = 16
+	},
+/obj/item/cigbutt{
+	pixel_x = -6;
+	pixel_y = 15
+	},
+/obj/item/cigbutt{
+	pixel_x = -12;
+	pixel_y = 14
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/item/lighter{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"GU" = (
+/turf/open/floor/plasteel/stairs/wood/walnut/left,
+/area/ruin/beach/gunsmith)
+"Hb" = (
+/obj/structure/safe/floor,
+/obj/item/spacecash/bundle/c1000,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Hd" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/suit/armor/ramzi{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/ramzi{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/armor/ramzi/bulletproof{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/helmet/bulletproof/x11/ramzi{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/obj/item/clothing/head/helmet/m10/ramzi{
+	pixel_x = 3;
+	pixel_y = 0
+	},
+/obj/item/clothing/head/helmet/m10/ramzi{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/workshop)
+"He" = (
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/kitchen)
+"Hg" = (
+/obj/effect/turf_decal/corner/opaque/black/half,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/ruin/beach/gunsmith/electrical)
+"Hw" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"HD" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/obj/machinery/light/dim/directional/west,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"HJ" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"HM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"HN" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 1;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"HT" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"HZ" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Ia" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/gun/ballistic/automatic/pistol/rattlesnake/cottonmouth{
+	pixel_x = 16;
+	pixel_y = 3
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"Id" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"Ig" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"Iq" = (
+/obj/structure/chair/sofa/red/old/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"Ir" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/bathroom)
+"Iw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"IF" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "engishutter"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/electrical)
+"II" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"IR" = (
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"IV" = (
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"Je" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Jf" = (
+/obj/structure/platform/wood{
+	dir = 10
+	},
+/obj/machinery/light/dim/directional/east,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Ji" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"Jl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"Jm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Jr" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"JF" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 4;
+	layer = 2.040
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"JW" = (
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"JX" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"Kb" = (
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Kc" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/crewquarters)
+"Kd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/walnut/right{
+	dir = 1
+	},
+/area/ruin/beach/gunsmith)
+"Kq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Kt" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"KA" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"KY" = (
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"La" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/left,
+/area/ruin/beach/gunsmith/workshop)
+"Ld" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Lt" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"Ly" = (
+/obj/structure/platform/wood{
+	dir = 9
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"LC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"LG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"LJ" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/kitchen)
+"LO" = (
+/obj/structure/railing/thin,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Mb" = (
+/obj/item/gun/energy/plasmacutter{
+	pixel_x = -16;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/mob/living/simple_animal/hostile/human/ramzi/civilian{
+	wander = 0
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"MA" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"MB" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"MC" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"MJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"MZ" = (
+/obj/structure/chair/comfy/grey{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"Na" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"Nl" = (
+/obj/structure/chair/sofa/brown/old/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"ND" = (
+/obj/structure/platform/wood/corner,
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"NF" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp{
+	pixel_x = -8;
+	pixel_y = 10;
+	layer = 3.3
+	},
+/obj/item/clothing/head/sunhat{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/clothing/under/shorts/pink{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"NI" = (
+/obj/structure/rack,
+/obj/item/grenade/c4/x4{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/grenade/c4/x4{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/folder/documents/syndicate/red{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/folder/documents/syndicate/ngr{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms/officer)
+"NS" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"NW" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Oh" = (
+/obj/effect/turf_decal/corner_steel_grid/full,
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 10;
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"Oi" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	id_tag = "gunsmithbathroom"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/beach/gunsmith/bathroom)
+"Ov" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "exchangewindows"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"OA" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"OP" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"Pc" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/workshop)
+"Pg" = (
+/obj/effect/turf_decal/corner/transparent/syndiered/border{
+	dir = 4
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker/large/napalm{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/workshop)
+"Pp" = (
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"PE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"PF" = (
+/turf/open/floor/plating/asteroid/sand,
+/area/ruin/beach/gunsmith)
+"PJ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"PM" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"PP" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"PQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"PS" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"PW" = (
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"PZ" = (
+/mob/living/simple_animal/hostile/human/ramzi/ranged/sniper/sentry,
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
+"Qb" = (
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Qd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"Qe" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"Qi" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521"
+	},
+/obj/structure/table/wood,
+/obj/item/paper/crumpled{
+	pixel_x = 3;
+	pixel_y = 5;
+	default_raw_text = "hey love. remember to be a little more careful moving the bookcase for the stash. gonna have to get rei to fix the floorboards again"
+	},
+/obj/item/desk_flag/trans{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Qk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"Ql" = (
+/obj/item/storage/cans/sixbeer{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Qm" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/electrical)
+"Qn" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "shutters"
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith/workshop)
+"Qt" = (
+/turf/open/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ruin/beach/gunsmith)
+"QF" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"QQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"QX" = (
+/obj/structure/platform,
+/obj/structure/railing/thin,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"QY" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"QZ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Rb" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 10
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Rf" = (
+/obj/structure/platform{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith/workshop)
+"Rj" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"Rl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken"
+	},
+/area/ruin/beach/gunsmith)
+"Rs" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/storage/cans/sixbeer{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Rt" = (
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"RD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"RF" = (
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"RM" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/obj/item/ammo_box/magazine/m556_42_hydra/empty{
+	pixel_x = 13;
+	pixel_y = 12
+	},
+/obj/item/ammo_casing/a556_42{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/ammo_casing/a556_42{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/obj/item/weaponcrafting/stock{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"RN" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/warning/securearea{
+	pixel_x = -26;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"RU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"Sf" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith/workshop)
+"Sh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"Sw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"SA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"SC" = (
+/obj/structure/platform,
+/obj/structure/platform/wood{
+	dir = 4;
+	layer = 3.07
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"SF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"SM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"SQ" = (
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"SR" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"Tb" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"Td" = (
+/obj/effect/turf_decal/techfloor/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"Te" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"Tg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Tj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#332521"
+	},
+/obj/structure/filingcabinet/double{
+	pixel_x = 0;
+	pixel_y = 19;
+	density = 0
+	},
+/obj/item/clipboard{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"Tn" = (
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Tt" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 9
+	},
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Tu" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Tv" = (
+/turf/open/floor/plasteel/stairs/wood/walnut/left{
+	dir = 1
+	},
+/area/ruin/beach/gunsmith)
+"TH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"TI" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 5
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"TN" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/machinery/button/door{
+	pixel_x = -22;
+	pixel_y = -10;
+	dir = 4;
+	id = "bedroomshutters";
+	name = "privacy shutters"
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"TV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#332521"
+	},
+/obj/structure/sign/warning/incident{
+	pixel_x = 0;
+	pixel_y = 31
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/officer/beach,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"TZ" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/kitchen)
+"Uc" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/beach/gunsmith/dorms)
+"Ue" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1,
+/area/ruin/beach/gunsmith)
+"Uk" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#332521"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#332521"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"Uo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/hydra/gunsmith,
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"Up" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"UK" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/right,
+/area/ruin/beach/gunsmith/workshop)
+"UP" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#D2BC9D"
+	},
+/obj/item/clothing/under/shorts/red{
+	pixel_x = -25;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"UQ" = (
+/obj/structure/chair/bench/beige{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/crewquarters)
+"UX" = (
+/turf/open/floor/plasteel/stairs/left{
+	dir = 4
+	},
+/area/ruin/beach/gunsmith)
+"Va" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/dorms/officer)
+"Vf" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/green,
+/area/ruin/beach/gunsmith/dorms)
+"Vv" = (
+/obj/machinery/light/dim/directional/north,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"VB" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/smg{
+	wander = 0
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"VJ" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/dorms)
+"VS" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"VU" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith)
+"VY" = (
+/obj/effect/turf_decal/corner_steel_grid{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-10";
+	layer = 3.1
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"Wq" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"Wu" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/beach,
+/area/ruin/beach/gunsmith)
+"WE" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"WK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/crewquarters)
+"WN" = (
+/obj/structure/platform/ship_three{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -13;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -9;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -4;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 6;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 11;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 16;
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"WX" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/beach/gunsmith/kitchen)
+"Xc" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/beach/gunsmith/electrical)
+"Xi" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"Xo" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Xv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"Xy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"XB" = (
+/obj/structure/railing/thin,
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"XJ" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#332521"
+	},
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 10;
+	name = "shutters";
+	id = "shutters"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -1;
+	id = "storage";
+	name = "storage door"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -12;
+	name = "armory lockdown";
+	id = "armory"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 28;
+	pixel_y = 10;
+	name = "windows";
+	id = "exchangewindows"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/workshop)
+"XV" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"Yj" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"Yq" = (
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/miras,
+/obj/item/food/meat/slab/miras,
+/obj/item/food/meat/slab/remes,
+/obj/item/food/meat/slab/remes,
+/obj/item/food/meat/slab/tiris,
+/obj/item/food/meat/slab/tiris,
+/obj/item/food/meat/rawcrab,
+/obj/item/food/meat/rawcrab,
+/obj/item/food/meat/rawcrab,
+/obj/item/food/meat/rawcrab,
+/obj/structure/closet/secure_closet/freezer,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/beach/gunsmith/kitchen)
+"YK" = (
+/obj/structure/platform/wood{
+	dir = 9
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/obj/machinery/light/dim/directional/east,
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"YX" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith/workshop)
+"Zb" = (
+/turf/open/floor/wood/walnut,
+/area/ruin/beach/gunsmith)
+"Zc" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles,
+/area/ruin/beach/gunsmith)
+"Zh" = (
+/obj/effect/turf_decal/trimline/opaque/red/line{
+	dir = 5
+	},
+/obj/structure/closet/wall/orange/directional/north,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/beach/gunsmith/electrical)
+"Zp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#332521"
+	},
+/mob/living/simple_animal/hostile/human/ramzi/melee/sledge,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/crewquarters)
+"Zq" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete,
+/area/ruin/beach/gunsmith/electrical)
+"Zr" = (
+/obj/structure/platform,
+/obj/structure/platform/wood{
+	dir = 8;
+	layer = 3.07
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "engineeringmoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach/deep,
+/area/ruin/beach/gunsmith)
+"Zt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#332521"
+	},
+/obj/machinery/oven,
+/turf/open/floor/wood/ebony,
+/area/ruin/beach/gunsmith/kitchen)
+"Zz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/beach/gunsmith/electrical)
+"ZC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
+"ZI" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/ammo_box/magazine/m556_42_hydra/empty{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/ammo_casing/a556_42{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+"ZO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/beach/gunsmith/dorms)
+"ZP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/button/door{
+	pixel_x = -10;
+	pixel_y = 20;
+	id = "gunsmithbathroom";
+	normaldoorcontrol = 1;
+	name = "bathroom lock";
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black{
+	name = "bathroom mat"
+	},
+/area/ruin/beach/gunsmith/bathroom)
+"ZS" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/structure/hazard/electrical/electrified_water{
+	id = "bunkermoat";
+	random_sparks = 0
+	},
+/turf/open/water/beach,
+/area/ruin/beach/gunsmith)
+"ZZ" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith/workshop)
+
+(1,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(2,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+JW
+JW
+JW
+Cm
+Cm
+Cm
+pG
+pG
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(3,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+JW
+JW
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(4,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+pG
+pG
+Cm
+Cm
+pG
+pG
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(5,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+JW
+IR
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(6,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+JW
+IR
+IR
+Ao
+bB
+uV
+eB
+IR
+IR
+JW
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(7,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+xW
+xW
+xW
+xW
+xW
+xW
+xW
+Cm
+JW
+JW
+IR
+IR
+Ao
+tg
+Zb
+kL
+IR
+IR
+IR
+Cm
+JW
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(8,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+xW
+hV
+ps
+lp
+xW
+ke
+xW
+xW
+JW
+IR
+IR
+IR
+Ao
+Zb
+Zb
+kL
+IR
+IR
+Cm
+Cm
+Cm
+Cm
+JW
+JW
+JW
+JW
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(9,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+xW
+xW
+wb
+LC
+RD
+eD
+aA
+Aa
+xW
+JW
+IR
+IR
+IR
+Ao
+xC
+Zb
+kL
+IR
+IR
+Cm
+Cm
+Cm
+Cm
+JW
+JW
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(10,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+xW
+Ia
+Mb
+Pc
+aT
+xW
+td
+BT
+xW
+JW
+IR
+qI
+Gu
+vj
+Zb
+tg
+Je
+Gu
+Vv
+IR
+IR
+Cm
+IR
+IR
+IR
+JW
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(11,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+xW
+ao
+wb
+Ig
+zj
+xW
+xW
+xW
+xW
+xW
+JW
+IR
+IR
+Ao
+Zb
+Zb
+kL
+IR
+IR
+IR
+IR
+IR
+IR
+IR
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(12,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+xW
+ip
+wb
+nn
+RD
+vg
+ow
+zV
+ol
+xW
+JW
+IR
+IR
+Ao
+Zb
+Zb
+jK
+IR
+IR
+IR
+IR
+qI
+Gu
+Vv
+Ao
+bB
+uV
+eB
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(13,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+RM
+FI
+kT
+Rt
+xW
+Tj
+Uk
+bh
+Fp
+IR
+IR
+IR
+jD
+tg
+Zb
+Xi
+bZ
+bZ
+bZ
+bZ
+sQ
+sQ
+sQ
+ai
+oT
+Zb
+ZS
+it
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(14,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+ZI
+Wq
+zN
+ZZ
+xW
+TV
+Fq
+XJ
+xW
+IR
+IR
+IR
+jD
+Zb
+Zb
+jm
+Zb
+tg
+tg
+Zb
+Zb
+Zb
+Zb
+Zb
+tg
+Zb
+ZS
+it
+it
+JW
+JW
+pG
+Cm
+Cm
+pG
+pG
+pG
+"}
+(15,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+xW
+xW
+xW
+xW
+jc
+xW
+xW
+Qn
+Ov
+xW
+xW
+IR
+IR
+ND
+nJ
+Na
+Sh
+Uo
+Sh
+Sh
+Rl
+Sh
+Sh
+Em
+Sh
+gO
+Zb
+tg
+ZS
+it
+it
+it
+JW
+Cm
+Cm
+Cm
+pG
+pG
+pG
+"}
+(16,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+xP
+tz
+Cj
+kz
+pg
+xW
+vy
+Lt
+Gc
+JW
+IR
+IR
+jD
+Zb
+HM
+qT
+Ly
+Id
+Id
+Id
+Xo
+Xo
+Jf
+Zb
+HM
+YK
+QY
+Dc
+it
+it
+it
+it
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+"}
+(17,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+cq
+Hd
+gY
+yR
+Bd
+xW
+vy
+mC
+Rf
+sQ
+sQ
+sQ
+nJ
+uz
+HM
+OA
+jK
+IV
+IV
+IR
+IR
+IR
+Gu
+Qt
+Ch
+Gu
+it
+QF
+it
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+"}
+(18,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+kf
+CB
+vi
+hA
+qV
+bv
+OP
+MA
+La
+Sh
+Em
+Sh
+Sh
+Sh
+WE
+Ly
+sA
+IV
+JW
+Cm
+Cm
+IR
+QX
+Qb
+LO
+lb
+vH
+zp
+it
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(19,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+cq
+nB
+al
+jz
+nB
+dW
+Td
+YX
+UK
+Zb
+jm
+xC
+Zb
+tg
+Zb
+fd
+Gu
+JW
+Cm
+Cm
+Cm
+IR
+QX
+Qb
+XB
+iT
+Kt
+ww
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(20,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+xW
+nB
+Cj
+wi
+cJ
+xW
+cC
+qe
+cc
+Xo
+Xo
+Xo
+wz
+Zb
+Zb
+kL
+IR
+JW
+Cm
+Cm
+Cm
+IR
+Gu
+PQ
+Fc
+Gu
+Gw
+XV
+XV
+Gw
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(21,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+Pg
+qS
+qS
+Au
+xW
+PJ
+MB
+vS
+gw
+pa
+pa
+sd
+Qt
+Dr
+rN
+pa
+pa
+yX
+Cm
+JW
+Gu
+Gu
+Jr
+so
+Gu
+Gu
+Ue
+Ue
+Gu
+Gu
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+"}
+(22,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+xW
+xW
+xW
+xW
+xW
+xW
+Sf
+Sf
+xW
+fU
+Tt
+sa
+dx
+tH
+tH
+Bx
+yH
+Rb
+Bj
+IR
+IR
+Gu
+Gu
+DL
+Oh
+jj
+Gu
+tL
+PZ
+Ql
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+"}
+(23,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+IR
+IR
+IV
+IV
+IR
+fU
+PP
+ZC
+zF
+tf
+ZC
+tf
+ZC
+jb
+Bj
+IR
+IR
+Gu
+cF
+HN
+VU
+qj
+FU
+ZC
+tf
+GK
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+"}
+(24,1,1) = {"
+pG
+pG
+BU
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+IV
+Gu
+JW
+IV
+fU
+uW
+ZC
+tf
+tf
+ZC
+zF
+ZC
+HZ
+Bj
+IR
+IR
+ci
+qj
+HN
+VU
+qC
+Gu
+zK
+fI
+Gu
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(25,1,1) = {"
+pG
+pG
+IR
+Cm
+Cm
+BU
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+bZ
+JW
+Cm
+JW
+yQ
+uW
+ZC
+tf
+tf
+tf
+ZC
+ZC
+HZ
+Bj
+IR
+IR
+ci
+qj
+HN
+VU
+wZ
+Gu
+Gu
+Gu
+Gu
+Gu
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(26,1,1) = {"
+pG
+pG
+IR
+IR
+IR
+IR
+IR
+BU
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+xY
+Cm
+Cm
+JW
+SC
+uW
+tf
+tf
+tf
+tf
+tf
+tf
+HZ
+Bj
+IR
+IR
+Gu
+Rs
+HN
+VU
+qj
+FU
+Zb
+rb
+oL
+Gu
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(27,1,1) = {"
+pG
+pG
+BU
+IR
+IR
+IR
+IR
+IR
+Cm
+Cm
+Cm
+JW
+JW
+Cm
+JW
+ec
+Cm
+Cm
+Cm
+Ar
+Tu
+ZC
+tf
+tf
+tf
+ZC
+tf
+af
+Bj
+IR
+IR
+Gu
+Gu
+Aq
+oU
+vZ
+Gu
+Qe
+tt
+Up
+ZS
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+"}
+(28,1,1) = {"
+pG
+pG
+BU
+BU
+BU
+BU
+BU
+IR
+IR
+IR
+Ao
+JW
+xk
+sK
+RF
+RF
+yj
+Cm
+JW
+Zr
+uW
+tf
+ZC
+tf
+tf
+ZC
+ZC
+HZ
+Bj
+JW
+IR
+IR
+Gu
+wV
+oz
+Gu
+Gu
+QY
+QY
+QY
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+"}
+(29,1,1) = {"
+pG
+PF
+PF
+BU
+Cm
+BU
+PF
+BU
+BU
+IR
+Ao
+xk
+JW
+sK
+RF
+RF
+RF
+JW
+JW
+nb
+uW
+tf
+ZC
+ZC
+tf
+ZC
+ZC
+HZ
+Bj
+JW
+Cm
+Gu
+Gu
+Qb
+kV
+Gu
+it
+it
+it
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+"}
+(30,1,1) = {"
+pG
+PF
+PF
+Cm
+Cm
+Cm
+PF
+Cm
+Cm
+dD
+dD
+dD
+dD
+dD
+JW
+RF
+RF
+yj
+yj
+nb
+Tu
+tf
+tf
+tf
+tf
+ZC
+tf
+af
+Bj
+Cm
+Cm
+Gu
+xU
+Qb
+cd
+iT
+eC
+it
+it
+it
+it
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+"}
+(31,1,1) = {"
+pG
+PF
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+dD
+Iw
+KA
+dF
+dD
+dD
+RF
+SQ
+Gu
+PM
+nb
+rA
+ZC
+tf
+tf
+tf
+tf
+tf
+HZ
+Bj
+Cm
+Cm
+Gu
+fQ
+DV
+SF
+yb
+ha
+km
+it
+JW
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+"}
+(32,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+SR
+lj
+Qm
+HT
+ub
+dD
+MC
+RF
+RF
+RF
+nb
+uW
+ZC
+tf
+tf
+ZC
+tf
+tf
+NW
+Bj
+Cm
+JW
+Gu
+yL
+PQ
+LO
+iT
+it
+it
+ez
+JW
+JW
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+"}
+(33,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+Pp
+Bu
+kn
+Ji
+kN
+dD
+Kq
+RF
+Dp
+RF
+nb
+uW
+tf
+ZC
+tf
+tf
+tf
+tf
+HZ
+Bj
+IR
+IR
+Gu
+Gu
+tT
+nE
+bq
+it
+it
+it
+JW
+JW
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+"}
+(34,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+SR
+Zq
+DM
+II
+ub
+dD
+Ad
+eT
+RF
+RF
+nb
+PP
+tf
+tf
+tf
+ZC
+ZC
+ZC
+jb
+Bj
+IR
+JW
+Tb
+HD
+jm
+HM
+rc
+HJ
+HJ
+Tb
+JW
+JW
+JW
+Cm
+pG
+pG
+pG
+pG
+pG
+"}
+(35,1,1) = {"
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+dD
+dD
+dD
+iW
+dD
+dD
+dD
+dD
+ml
+JW
+JW
+nb
+TI
+Hw
+uj
+uj
+uj
+uj
+Hw
+NS
+Bj
+JW
+JW
+Tv
+Zb
+Zb
+HM
+Zb
+Zb
+Zb
+GU
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(36,1,1) = {"
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+iv
+JX
+RN
+ty
+dD
+uo
+uE
+BY
+Wu
+JW
+JW
+cf
+Fv
+Fv
+Bq
+tT
+UX
+aw
+Fv
+Fv
+gz
+JW
+aW
+Kd
+Sh
+Sh
+WE
+Zb
+xC
+Zb
+zv
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(37,1,1) = {"
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+hr
+wF
+Xc
+Jl
+IF
+ph
+fu
+VY
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+jI
+ak
+ak
+ak
+ak
+ak
+EC
+JW
+Xo
+Xo
+Xo
+Xo
+Xo
+cI
+cI
+cI
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+"}
+(38,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+hr
+wF
+VS
+TH
+eO
+Hg
+PS
+oY
+JW
+ov
+JW
+JW
+JW
+JW
+JW
+JW
+dc
+JW
+JW
+JW
+JW
+JW
+IR
+Cm
+Cm
+Cm
+Cm
+IR
+IR
+JW
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(39,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+Gb
+pA
+gk
+ls
+dD
+Zh
+JF
+zW
+JW
+JW
+JW
+JW
+JW
+JW
+JW
+IR
+QQ
+JW
+JW
+IR
+ut
+IR
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(40,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+dD
+dD
+dD
+iW
+dD
+dD
+dD
+dD
+Cm
+JW
+JW
+JW
+IR
+qI
+Gu
+CS
+KY
+Dr
+kw
+gs
+gs
+gs
+gs
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(41,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+SR
+lj
+vL
+HT
+ub
+dD
+Cm
+JW
+JW
+JW
+Cm
+IR
+IR
+fU
+kq
+PW
+bQ
+Ld
+gs
+BF
+jV
+gs
+gs
+Cm
+Cm
+Cm
+Cm
+Cm
+JW
+JW
+JW
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(42,1,1) = {"
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+Pp
+Bu
+gJ
+Ji
+Pp
+dD
+Cm
+PF
+JW
+Cm
+Cm
+IR
+IR
+fU
+yg
+Tg
+Qb
+Jm
+rX
+sb
+PE
+GB
+gs
+WX
+WX
+WX
+WX
+JW
+JW
+JW
+JW
+Cm
+JW
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(43,1,1) = {"
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+SR
+lj
+qr
+II
+ub
+dD
+PF
+PF
+Cm
+Cm
+Cm
+IR
+IR
+cj
+VB
+ry
+DV
+cr
+cU
+WK
+CZ
+UQ
+gs
+qw
+Yq
+nm
+WX
+WX
+LJ
+LJ
+WX
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(44,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+dD
+Zz
+iE
+nF
+dD
+dD
+PF
+PF
+BU
+Cm
+IR
+IR
+IR
+cj
+lo
+Dy
+Zc
+Xy
+gs
+gZ
+ql
+yJ
+gs
+WN
+Ef
+RU
+WX
+Zt
+Gn
+Qk
+WX
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(45,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+dD
+dD
+dD
+dD
+dD
+Cm
+Cm
+PF
+BU
+BU
+IR
+IR
+BU
+VJ
+VJ
+qv
+qv
+VJ
+gs
+gs
+rt
+gs
+gs
+WX
+WX
+He
+WX
+BE
+ds
+lt
+WX
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+"}
+(46,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+BU
+IR
+IR
+IR
+VJ
+VJ
+TN
+Vf
+NF
+Vf
+VJ
+BW
+Kc
+wJ
+io
+WX
+FQ
+mq
+Cd
+oN
+lm
+CX
+WX
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+"}
+(47,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+BU
+BU
+IR
+IR
+IR
+VJ
+Vf
+ZO
+SA
+UP
+Rj
+VJ
+Zp
+Xv
+by
+sh
+LJ
+os
+mq
+kR
+kR
+kR
+ca
+WX
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+"}
+(48,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+BU
+bW
+Gu
+IR
+IR
+jp
+oB
+Qd
+yk
+Ag
+Uc
+mo
+MJ
+mv
+zB
+vI
+WX
+TZ
+mq
+CN
+qo
+kR
+vY
+WX
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+"}
+(49,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+BU
+BU
+IR
+IR
+VJ
+Cu
+pT
+mD
+hl
+tn
+VJ
+GJ
+Nl
+fk
+Te
+vl
+Cp
+dn
+dV
+GC
+kR
+kd
+WX
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+"}
+(50,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+PF
+BU
+IR
+IR
+VJ
+VJ
+Iq
+ib
+Yj
+oe
+VJ
+fk
+fk
+MZ
+ii
+WX
+sW
+fz
+pE
+At
+kR
+WX
+WX
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+"}
+(51,1,1) = {"
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+BU
+IR
+IR
+IR
+BU
+lq
+lq
+lq
+eu
+lq
+lq
+Bv
+AC
+Ir
+Oi
+Ir
+Ir
+WX
+WX
+WX
+WX
+WX
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+"}
+(52,1,1) = {"
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+PF
+PF
+Cm
+IR
+IR
+IR
+IR
+lq
+yd
+lO
+fr
+iA
+lq
+gs
+gs
+Ir
+ZP
+nT
+Ir
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+"}
+(53,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+Cm
+Cm
+Cm
+IR
+IR
+lq
+lq
+gT
+bc
+SM
+aP
+fZ
+Hb
+Ir
+Ir
+EE
+zE
+Ir
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(54,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+Cm
+Cm
+Cm
+Cm
+IR
+IR
+IR
+aC
+LG
+QZ
+Kb
+Qi
+lq
+NI
+Ir
+dO
+am
+Ir
+Ir
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(55,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+Cm
+Cm
+Cm
+Cm
+IR
+IR
+BU
+aC
+Va
+nZ
+Sw
+nu
+lq
+lq
+Ir
+Ir
+Ir
+Ir
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(56,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+PF
+PF
+PF
+BU
+BU
+IR
+IR
+IR
+BU
+lq
+lq
+hs
+Tn
+Tn
+cN
+lq
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(57,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+PF
+PF
+BU
+IR
+IR
+IR
+IR
+BU
+Cm
+lq
+CY
+cl
+go
+lq
+lq
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(58,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+IR
+IR
+IR
+IR
+Cm
+Cm
+lq
+lq
+lq
+lq
+lq
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(59,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+IR
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(60,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(61,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}
+(62,1,1) = {"
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+Cm
+Cm
+pG
+Cm
+Cm
+pG
+Cm
+Cm
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+"}

--- a/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_underground_gunsmith.dmm
+++ b/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_underground_gunsmith.dmm
@@ -79,6 +79,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/beach/gunsmith/workshop)
+"aB" = (
+/mob/living/simple_animal/hostile/human/ramzi/ranged/smg/sidewinder,
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
 "aC" = (
 /obj/structure/window/plasma/reinforced/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -382,6 +386,7 @@
 /obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/hydra/gunsmith,
 /turf/open/floor/concrete/slab_1,
 /area/ruin/beach/gunsmith)
 "dD" = (
@@ -2530,6 +2535,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/shotgun,
 /turf/open/floor/plating,
 /area/ruin/beach/gunsmith/workshop)
 "yX" = (
@@ -3517,6 +3523,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/concrete/tiles,
 /area/ruin/beach/gunsmith)
+"Jq" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/ramzi/civilian{
+	wander = 0
+	},
+/turf/open/floor/concrete/slab_4,
+/area/ruin/beach/gunsmith)
 "Jr" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4
@@ -4445,7 +4458,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/mob/living/simple_animal/hostile/human/ramzi/ranged/hydra/gunsmith,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/smg/sidewinder,
 /turf/open/floor/wood/walnut,
 /area/ruin/beach/gunsmith)
 "Up" = (
@@ -6037,7 +6050,7 @@ zF
 tf
 ZC
 tf
-ZC
+Jq
 jb
 Bj
 IR
@@ -6185,7 +6198,7 @@ uW
 tf
 tf
 tf
-tf
+aB
 tf
 tf
 HZ

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -103,6 +103,21 @@
 	suffix = "beach_bunkers.dmm"
 	cost = 2
 	ruin_tags = list(RUIN_TAG_MEDIUM_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_LIVEABLE)
+
+/datum/map_template/ruin/beachplanet/frontie_moat
+	name = "Frontiersmen Moat"
+	id = "frontie_moat"
+	description = "A frontiersman-built moat village. Not the worst place to live."
+	suffix = "beach_surface_frontie_moat.dmm"
+	cost = 3
+
+/datum/map_template/ruin/beachplanet/gunsmith
+	name = "Ramzi Gunsmith"
+	id = "gunsmith"
+	description = "A decadent gunsmithing den jointly owned by an outfit of the Ramzi Clique and a corrupt NGR official. Hidden within a cave."
+	suffix = "beach_underground_gunsmith.dmm"
+	cost = 3
+
 //							///
 //		MARK: Icemoon
 //							///


### PR DESCRIPTION
## Описание / Что этот PR делает
Перенос оффовских руин для пляжной планеты.
## Причина создания ПР / Почему это хорошо для игры
Расшинение пула руин, крутые руины.
## Демонстрация изменений / Тестирование
<img width="2208" height="1728" alt="image" src="https://github.com/user-attachments/assets/d09e7927-4905-477b-a748-d1c3caacb29b" />
<img width="1984" height="1536" alt="image" src="https://github.com/user-attachments/assets/b7f70982-561b-48e3-ab12-17cbb5e1ba21" />


## Список изменений

```yml
🆑
map: добавляет на пляж Frontie Moat, Gunsmith.
/🆑
```
