### PR TITLE
FIX: Небольшой фикс Box Hospital

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
@@ -1205,7 +1205,8 @@
 /obj/item/fish_feed{
 	layer = 2
 	},
-/obj/item/reagent_containers/glass/bottle/vial/large/preloaded/CMO,
+/obj/effect/spawner/random/medical/surgery_tool/adv,
+/obj/item/storage/box/hypospray,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "gE" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -3825,6 +3825,7 @@
 	},
 /obj/item/storage/belt/medical/webbing,
 /obj/item/clothing/mask/balaclava/combat,
+/obj/item/healthanalyzer/ranged,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "YV" = (

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_skybreaker.dmm
@@ -3825,7 +3825,6 @@
 	},
 /obj/item/storage/belt/medical/webbing,
 /obj/item/clothing/mask/balaclava/combat,
-/obj/item/healthanalyzer/ranged,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "YV" = (


### PR DESCRIPTION
## Описание / Что этот PR делает
Улучшаем немного быт медиков на боксе
## Причина создания ПР / Почему это хорошо для игры
### **Независимый корабль (Box):**
- Боксу вернул то что забрали случайно после ремапа #1339 + fix #2590 (так как возвращается то что убирает проблему)
__Причина:__ Фиксит ишуй с некорректными гипоспреями внутри ящика и в мед поясе глав врача(капитана корабля) + возвращает рандомный улучшеный хирургический инструмент который убрали также случайно когда меняли тип locker и как минимум автор ПРа не указывал, что продал некоторое оборудование бокса 😄 
<img width="823" height="179" alt="image" src="https://github.com/user-attachments/assets/e5e27d36-e4eb-43a8-a86d-7afba897e126" />
<img width="1595" height="757" alt="image" src="https://github.com/user-attachments/assets/e9122182-7d48-40cb-85e2-871042f9af07" />

## Демонстрация изменений / Тестирование
Не требуется, все указано выше

## Список изменений

```yml
🆑 Azzy.Dreemurr
fix: Box hospital (Independent) - получил обратно коробку гипоспреев и рандомный улучшенный инструмент хирургии
/🆑
```
