### PR TITLE
REVERT: IPCs can no longer heal through space suits

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -122,8 +122,8 @@
 	var/obj/item/bodypart/attackedLimb = target.get_bodypart(check_zone(user.zone_selected))
 	if(!attackedLimb || IS_ORGANIC_LIMB(attackedLimb) || (user.a_intent == INTENT_HARM))
 		return ..()
-	if(!target.is_exposed(user, TRUE, user.zone_selected))
-		return TRUE
+	//if(!target.is_exposed(user, TRUE, user.zone_selected))	// [CELADON-REMOVE] - NO-HARDER-REPAIR-IPC
+	//	return TRUE												// [/CELADON-REMOVE]
 	if(!tool_start_check(user, amount = 1))
 		return TRUE
 	user.visible_message(span_notice("[user] starts to fix some of the dents on [target]'s [parse_zone(attackedLimb.body_zone)]."),

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -504,6 +504,7 @@
 /mob/living/carbon/human/proc/canUseHUD()
 	return (mobility_flags & MOBILITY_USE)
 
+/* // [CELADON-REMOVE] - NO-HARDER-REPAIR-IPC - Это используется только под IPC - Они и так через фичу обходят этот момент, так что зачем усложнять все?
 //ohh god this'll need to be reworked into a zone-by-zone selection, rather than just "are yuor jorts thick"
 
 /mob/living/carbon/human/proc/is_exposed(mob/user, error_msg, target_zone)
@@ -527,7 +528,7 @@
 	if(!. && error_msg && user)
 		// Might need re-wording.
 		to_chat(user, span_alert("There is no exposed flesh or thin material [above_neck(target_zone) ? "on [p_their()] head" : "on [p_their()] body"]."))
-
+*/ // [/CELADON-REMOVE]
 
 /mob/living/carbon/human/can_inject(mob/user, target_zone, injection_flags)
 	. = TRUE // Default to returning true.

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -538,8 +538,8 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list(new/datum/stack_recipe("cable restrain
 	if(!istype(H))
 		return ..()
 
-	if(!H.is_exposed(user, TRUE, user.zone_selected))
-		return TRUE
+	//if(!H.is_exposed(user, TRUE, user.zone_selected))	// [CELADON-REMOVE] - NO-HARDER-REPAIR-IPC
+	//	return TRUE										// [/CELADON-REMOVE]
 
 	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 	if(affecting && (!IS_ORGANIC_LIMB(affecting)))

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -196,8 +196,8 @@
 	var/obj/item/bodypart/attackedLimb = target.get_bodypart(check_zone(user.zone_selected))
 	if(!attackedLimb || IS_ORGANIC_LIMB(attackedLimb) || (user.a_intent == INTENT_HARM))
 		return ..()
-	if(!target.is_exposed(user, TRUE, user.zone_selected))
-		return TRUE
+	//if(!target.is_exposed(user, TRUE, user.zone_selected))	// [CELADON-REMOVE] - NO-HARDER-REPAIR-IPC
+	//	return TRUE												// [/CELADON-REMOVE]
 	if(!tool_start_check(user, amount = 1))
 		return TRUE
 	user.visible_message(span_notice("[user] starts to fix some of the dents on [target]'s [parse_zone(attackedLimb.body_zone)]."),


### PR DESCRIPTION
## Описание / Что этот PR делает
Убирает ограничение на починку в космосе через риги у Роботов.
+ Уже просил не один человек, обойти это ограничение очень просто просто не удобно.

## Причина создания ПР / Почему это хорошо для игры
Это хоть и реалистично, но создает тупые ситуации когда роботы и так могут чиниться в космосе, но раз в 5 медленнее чем хуман с химией.
Делает снова играбельными космо-бои в ригах на КПБ (IPC)

## Список изменений

```yml
🆑
del: Код на починку через риги у КПБ (IPC)
/🆑
```
