### PR TITLE
BALANCE: Replaces outpostmeds with nanomeds

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_crashed_starwalker.dmm
+++ b/_maps/_mod_celadon/RandomRuins/BeachRuins/beach_crashed_starwalker.dmm
@@ -2300,7 +2300,7 @@
 	dir = 4
 	},
 /obj/structure/rack,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -28
 	},
 /obj/item/storage/pill_bottle/epinephrine{

--- a/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_surface_corporate_rejects.dmm
+++ b/_maps/_mod_celadon/RandomRuins/IceRuins/icemoon_surface_corporate_rejects.dmm
@@ -754,7 +754,7 @@
 /area/ruin/unpowered/corprejectvault)
 "rH" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -25
 	},
 /obj/structure/cable/blue{
@@ -816,7 +816,7 @@
 /area/ruin/unpowered/corprejectrooms)
 "tM" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 25
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,

--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_paradise.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_paradise.dmm
@@ -183,7 +183,7 @@
 	},
 /area/overmap_encounter/planetoid/cave/explored)
 "bt" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
@@ -4526,7 +4526,7 @@
 /turf/open/floor/plating/asteroid/dirt/jungle/dark,
 /area/overmap_encounter/planetoid/cave/explored)
 "Gi" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
@@ -5044,7 +5044,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/techfloor,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	name = "Emergency NanoMed";
 	pixel_y = -27;
 	use_power = 0

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
@@ -7386,7 +7386,7 @@
 /obj/item/circuitboard/machine/vendor{
 	name = "NanoMed Vendor (Machine Board)"
 	},
-/obj/item/vending_refill/wallmed{
+/obj/item/vending_refill/wallmed/ship{
 	name = "NanoMed restocking unit"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/lavaland,
@@ -13445,7 +13445,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	icon_state = "wallmed-off";
 	pixel_y = -28
 	},

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
@@ -13445,7 +13445,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed/ship{
+/obj/machinery/vending/wallmed{
 	icon_state = "wallmed-off";
 	pixel_y = -28
 	},

--- a/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
+++ b/_maps/_mod_celadon/RandomRuins/LavaRuins/lavaland_crashed_heron.dmm
@@ -7386,7 +7386,7 @@
 /obj/item/circuitboard/machine/vendor{
 	name = "NanoMed Vendor (Machine Board)"
 	},
-/obj/item/vending_refill/wallmed/ship{
+/obj/item/vending_refill/wallmed{
 	name = "NanoMed restocking unit"
 	},
 /turf/open/floor/plating/asteroid/dirt/grass/lavaland,
@@ -13445,7 +13445,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	icon_state = "wallmed-off";
 	pixel_y = -28
 	},

--- a/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
@@ -1443,7 +1443,7 @@
 /obj/effect/turf_decal/trimline/opaque/white/filled/corner{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/_mod_celadon/shuttles/independent/independent_dwayne.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_dwayne.dmm
@@ -895,7 +895,7 @@
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "sZ" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 28
 	},
 /obj/structure/closet/crate/freezer/blood,

--- a/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_lagoon.dmm
@@ -3030,7 +3030,7 @@
 /area/ship/crew/canteen)
 "rQ" = (
 /obj/structure/chair/office,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{

--- a/_maps/_mod_celadon/shuttles/independent/independent_mimos.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_mimos.dmm
@@ -1045,7 +1045,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "ms" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 25
 	},
 /obj/structure/bed/roller,

--- a/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
@@ -1334,7 +1334,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 25
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
@@ -3450,7 +3450,7 @@
 /obj/effect/turf_decal/corner/opaque/green/border{
 	dir = 5
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -1;
 	pixel_y = -28
 	},

--- a/_maps/_mod_celadon/shuttles/independent/independent_rube_goldberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_rube_goldberg.dmm
@@ -5211,7 +5211,7 @@
 /turf/open/floor/engine/airless,
 /area/ship/engineering/atmospherics)
 "Zt" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 28
 	},
 /obj/structure/window/reinforced/spawner{

--- a/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_schmiedeberg.dmm
@@ -325,7 +325,7 @@
 	},
 /area/ship/crew/canteen)
 "dU" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/oil/streak,

--- a/_maps/_mod_celadon/shuttles/independent/independent_tranquility.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_tranquility.dmm
@@ -5361,7 +5361,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/storage)
 "QR" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/corner/opaque/bottlegreen{

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_executioner.dmm
@@ -385,7 +385,7 @@
 /turf/open/floor/plasteel,
 /area/ship/crew/office)
 "dt" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/industrial/traffic{
@@ -3833,7 +3833,7 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/industrial/traffic/corner{

--- a/_maps/_mod_celadon/shuttles/inteq/inteq_hammerhead.dmm
+++ b/_maps/_mod_celadon/shuttles/inteq/inteq_hammerhead.dmm
@@ -1927,7 +1927,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ship/crew/dorm)
 "lG" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/titanium/white,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -2991,7 +2991,7 @@
 /obj/effect/turf_decal/trimline/opaque/deforestblue/line{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 0;
 	pixel_y = 32
 	},

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_chariot.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_chariot.dmm
@@ -2079,7 +2079,7 @@
 /turf/open/floor/plating/ship,
 /area/ship/general/engineering/engineering_1)
 "sg" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/siding/red{

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_daggerfall.dmm
@@ -4068,7 +4068,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -31
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_darect.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_darect.dmm
@@ -1091,7 +1091,7 @@
 "st" = (
 /obj/effect/turf_decal/industrial/hatch/blue,
 /obj/machinery/stasis,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_gecko.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_gecko.dmm
@@ -1648,7 +1648,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "tN" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -5
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_heron.dmm
@@ -6008,7 +6008,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -28
 	},
 /obj/machinery/button/door{
@@ -8573,7 +8573,7 @@
 /area/ship/bridge)
 "EK" = (
 /obj/machinery/medical_kiosk,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -27
 	},
 /obj/effect/turf_decal/siding/white{

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_mimir.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_mimir.dmm
@@ -7256,7 +7256,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance/port)
 "Qc" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -32
 	},
 /obj/structure/sink{

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -214,7 +214,7 @@
 /obj/structure/chair/sofa/grey/right/directional/east{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 32
 	},
 /obj/machinery/light/directional/north,
@@ -4041,7 +4041,7 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 32
 	},
 /obj/structure/chair/handrail{

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_ember.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_ember.dmm
@@ -2371,7 +2371,7 @@
 	icon_state = "gib6-old";
 	pixel_x = 8
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 32
 	},
 /obj/structure/cable{
@@ -4794,7 +4794,7 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 32
 	},
 /obj/item/radio/intercom/directional/east,
@@ -5115,7 +5115,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/patterned/cargo_one,

--- a/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
+++ b/_maps/_mod_celadon/shuttles/pirate/pirate_libertatia.dmm
@@ -964,7 +964,7 @@
 /area/ship/hallway/port)
 "Ce" = (
 /obj/structure/table/reinforced,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 30
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery,

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_anomaly.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_anomaly.dmm
@@ -2425,7 +2425,7 @@
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "Ml" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/darkbrownfull/darkbrown{

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_firetail.dmm
@@ -7718,7 +7718,7 @@
 /obj/structure/sign/poster/solgov/suns{
 	pixel_y = 32
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -31
 	},
 /turf/open/floor/marble/black,

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_glimpse.dmm
@@ -1165,7 +1165,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -27
 	},
 /obj/structure/cable{

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_inqrutsio.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_inqrutsio.dmm
@@ -831,7 +831,7 @@
 	color = "#2d2a4e"
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 30;
 	pixel_y = -4
 	},

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_lightning.dmm
@@ -3922,7 +3922,7 @@
 /obj/effect/turf_decal/trimline/opaque/cybersunteal/line{
 	dir = 6
 	},
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = 30;
 	pixel_y = -4
 	},

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_saber.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_saber.dmm
@@ -2361,7 +2361,7 @@
 /turf/open/floor/wood/ebony,
 /area/ship/security/armory)
 "sT" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{

--- a/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
+++ b/_maps/_mod_celadon/shuttles/solfed/solfed_tomahawk.dmm
@@ -3695,7 +3695,7 @@
 /obj/effect/turf_decal/corner/opaque/cybersunteal/border,
 /obj/structure/table/glass,
 /obj/item/storage/case/surgery,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/_mod_celadon/shuttles/subshuttles/nanotrasen_falcon.dmm
+++ b/_maps/_mod_celadon/shuttles/subshuttles/nanotrasen_falcon.dmm
@@ -144,7 +144,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -28
 	},
 /obj/effect/landmark/ert_shuttle_spawn,

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_aegis.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_aegis.dmm
@@ -2873,7 +2873,7 @@
 	},
 /obj/item/clothing/mask/muzzle,
 /obj/item/defibrillator/compact/loaded,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/tech,

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_beetle.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_beetle.dmm
@@ -2170,7 +2170,7 @@
 /obj/item/clothing/suit/space/hardsuit/syndi/cybersun/paramed,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 28
 	},
 /obj/machinery/airalarm/directional/west,

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_gorlex_sunset.dmm
@@ -1698,7 +1698,7 @@
 /turf/open/floor/marble/black,
 /area/ship/hallway/central)
 "BG" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = 28;
 	pixel_x = 3
 	},

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_twinkleshine.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_twinkleshine.dmm
@@ -8068,7 +8068,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
 "TT" = (
-/obj/machinery/vending/wallmed{
+/obj/machinery/vending/wallmed/ship{
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/corner/opaque/orange{

--- a/mod_celadon/balance/code/vending.dm
+++ b/mod_celadon/balance/code/vending.dm
@@ -20,6 +20,7 @@
 		/obj/item/stack/medical/ointment = 2,
 		/obj/item/stack/medical/splint = 2,
 		/obj/item/storage/pill_bottle/charcoal/less = 1,
+		/obj/item/reagent_containers/syringe/antiviral = 2,
 		/obj/item/stack/medical/gauze = 4,
 		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
 		/obj/item/reagent_containers/hypospray/medipen/tramal = 2,

--- a/mod_celadon/balance/code/vending.dm
+++ b/mod_celadon/balance/code/vending.dm
@@ -8,6 +8,34 @@
 /obj/machinery/vending/wallmed
 	all_items_free = TRUE
 
+/obj/machinery/vending/wallmed/ship //специальный вариант валлмеда для шипов и руинок, без бесконечных рестоков и дебаг лута
+	name = "\improper wall-mounted NanoMed"
+	desc = "Wall-mounted Medical Equipment dispenser."
+	product_ads = ""
+	armor = list("melee" = 20, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 70)
+	restock_hourly = FALSE
+
+	products = list(
+		/obj/item/stack/medical/bruise_pack = 2,
+		/obj/item/stack/medical/ointment = 2,
+		/obj/item/stack/medical/splint = 2,
+		/obj/item/storage/pill_bottle/charcoal/less = 1,
+		/obj/item/stack/medical/gauze = 4,
+		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
+		/obj/item/reagent_containers/hypospray/medipen/tramal = 2,
+		/obj/item/healthanalyzer = 2,
+	)
+	contraband = list(
+		/obj/item/reagent_containers/pill/tox = 1,
+		/obj/item/storage/box/gum/happiness = 1,
+	)
+	premium = list(
+		/obj/item/reagent_containers/pill/patch/indomide = 2,
+		/obj/item/reagent_containers/pill/patch/alvitane = 2,
+		/obj/item/reagent_containers/medigel/hadrakine = 2,
+		/obj/item/reagent_containers/medigel/quardexane = 2,
+	)
+
 /obj/machinery/vending/medical/outpost_access
 	name = "\improper Elysium Plus"
 	all_items_free = TRUE

--- a/mod_celadon/balance/code/vending.dm
+++ b/mod_celadon/balance/code/vending.dm
@@ -18,10 +18,11 @@
 	products = list(
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 2,
+		/obj/item/stack/medical/gauze = 4,
 		/obj/item/stack/medical/splint = 2,
+		/obj/item/stack/medical/bone_gel = 1,
 		/obj/item/storage/pill_bottle/charcoal/less = 1,
 		/obj/item/reagent_containers/syringe/antiviral = 2,
-		/obj/item/stack/medical/gauze = 4,
 		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
 		/obj/item/reagent_containers/hypospray/medipen/tramal = 2,
 		/obj/item/healthanalyzer = 2,


### PR DESCRIPTION
## Описание / Что этот PR делает
Создает отдельный вариант валлмеда без кучи медицины и рестоков для использования на шипах и руинах.
Ставит его на все модульные шипы и руины. Аванпосты не затрагивает.

## Причина создания ПР / Почему это хорошо для игры
Сильно ломающая смысл делать закуп/варку химии вещь, что стоит на половине шипов в игре, которая еще и быть на них изначально не должна, ибо это оффовский валлмед для их аванпостов.

/ship вариант имеет более скромный ассортимент. За основу взят валлмед с ТГ. Плюс он без авторестоков.

## Демонстрация изменений / Тестирование
<img width="438" height="527" alt="image" src="https://github.com/user-attachments/assets/c2d9f509-d4ad-4878-ace6-ed02cfa69770" />


## Список изменений

```yml
🆑
balance: Настенные наномеды на кораблях получили более скромный ассортимент.
/🆑
```
