### PR TITLE
ADD: E-GUN - HOTKEY-RELOAD swap `select_fire`

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -138,6 +138,13 @@
 		return
 	return ..()
 
+// [CELADON-ADD] - HOTKEY-RELOAD - Возвращает переключение режимов стрельбы на кнопку перезарядки
+/obj/item/gun/energy/unique_action(mob/living/user)
+	if(ammo_type.len > 1)
+		select_fire(user)
+		update_appearance()
+// [/CELADON-ADD]
+
 /obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
 	if(..())
 		return FALSE


### PR DESCRIPTION
## Описание / Что этот PR делает
Возвращает переключение режимов стрельбы на хоткей перезарядки

## Причина создания ПР / Почему это хорошо для игры
Хоткей по нажатию переключает режимы у энерго-оружия, у нас нету слотов под аккумуляторы на это действие как на апстриме.

## Список изменений

```yml
🆑
add: Переключение режимов стрельбы у Еганов
/🆑
```
