### PR TITLE
MAP: Tear drop on ground oh!

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_teardrop.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_teardrop.json
@@ -6,6 +6,8 @@
 	"map_path": "_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm",
 	"enabled": true,
 	"limit": 1,
+	"tranist_x_offset": -15,
+	"tranist_y_offset": -11,
 	"sensor_range": 4,
 	"prefix": "NTASV",
 	"faction": "/datum/faction/nt",

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -423,14 +423,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "dP" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
 /obj/effect/turf_decal/techfloor,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/marker_beacon{
-	picked_color = "Teal"
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
 	},
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "dU" = (
@@ -610,6 +610,10 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
@@ -1520,12 +1524,28 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "ox" = (
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/light/floor,
+/obj/machinery/door/airlock/freezer{
+	name = "Toilet";
+	id_tag = "teardrop_bathroom";
 	dir = 4
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
+"oI" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 9
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "oO" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -1573,14 +1593,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "oU" = (
-/obj/effect/turf_decal/techfloor,
 /obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/effect/turf_decal/industrial/stand_clear{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/marker_beacon{
+	picked_color = "Teal"
+	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "pd" = (
@@ -2259,6 +2284,15 @@
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/machinery/button/door{
+	pixel_y = 22;
+	pixel_x = 10;
+	id = "teardrop_bathroom";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	name = "Bolt Control"
+	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/dorm)
 "xj" = (
@@ -2560,22 +2594,6 @@
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
-"yW" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/marker_beacon{
-	picked_color = "Teal"
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
 "yZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -2811,7 +2829,7 @@
 	name = "Engineering";
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/hallway/central)
 "Bq" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
@@ -2855,7 +2873,7 @@
 /obj/machinery/door/airlock/public/glass{
 	dir = 1
 	},
-/turf/open/floor/plasteel/heavymetal/var4,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "BR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -2864,16 +2882,14 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/bridge)
 "BZ" = (
-/obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets";
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/industrial/warning{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/turf_decal/techfloor,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/marker_beacon{
+	picked_color = "Teal"
+	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "Cj" = (
@@ -3174,15 +3190,6 @@
 /obj/item/wrench,
 /turf/open/floor/engine,
 /area/ship/engineering)
-"Fs" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/stand_clear,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
 "Fx" = (
 /obj/effect/turf_decal/spline/plain/opaque/purple,
 /turf/open/floor/plasteel/strongdark,
@@ -3524,6 +3531,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/bridge)
+"Ke" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "Km" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -4074,7 +4090,19 @@
 	name = "Engineering";
 	dir = 8
 	},
-/turf/open/floor/plasteel/tech/grid,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/engineering)
 "PS" = (
 /obj/machinery/door/firedoor/border_only{
@@ -4409,7 +4437,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel/heavymetal/var4,
+/turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "ST" = (
 /obj/machinery/door/firedoor/border_only{
@@ -4533,6 +4561,7 @@
 	dir = 4
 	},
 /obj/item/soap/nanotrasen,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/crew/dorm)
 "UY" = (
@@ -4578,14 +4607,13 @@
 "Vo" = (
 /obj/machinery/porta_turret/ship/nt/light{
 	id = "teardrop_turrets";
-	dir = 9
+	dir = 1
 	},
+/obj/effect/turf_decal/box,
 /obj/effect/turf_decal/industrial/warning{
-	dir = 9
+	dir = 1
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
+/obj/effect/turf_decal/techfloor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
@@ -4649,6 +4677,14 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
@@ -4733,7 +4769,7 @@
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = -12;
-	pixel_y = -20
+	pixel_y = -15
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -5193,7 +5229,7 @@ fa
 fa
 fa
 fa
-Vo
+oI
 yz
 DY
 IT
@@ -5360,7 +5396,7 @@ fa
 (15,1,1) = {"
 fa
 fa
-dP
+BZ
 It
 Ix
 bf
@@ -5378,13 +5414,13 @@ yz
 RJ
 Zm
 yz
-yW
+oU
 fa
 "}
 (16,1,1) = {"
 fa
 fa
-BZ
+Vo
 It
 cM
 Fx
@@ -5408,7 +5444,7 @@ fa
 (17,1,1) = {"
 fa
 fa
-oU
+dP
 It
 FL
 vG
@@ -5426,7 +5462,7 @@ aO
 aO
 aO
 aO
-Fs
+Ke
 fa
 "}
 (18,1,1) = {"

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -424,14 +424,9 @@
 /area/ship/medical)
 "dP" = (
 /obj/effect/turf_decal/industrial/warning{
-	dir = 10
+	dir = 9
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	dir = 4
-	},
+/obj/effect/turf_decal/techfloor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon{
 	picked_color = "Teal"
@@ -1451,7 +1446,7 @@
 /obj/item/radio/headset/nanotrasen/alt/captain,
 /obj/item/extinguisher/advanced,
 /obj/item/extinguisher/mini,
-/obj/item/inducer/adv,
+/obj/item/inducer,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "oc" = (
@@ -1497,6 +1492,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "ov" = (
@@ -1530,20 +1526,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
-"oI" = (
-/obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets";
-	dir = 9
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
 "oO" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -1590,6 +1572,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
+"oU" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "pd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -1994,19 +1987,6 @@
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
-"tK" = (
-/obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets";
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
 "tM" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -2582,9 +2562,14 @@
 /area/ship/engineering)
 "yW" = (
 /obj/effect/turf_decal/industrial/warning{
-	dir = 9
+	dir = 10
 	},
-/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/marker_beacon{
 	picked_color = "Teal"
@@ -2879,8 +2864,18 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/bridge)
 "BZ" = (
-/turf/template_noop,
-/area/space)
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "Cj" = (
 /obj/machinery/power/shieldwallgen/atmos{
 	anchored = 1;
@@ -3083,7 +3078,7 @@
 /turf/open/floor/engine/n2,
 /area/ship/engineering)
 "DY" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/rnd/server,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Eb" = (
@@ -3179,6 +3174,15 @@
 /obj/item/wrench,
 /turf/open/floor/engine,
 /area/ship/engineering)
+"Fs" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "Fx" = (
 /obj/effect/turf_decal/spline/plain/opaque/purple,
 /turf/open/floor/plasteel/strongdark,
@@ -3520,13 +3524,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/bridge)
-"Ke" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "teardrop_windows"
-	},
-/turf/open/floor/engine/hull/interior,
-/area/ship/security)
 "Km" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -3897,16 +3894,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/dormtwo)
 "NW" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 1
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/poddoor{
+	id = "teardrop_windows"
 	},
-/obj/effect/turf_decal/industrial/stand_clear{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/hull/reinforced,
-/area/ship/external)
+/turf/open/floor/engine/hull/interior,
+/area/ship/security)
 "NX" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -4583,11 +4576,16 @@
 /turf/open/floor/engine/o2,
 /area/ship/engineering)
 "Vo" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 9
 	},
-/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
@@ -4637,7 +4635,8 @@
 /obj/docking_port/stationary{
 	width = 27;
 	height = 15;
-	dwidth = 10
+	dwidth = 10;
+	disable_on_owner_ship_dock = 1
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -5194,7 +5193,7 @@ fa
 fa
 fa
 fa
-oI
+Vo
 yz
 DY
 IT
@@ -5361,7 +5360,7 @@ fa
 (15,1,1) = {"
 fa
 fa
-yW
+dP
 It
 Ix
 bf
@@ -5379,13 +5378,13 @@ yz
 RJ
 Zm
 yz
-dP
+yW
 fa
 "}
 (16,1,1) = {"
 fa
 fa
-tK
+BZ
 It
 cM
 Fx
@@ -5409,7 +5408,7 @@ fa
 (17,1,1) = {"
 fa
 fa
-NW
+oU
 It
 FL
 vG
@@ -5427,7 +5426,7 @@ aO
 aO
 aO
 aO
-Vo
+Fs
 fa
 "}
 (18,1,1) = {"
@@ -5774,7 +5773,7 @@ fa
 fa
 fa
 fa
-Ke
+NW
 vY
 ma
 yZ
@@ -5782,7 +5781,7 @@ Rv
 ve
 CS
 vY
-Ke
+NW
 fa
 fa
 fa
@@ -5798,7 +5797,7 @@ fa
 fa
 fa
 fa
-Ke
+NW
 fI
 ZG
 gB
@@ -5806,7 +5805,7 @@ Kn
 jd
 lg
 fI
-Ke
+NW
 fa
 fa
 fa
@@ -5846,7 +5845,7 @@ fa
 fa
 fa
 fa
-Ke
+NW
 Lz
 ts
 ii
@@ -5854,7 +5853,7 @@ aC
 Lo
 TT
 it
-Ke
+NW
 fa
 fa
 fa
@@ -5870,7 +5869,7 @@ fa
 fa
 fa
 fa
-Ke
+NW
 yp
 QV
 jh
@@ -5878,7 +5877,7 @@ fq
 Vw
 QV
 NB
-Ke
+NW
 fa
 fa
 fa
@@ -6029,76 +6028,4 @@ fa
 fa
 fa
 fa
-"}
-(43,1,1) = {"
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-"}
-(44,1,1) = {"
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-"}
-(45,1,1) = {"
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
-BZ
 "}

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -2871,7 +2871,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/public/glass{
-	dir = 1
+	req_ship_access = 1;
+	name = "Cargo Bay"
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
@@ -4436,7 +4437,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/airlock/public/glass{
+	req_ship_access = 1;
+	name = "Cargo Bay"
+	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/cargo)
 "ST" = (
@@ -4462,7 +4466,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/public/glass{
-	dir = 8
+	dir = 8;
+	req_ship_access = 1
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/hallway/central)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_teardrop.dmm
@@ -97,6 +97,14 @@
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -32
 	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_x = 28;
+	pixel_y = -7
+	},
+/obj/machinery/firealarm/directional/east{
+	pixel_x = 32;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/dorm)
 "aK" = (
@@ -198,6 +206,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = -7
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -32;
+	pixel_y = 6
+	},
 /turf/open/floor/wood/walnut,
 /area/ship/crew/dorm)
 "bL" = (
@@ -237,6 +252,9 @@
 	tag = null
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "cf" = (
@@ -273,19 +291,33 @@
 /turf/open/floor/plasteel/stairs/stairs_pack/dark,
 /area/ship/engineering)
 "cL" = (
+/obj/structure/platform/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/stairs/stairs_pack/dark,
 /area/ship/engineering)
 "cM" = (
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/spline/plain/opaque/purple{
 	dir = 1
 	},
 /obj/structure/chair/greyscale,
+/obj/machinery/light/directional/north,
 /turf/open/floor/plasteel/strongdark,
 /area/ship/crew/canteen/kitchen)
 "cN" = (
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets";
+	dir = 10
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/reinforced,
-/area/template_noop)
+/area/ship/external)
 "cP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -368,6 +400,13 @@
 /obj/item/clothing/under/nanotrasen/affairs,
 /obj/item/clothing/under/nanotrasen/affairs,
 /obj/item/clothing/under/nanotrasen/affairs,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
+/obj/item/storage/wallet/nt_wallet,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "dI" = (
@@ -384,6 +423,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "dP" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/marker_beacon{
+	picked_color = "Teal"
+	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "dU" = (
@@ -410,7 +462,10 @@
 /obj/item/gun/energy/e_gun/e_old/iot,
 /obj/item/gun/energy/e_gun/e_old/iot,
 /obj/item/gun/energy/e_gun/e_old/iot,
-/obj/item/gun/energy/e_gun/e_old/iot,
+/obj/item/gun/ballistic/automatic/smg/wt550{
+	pixel_x = 0;
+	pixel_y = 4
+	},
 /obj/item/melee/sword/mass,
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
@@ -472,6 +527,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "fq" = (
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 4
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/security)
 "ft" = (
@@ -603,6 +661,9 @@
 /area/ship/medical)
 "hc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/platform/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/stairs_pack/dark{
 	dir = 1
 	},
@@ -625,11 +686,11 @@
 	dir = 8;
 	layer = 3
 	},
-/obj/structure/platform{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/platform{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/ship/engineering)
@@ -653,6 +714,9 @@
 /obj/structure/chair/sofa/blue/corpo/left/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
+	},
+/obj/structure/sign/poster/contraband/starkist{
+	pixel_x = -32
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -816,6 +880,11 @@
 /obj/effect/turf_decal/spline/plain/opaque/purple{
 	dir = 10
 	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -13
+	},
 /turf/open/floor/plasteel/strongdark,
 /area/ship/crew/canteen/kitchen)
 "iS" = (
@@ -833,20 +902,22 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "ja" = (
-/obj/structure/railing/wood{
-	color = "#792f27";
-	dir = 6
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/obj/structure/railing/wood{
-	color = "#792f27";
-	dir = 9;
-	layer = 2
+/obj/structure/table/glass/light_glass,
+/obj/machinery/coffeemaker{
+	pixel_y = 10;
+	pixel_x = -1
 	},
-/obj/structure/fluff/hedge/opaque{
-	layer = 3
+/obj/item/coffee_cartridge/fancy/mocha{
+	pixel_x = 9;
+	pixel_y = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/item/coffee_cartridge/fancy/blend{
+	pixel_x = 9;
+	pixel_y = -3
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
@@ -872,6 +943,7 @@
 /obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
 	dir = 1
 	},
+/obj/effect/turf_decal/spline/fancy/opaque/ntbluelight/corner,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/security)
 "jj" = (
@@ -906,16 +978,30 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/bridge)
 "jp" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/porta_turret/ship/nt/light{
+	id = "teardrop_turrets"
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/external)
 "jG" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 6
+	},
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -6
+	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
 "jT" = (
@@ -959,7 +1045,8 @@
 	dir = 5
 	},
 /obj/structure/sign/directions/engineering{
-	pixel_y = -32
+	pixel_y = -19;
+	pixel_x = 4
 	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
@@ -971,6 +1058,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "kB" = (
@@ -1088,10 +1178,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/firealarm/directional/east{
+	pixel_x = 32;
+	pixel_y = 10
+	},
 /obj/machinery/light_switch{
 	pixel_x = 20;
 	dir = 8;
 	pixel_y = -12
+	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_x = 28;
+	pixel_y = -2
 	},
 /turf/open/floor/carpet/nanoweave,
 /area/ship/crew/canteen/kitchen)
@@ -1133,6 +1231,9 @@
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
@@ -1218,10 +1319,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "mR" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
-	dir = 1;
-	layer = 4
-	},
 /obj/effect/turf_decal/borderfloorblack,
 /obj/effect/turf_decal/techfloor{
 	dir = 1;
@@ -1232,6 +1329,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/warning{
+	dir = 1;
+	layer = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
@@ -1307,6 +1408,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "nF" = (
@@ -1327,7 +1431,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "nQ" = (
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/cryopod{
 	dir = 8
 	},
@@ -1393,6 +1496,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "ov" = (
@@ -1431,8 +1535,15 @@
 	id = "teardrop_turrets";
 	dir = 9
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "oO" = (
 /obj/effect/turf_decal/techfloor/corner{
 	dir = 8
@@ -1444,10 +1555,6 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "oT" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
-	dir = 1;
-	layer = 4
-	},
 /obj/effect/turf_decal/borderfloorblack/corner{
 	dir = 8
 	},
@@ -1467,28 +1574,22 @@
 	pixel_y = 5;
 	pixel_x = -2
 	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
+	dir = 1;
+	layer = 4
+	},
+/obj/machinery/button/shieldwallgen{
+	id = "teardrop_holo";
+	pixel_x = -9;
+	pixel_y = 21
+	},
+/obj/machinery/button/door{
+	id = "teardrop_cargo";
+	pixel_x = 2;
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
-"oU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/corner/opaque/ntblue/three_quarters,
-/obj/effect/turf_decal/trimline/opaque/black/warning{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 1
-	},
-/turf/open/floor/plasteel/heavymetal/var4,
-/area/ship/hallway/central)
 "pd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -1613,7 +1714,7 @@
 	dir = 4;
 	id = "teardrop_eng"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/engineering)
 "qe" = (
 /obj/machinery/airalarm/directional/south,
@@ -1687,9 +1788,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "re" = (
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/corner/opaque/black/three_quarters{
 	dir = 4
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = -18;
+	pixel_x = 0
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
@@ -1737,6 +1841,13 @@
 /obj/structure/chair/handrail{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -31;
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "su" = (
@@ -1766,7 +1877,7 @@
 	dir = 5
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/area/ship/crew/dorm)
 "sC" = (
 /obj/machinery/computer/atmos_control/incinerator{
 	sensors = list("teardrop_burn_sensor"= "Incinerator Chamber")
@@ -1780,15 +1891,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
 /obj/effect/turf_decal/corner/opaque/ntblue{
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/opaque/black/warning{
 	dir = 8
-	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -1796,6 +1903,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "sH" = (
@@ -1814,13 +1925,17 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/engine/hull/interior,
 /area/ship/engineering)
 "sP" = (
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 8
 	},
 /obj/item/banner/nanotrasen/mundane,
+/obj/structure/sign/poster/nanotrasen/vigilitas_nonlethal{
+	pixel_x = 27;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "tj" = (
@@ -1832,7 +1947,7 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plasteel/patterned/brushed,
+/turf/open/floor/engine/hull/interior,
 /area/ship/engineering)
 "tn" = (
 /obj/machinery/atmospherics/pipe/simple/dark{
@@ -1874,15 +1989,24 @@
 	dir = 4
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "tK" = (
 /obj/machinery/porta_turret/ship/nt/light{
 	id = "teardrop_turrets";
-	dir = 10
+	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "tM" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -1973,15 +2097,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/ntblue{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/opaque/black/warning{
 	dir = 4
+	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 1
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/engineering)
@@ -2119,13 +2243,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
 /obj/item/cigbutt{
 	pixel_x = -12;
 	pixel_y = -9
 	},
+/obj/machinery/atmospherics/components/binary/valve/layer4,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "wI" = (
@@ -2133,12 +2255,22 @@
 	icon_state = "2-4";
 	tag = null
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -8;
+	pixel_y = 28
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 4;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/heavymetal/var3,
 /area/ship/engineering)
 "wJ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/engineering)
@@ -2154,6 +2286,13 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -32;
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = -7
+	},
 /turf/open/floor/wood,
 /area/ship/hallway/central)
 "xy" = (
@@ -2164,6 +2303,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/window/plasma/reinforced/spawner/east,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
 /turf/open/floor/engine/hull/reinforced,
 /area/ship/engineering)
 "xz" = (
@@ -2200,7 +2342,7 @@
 	dir = 4;
 	id = "teardrop_eng"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/engineering)
 "xN" = (
 /obj/machinery/airalarm/directional/south,
@@ -2227,13 +2369,14 @@
 	},
 /obj/effect/turf_decal/corner/opaque/ntblue/half,
 /obj/effect/turf_decal/trimline/opaque/black/warning,
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 10
-	},
 /obj/effect/turf_decal/spline/fancy/opaque/ntbluelight/corner{
 	dir = 4
 	},
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 8
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/ntbluelight/corner,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "xT" = (
@@ -2438,14 +2581,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering)
 "yW" = (
-/obj/effect/turf_decal/corner/opaque/black/three_quarters{
-	dir = 8
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
 	},
-/obj/structure/sign/poster/contraband/starkist{
-	pixel_x = -32
+/obj/effect/turf_decal/techfloor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/marker_beacon{
+	picked_color = "Teal"
 	},
-/turf/open/floor/plasteel/heavymetal/var4,
-/area/ship/hallway/central)
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "yZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -2478,6 +2623,7 @@
 	sensors = list("teardrop_tox_sensor"="Plasma Tank");
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "zs" = (
@@ -2528,7 +2674,8 @@
 	dir = 6
 	},
 /obj/structure/sign/poster/contraband/steppyflag{
-	pixel_x = 32
+	pixel_x = 27;
+	pixel_y = 3
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
@@ -2572,7 +2719,7 @@
 	dir = 8
 	},
 /obj/machinery/door/window/eastright,
-/turf/open/floor/engine,
+/turf/open/floor/engine/hull/reinforced,
 /area/ship/engineering)
 "As" = (
 /obj/structure/cable{
@@ -2803,7 +2950,14 @@
 /obj/effect/turf_decal/trimline/opaque/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_x = -28;
+	pixel_y = 13
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -32;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "CE" = (
@@ -2844,7 +2998,7 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/crew/dorm/dormtwo)
 "CS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -2934,7 +3088,11 @@
 /area/ship/engineering)
 "Eb" = (
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
-/obj/machinery/light/directional/east,
+/obj/structure/cabinet/fireaxe{
+	pixel_y = 0;
+	dir = 8;
+	pixel_x = 20
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "Ep" = (
@@ -2968,13 +3126,11 @@
 	dir = 8;
 	layer = 3
 	},
-/obj/structure/platform{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/reagent_dispensers/watertank,
+/obj/structure/platform,
 /turf/open/floor/engine,
 /area/ship/engineering)
 "EZ" = (
@@ -3023,13 +3179,6 @@
 /obj/item/wrench,
 /turf/open/floor/engine,
 /area/ship/engineering)
-"Fs" = (
-/obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets";
-	dir = 1
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "Fx" = (
 /obj/effect/turf_decal/spline/plain/opaque/purple,
 /turf/open/floor/plasteel/strongdark,
@@ -3054,6 +3203,7 @@
 /obj/effect/turf_decal/spline/plain/opaque/purple{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/strongdark,
 /area/ship/crew/canteen/kitchen)
 "Gk" = (
@@ -3062,7 +3212,7 @@
 	id = "teardrop_windows";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/medical)
 "Gm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -3162,6 +3312,7 @@
 /area/ship/hallway/central)
 "HH" = (
 /obj/machinery/space_heater,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "HL" = (
@@ -3177,8 +3328,18 @@
 /turf/open/floor/engine/o2,
 /area/ship/engineering)
 "HT" = (
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/east{
+	pixel_x = 32;
+	pixel_y = -9
+	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/machinery/button/door{
+	id = "teardrop_eng";
+	name = "Engine Shutters";
+	pixel_x = 22;
+	dir = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "Ia" = (
@@ -3253,16 +3414,58 @@
 /area/ship/hallway/central)
 "IS" = (
 /obj/structure/closet/wall/red/directional/north,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
-/obj/item/stock_parts/cell/gun,
-/obj/item/screwdriver/nuke,
-/obj/item/screwdriver,
-/obj/item/screwdriver,
-/obj/item/screwdriver,
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/ammo/c46{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/screwdriver{
+	pixel_x = 1;
+	pixel_y = -11
+	},
+/obj/item/screwdriver{
+	pixel_x = 4;
+	pixel_y = -12
+	},
+/obj/item/screwdriver/nuke{
+	pixel_x = 7;
+	pixel_y = -13
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = -9;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/security)
 "IT" = (
@@ -3322,19 +3525,23 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plasteel/mono/dark,
+/turf/open/floor/engine/hull/interior,
 /area/ship/security)
 "Km" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
 	id = "teardrop_bridge"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/bridge)
 "Kn" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/toy/cards/deck{
 	pixel_y = 6
+	},
+/obj/item/folder/biscuit/unsealed/confidental{
+	pixel_y = 15;
+	pixel_x = -3
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
@@ -3352,6 +3559,9 @@
 	icon_state = "0-1"
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "KI" = (
@@ -3434,6 +3644,10 @@
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
 	pixel_y = 4
+	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = -2;
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
@@ -3522,7 +3736,7 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/crew/dorm)
 "LR" = (
 /obj/structure/railing{
@@ -3629,25 +3843,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
 	},
-/obj/structure/cabinet/fireaxe{
-	pixel_y = -24;
-	dir = 1
-	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/structure/sign/nanotrasen/nakamura{
+	pixel_x = -1;
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "Nr" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/recharger{
-	pixel_x = 5
-	},
 /obj/structure/cable{
 	icon_state = "0-1"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/recharger{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/machinery/recharger,
+/obj/machinery/recharger{
+	pixel_x = 10;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/security)
 "NB" = (
@@ -3680,12 +3897,16 @@
 /turf/open/floor/carpet/royalblack,
 /area/ship/crew/dorm/dormtwo)
 "NW" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/poddoor{
-	id = "teardrop_windows"
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/ship/security)
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "NX" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -3741,7 +3962,8 @@
 "Oj" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
-	pixel_x = -32
+	pixel_x = -27;
+	pixel_y = -2
 	},
 /obj/effect/turf_decal/corner/opaque/black/three_quarters{
 	dir = 1
@@ -3749,7 +3971,6 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "Oq" = (
-/obj/machinery/recharger,
 /obj/item/gun/ballistic/revolver/shadow/empty{
 	name = "\improper Last Exit"
 	},
@@ -3760,10 +3981,19 @@
 "Ou" = (
 /obj/structure/table/glass/light_glass,
 /obj/machinery/jukebox/boombox{
-	pixel_y = 1
+	pixel_y = 4;
+	pixel_x = 7
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 3;
+	pixel_x = 0
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_y = 4;
+	pixel_x = -10
 	},
 /turf/open/floor/wood/ebony,
 /area/ship/crew/canteen/kitchen)
@@ -3912,11 +4142,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/opaque/ntblue/three_quarters{
-	dir = 4
+/obj/effect/turf_decal/corner/opaque/ntblue{
+	dir = 9
 	},
 /obj/effect/turf_decal/trimline/opaque/black/warning{
-	dir = 9
+	dir = 8
 	},
 /obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
 /obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
@@ -4015,13 +4245,10 @@
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
 "Rv" = (
-/obj/machinery/firealarm/directional/west{
-	pixel_x = -39
-	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -20;
-	pixel_y = -12
+	pixel_y = -13
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -4031,6 +4258,14 @@
 	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -32;
+	pixel_y = -2
+	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_x = -28;
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/security)
@@ -4067,6 +4302,14 @@
 "RJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -10;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
@@ -4110,6 +4353,7 @@
 	dir = 1
 	},
 /obj/machinery/light/floor,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood/ebony,
 /area/ship/crew/dorm)
 "Sf" = (
@@ -4142,7 +4386,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/newscaster/directional/south{
+	pixel_x = 9;
+	pixel_y = -30
+	},
 /obj/effect/turf_decal/siding/wood{
 	color = "#B38274";
 	dir = 10
@@ -4271,9 +4518,6 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "UC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/light_switch{
 	pixel_y = 23;
@@ -4286,6 +4530,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/corner/opaque/black/diagonal,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "UH" = (
@@ -4336,11 +4583,14 @@
 /turf/open/floor/engine/o2,
 /area/ship/engineering)
 "Vo" = (
-/obj/machinery/porta_turret/ship/nt/light{
-	id = "teardrop_turrets"
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/techfloor{
+	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull/reinforced,
+/area/ship/external)
 "Vp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4369,6 +4619,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/spline/plain/opaque/ntbluelight,
+/obj/effect/turf_decal/spline/fancy/opaque/ntbluelight/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/security)
 "VS" = (
@@ -4477,9 +4730,6 @@
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "Xe" = (
-/obj/machinery/firealarm/directional/south{
-	pixel_y = -36
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light_switch{
 	dir = 1;
@@ -4505,7 +4755,7 @@
 /obj/machinery/door/poddoor{
 	id = "teardrop_windows"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/medical)
 "Xn" = (
 /obj/machinery/porta_turret/ship/nt/light{
@@ -4513,7 +4763,7 @@
 	dir = 6
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/area/ship/crew/dorm/dormtwo)
 "Xo" = (
 /obj/structure/catwalk/over/plated_catwalk/dark,
 /obj/structure/cable{
@@ -4569,21 +4819,17 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo)
 "Yp" = (
-/obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
-	dir = 4;
-	layer = 4
-	},
 /obj/structure/table,
 /obj/item/binoculars,
 /obj/machinery/button/door{
 	id = "teardrop_cargo";
-	pixel_x = -5;
-	pixel_y = 25
+	pixel_x = -2;
+	pixel_y = 23
 	},
 /obj/machinery/button/shieldwallgen{
 	id = "teardrop_holo";
-	pixel_x = 5;
-	pixel_y = 24
+	pixel_x = 9;
+	pixel_y = 21
 	},
 /obj/effect/turf_decal/borderfloorblack/corner,
 /obj/effect/turf_decal/techfloor{
@@ -4593,13 +4839,23 @@
 	pixel_y = 3;
 	pixel_x = -1
 	},
+/obj/effect/turf_decal/trimline/opaque/solgovgold/corner{
+	dir = 4;
+	layer = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/cargo)
 "Ys" = (
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -32;
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/west{
+	pixel_y = -7
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "YK" = (
@@ -4610,7 +4866,6 @@
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "YP" = (
-/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/trimline/opaque/blue/filled/line{
 	dir = 10
 	},
@@ -4635,12 +4890,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "YV" = (
-/obj/machinery/button/door{
-	id = "teardrop_eng";
-	name = "Engine Shutters";
-	pixel_x = 31;
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 1;
 	layer = 2
@@ -4650,6 +4899,7 @@
 /obj/machinery/suit_storage_unit/inherit,
 /obj/item/tank/jetpack/oxygen/security,
 /obj/item/clothing/mask/gas/atmos,
+/obj/machinery/light/directional/east,
 /turf/open/floor/plasteel/patterned/brushed,
 /area/ship/engineering)
 "Za" = (
@@ -4658,22 +4908,22 @@
 	id = "teardrop_bridge";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine/hull/interior,
 /area/ship/bridge)
 "Zc" = (
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
-	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 8
 	},
 /obj/effect/turf_decal/trimline/transparent/deforestblue/filled/warning{
 	dir = 1;
 	color = "#eeac2e";
 	layer = 2
+	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 8
 	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
@@ -4698,7 +4948,10 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/machinery/light/colored/red/directional/south,
+/obj/machinery/light/colored/red/directional/south{
+	pixel_x = 0;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering)
 "Zx" = (
@@ -4733,12 +4986,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 8
-	},
-/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4747,15 +4994,19 @@
 	color = "#eeac2e";
 	layer = 2
 	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/plain/opaque/ntbluelight{
+	dir = 8
+	},
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "ZI" = (
 /obj/effect/turf_decal/corner/opaque/black/half{
 	dir = 1
 	},
-/obj/structure/sign/directions/medical{
-	pixel_y = -32
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/heavymetal/var4,
 /area/ship/hallway/central)
 "ZM" = (
@@ -4920,7 +5171,7 @@ fa
 fa
 fa
 fa
-oI
+yz
 HH
 MQ
 Vp
@@ -4934,7 +5185,7 @@ EU
 PH
 nl
 ot
-tK
+yz
 fa
 fa
 fa
@@ -4943,7 +5194,7 @@ fa
 fa
 fa
 fa
-dP
+oI
 yz
 DY
 IT
@@ -5087,7 +5338,7 @@ fa
 fa
 fa
 fa
-Fs
+It
 Ui
 iB
 It
@@ -5096,21 +5347,21 @@ lo
 ja
 Oj
 sG
-yW
+su
 ho
 sH
 xj
 yz
 VS
 Ls
-Vo
+yz
 fa
 fa
 "}
 (15,1,1) = {"
 fa
 fa
-dP
+yW
 It
 Ix
 bf
@@ -5134,7 +5385,7 @@ fa
 (16,1,1) = {"
 fa
 fa
-dP
+tK
 It
 cM
 Fx
@@ -5158,7 +5409,7 @@ fa
 (17,1,1) = {"
 fa
 fa
-dP
+NW
 It
 FL
 vG
@@ -5176,7 +5427,7 @@ aO
 aO
 aO
 aO
-dP
+Vo
 fa
 "}
 (18,1,1) = {"
@@ -5481,7 +5732,7 @@ Ww
 yr
 Bw
 mc
-oU
+ar
 wD
 QC
 xH
@@ -5523,7 +5774,7 @@ fa
 fa
 fa
 fa
-NW
+Ke
 vY
 ma
 yZ
@@ -5531,7 +5782,7 @@ Rv
 ve
 CS
 vY
-NW
+Ke
 fa
 fa
 fa
@@ -5547,7 +5798,7 @@ fa
 fa
 fa
 fa
-NW
+Ke
 fI
 ZG
 gB
@@ -5555,7 +5806,7 @@ Kn
 jd
 lg
 fI
-NW
+Ke
 fa
 fa
 fa
@@ -5595,7 +5846,7 @@ fa
 fa
 fa
 fa
-NW
+Ke
 Lz
 ts
 ii
@@ -5619,7 +5870,7 @@ fa
 fa
 fa
 fa
-NW
+Ke
 yp
 QV
 jh


### PR DESCRIPTION
## Описание / Что этот PR делает
Маленько ребалансит корабль + фиксит недочеты. Всё ещё не превращает тирдроп в замечательный шип, но он теперь стал сносным. По факту хочется либо его ремаппнуть, либо заменить, либо дать Гарфилду шишку.

Фиксит пару ошибок, маленько редекалит, заменяет 1 иот на ВТ.
Убирает де факто дебаг индусер и заменяет его на обычный.
Фиксит возможность нюка всех последующих кораблей после спавна тир дропа.
Фиксит зоны, не позволяя больше кораблю нюкнуть зонами корабль, если на то вдруг получится.
Фиксит проводку для 1 АПЦ в коридоре.
Немного меняет вары доку.
Маленький редекалинг корабля.
Добавил кофемашину. Помогает от альцгеймера, вы слышали?
Добавил файрлоки в инженерку ещё.
Всё ещё не фиксит кстати оффсеты для корабля, из-за чего некоторые субы могут аннигилироваться об край карты лол. БОЙТЕСЬ К НЕМУ СТЫКОВАТЬСЯ.
Фиксит ему доступы на шлюзах. Теперь нельзя никому кроме экипажа приходить сквозь двери в карго.

## Причина создания ПР / Почему это хорошо для игры
Попросили.

## Демонстрация изменений / Тестирование

Тестил? Нет. Мне лень компилить локалку 20 минут, ибо мне пришлось её полностью перекачивать. Извините.

<details><summary>скрин SDMM</summary>

<img width="1344" height="704" alt="image" src="https://github.com/user-attachments/assets/e647e883-7e50-4e31-9646-62005e46cbb9" />

</details>

## Список изменений

```yml
🆑
map: Tearpdrop: 1 iot --> WT550, redecaling, zone fix, size fixes, docking fixes and etc. This ship still requires a proper rework.

/🆑
```
