### PR TITLE
MAP: Whitesand ruins

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_nomads_stop.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_nomads_stop.dmm
@@ -1,0 +1,8293 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"al" = (
+/obj/effect/turf_decal/road/edge{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"am" = (
+/obj/machinery/computer/mech_bay_power_console/retro{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ao" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"at" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"aB" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/spawner/random/waste/atmos_can,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"aC" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"aE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aH" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"aJ" = (
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aU" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ba" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bc" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/food)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"bm" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/tesla_rifle{
+	wander = 0
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bq" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bw" = (
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bF" = (
+/obj/machinery/modular_computer/console/preset/command{
+	icon_state = "computer-right"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"bM" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"cb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/conveyor_switch/oneway{
+	pixel_y = 17;
+	pixel_x = 9;
+	id = "twohickey"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"cf" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"cl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ct" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"cw" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"cA" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cC" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/rack,
+/obj/item/pushbroom,
+/obj/item/bodybag{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"cF" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cX" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/ruin/whitesands/nomad_stop/food)
+"cY" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"db" = (
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"dh" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"dj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 31
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"dy" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w5";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"dz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/smes/engineering{
+	input_level = 10000
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dA" = (
+/obj/machinery/door/poddoor{
+	id = "g1"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"dC" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"dF" = (
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dP" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dQ" = (
+/turf/closed/wall/concrete,
+/area/ruin/whitesands/nomad_stop/engineering)
+"dV" = (
+/turf/closed/wall/concrete,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ei" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_y = -9;
+	pixel_x = -23;
+	id = "g2";
+	name = "gate control";
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = 16
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_x = -22;
+	id = "s2";
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ej" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ek" = (
+/obj/structure/table,
+/obj/machinery/newscaster/directional/north,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 6;
+	pixel_x = 11
+	},
+/obj/item/food/kebab/miras{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"el" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ev" = (
+/obj/effect/turf_decal/road/edge{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ew" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"eA" = (
+/obj/machinery/power/shuttle/engine/turbine{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"eB" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/ruin/whitesands/nomad_stop/engineering)
+"eH" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eI" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eV" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_y = 11;
+	pixel_x = 19
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"eZ" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"fc" = (
+/obj/machinery/power/terminal,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fe" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fj" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fr" = (
+/obj/structure/chair/sofa/olive/old/corner/directional/east,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"fs" = (
+/obj/effect/turf_decal/road/edge{
+	dir = 8
+	},
+/obj/effect/turf_decal/road/edge{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ft" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fx" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"fC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"fQ" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"fR" = (
+/obj/structure/flora/ash/stem_shroom,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fU" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fX" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fY" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/laundry)
+"ge" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"gk" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"go" = (
+/obj/structure/platform/industrial_alt/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gy" = (
+/obj/structure/flora/ash/fern,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gH" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gL" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gU" = (
+/obj/structure/platform/wood,
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"gV" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gW" = (
+/obj/structure/closet/wall/red/directional/east,
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/item/crowbar/red{
+	pixel_y = -8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"gY" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"hb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hh" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/whitesand/lit{
+	dir = 8
+	},
+/area/ruin/whitesands/nomad_stop)
+"hj" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/dresser,
+/obj/machinery/airalarm/directional/east,
+/obj/item/pinpointer/mineral{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/stack/sheet/mineral/diamond{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"hm" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w4"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"hp" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/rack,
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"hq" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ht" = (
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hx" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"hD" = (
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hG" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"hJ" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hL" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/dresser,
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 8;
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 14;
+	pixel_x = 12
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/item/pda/shaftminer{
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"hX" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"ib" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ie" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"if" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/curtain,
+/obj/effect/turf_decal/steeldecal/steel_decals9,
+/obj/effect/turf_decal/steeldecal/steel_decals9{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/laundry)
+"ig" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/item/folder/documents{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/folder/red{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/folder/red{
+	pixel_x = -1;
+	pixel_y = -6
+	},
+/obj/item/folder{
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 5
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige/corner{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ih" = (
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"im" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"is" = (
+/turf/open/floor/plasteel/stairs/whitesand/lit{
+	dir = 1
+	},
+/area/ruin/whitesands/nomad_stop)
+"iu" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"iD" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"iN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"iO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/machinery/button/ignition{
+	id = "i1";
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -11
+	},
+/obj/machinery/button/door{
+	pixel_y = -2;
+	pixel_x = -22;
+	dir = 4;
+	id = "w5";
+	name = "window shutter control"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"iV" = (
+/obj/structure/flora/ash/leaf_shroom,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iX" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"ji" = (
+/obj/structure/platform/industrial_alt{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jk" = (
+/obj/item/stack/sheet/mineral/sandbags{
+	amount = 10
+	},
+/obj/structure/closet/crate/secure/gear,
+/obj/item/storage/box/emptysandbags{
+	pixel_x = -5
+	},
+/obj/item/storage/box/emptysandbags{
+	pixel_x = 8
+	},
+/obj/item/shovel,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"jo" = (
+/obj/machinery/conveyor{
+	id = "doohickey";
+	dir = 6
+	},
+/obj/structure/railing/thin{
+	dir = 5
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"jp" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"js" = (
+/obj/structure/table,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 8
+	},
+/obj/item/paper/crumpled{
+	icon_state = "scrap_mud";
+	default_raw_text = "Under the floor. 28-69-1"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"jB" = (
+/obj/effect/turf_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/laundry)
+"jE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"jT" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"jX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"kc" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/quarters)
+"ke" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/obj/structure/closet/crate/bin{
+	pixel_x = -6;
+	pixel_y = 13;
+	allow_dense = 0;
+	dense_when_open = 0;
+	density = 0
+	},
+/obj/machinery/button/door{
+	pixel_y = 22;
+	pixel_x = 8;
+	id = "w1";
+	name = "window shutter control"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"kg" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"ki" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/solarpanel_small,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kk" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"kp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = -16;
+	dir = 1
+	},
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"ku" = (
+/obj/structure/flora/tree/dead/barren,
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kH" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/engineering)
+"kJ" = (
+/turf/closed/mineral/random/whitesands,
+/area/overmap_encounter/planetoid/cave/explored)
+"kM" = (
+/obj/structure/table,
+/obj/item/card/data/disk{
+	pixel_y = 5;
+	pixel_x = -4;
+	name = "data card - 'Busty Xenofauna Babes 3D Extreme'"
+	},
+/obj/item/card/data/disk{
+	pixel_y = -2;
+	pixel_x = 5;
+	name = "data card - 'CLIP Command'"
+	},
+/obj/item/card/data/disk{
+	pixel_y = 10;
+	pixel_x = 5;
+	name = "data card - 'Blueflame Battle Royale'"
+	},
+/obj/item/card/data/disk{
+	pixel_x = -5;
+	pixel_y = -5;
+	name = "data card - 'Vanguard's Special Assignment'"
+	},
+/obj/item/card/data/disk{
+	pixel_y = 2;
+	name = "data card - 'Elzousa Simulator 499 FSC'"
+	},
+/obj/item/card/data/disk{
+	pixel_x = 1;
+	pixel_y = -4;
+	name = "data card = 'Orbital Defense Platform Operator'"
+	},
+/obj/item/card/data/disk{
+	pixel_y = 6;
+	pixel_x = -3;
+	name = "data card - 'RILENA: Lenelasa Me Refi!!'"
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"kN" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kP" = (
+/obj/effect/turf_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"lb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/igniter{
+	id = "i2"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"ld" = (
+/obj/machinery/conveyor{
+	id = "twohickey";
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"lh" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w4";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/laundry)
+"lj" = (
+/obj/structure/platform/industrial_alt{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lk" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ln" = (
+/obj/structure/flora/ash/stem_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ly" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"lC" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lL" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"lM" = (
+/obj/structure/table,
+/obj/item/food/icecreamsandwich{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"mc" = (
+/obj/effect/turf_decal/road,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mi" = (
+/obj/effect/turf_decal/road/edge{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mj" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w1"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"mq" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 19;
+	pixel_x = 11
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = -29
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/quarters)
+"mr" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/cutting_board,
+/obj/item/melee/knife/butcher,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"mt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"mu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"mx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"mA" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"mC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"mG" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mQ" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"mV" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"mX" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nj" = (
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"nl" = (
+/obj/machinery/door/poddoor{
+	id = "g2";
+	dir = 8
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "s2";
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"nq" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"nD" = (
+/obj/structure/chair/sofa/olive/old/corner/directional/north,
+/obj/machinery/button/door{
+	pixel_y = -22;
+	pixel_x = -10;
+	dir = 1;
+	id = "w5";
+	name = "window shutter control"
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"nL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/laundry)
+"nM" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"nN" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"nP" = (
+/obj/machinery/conveyor{
+	id = "twohickey"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 8
+	},
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma{
+	pixel_x = 4
+	},
+/obj/item/shard/plasma{
+	pixel_y = -6;
+	pixel_x = 2
+	},
+/obj/item/shard/plasma{
+	pixel_y = 5;
+	pixel_x = -1
+	},
+/obj/item/shard/plasma{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/shard/plasma{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"nX" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ob" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/directional/south,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/materials,
+/obj/effect/spawner/random/materials,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"op" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"os" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oE" = (
+/obj/machinery/computer/turbine_computer{
+	icon_state = "computer-left";
+	id = "kill_me"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"oF" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oG" = (
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oP" = (
+/obj/effect/turf_decal/road{
+	dir = 10
+	},
+/obj/effect/turf_decal/road{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oU" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/head/hardhat/frontier{
+	pixel_x = -8
+	},
+/obj/item/clothing/head/hardhat/frontier{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/gas/frontiersmen{
+	pixel_x = 10
+	},
+/obj/item/clothing/mask/gas/frontiersmen{
+	pixel_x = 5
+	},
+/obj/item/clothing/under/frontiersmen/deckhand{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/clothing/under/frontiersmen/deckhand{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oW" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/item/folder/red{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/folder/red{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"oZ" = (
+/obj/machinery/door/poddoor{
+	id = "g1"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "s1"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"pb" = (
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/obj/effect/turf_decal/industrial/warning/corner,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pj" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"pn" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ps" = (
+/obj/structure/table,
+/obj/item/food/jellysandwich/cherry{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"pG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/engineering)
+"pH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pJ" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/food)
+"pM" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pP" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"pT" = (
+/obj/structure/closet/wall/red/directional/east,
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/item/crowbar/red{
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"qa" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/sink/chem{
+	name = "kitchen sink";
+	dir = 4;
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/structure/sign/poster/clip/maxin{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"qk" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w6";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"qn" = (
+/obj/machinery/conveyor{
+	id = "doohickey";
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"qt" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qO" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ra" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "s2"
+	},
+/obj/machinery/door/poddoor{
+	id = "g2";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"rg" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ri" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"rx" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w2";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"rA" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"rF" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w4";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"rI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"rK" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"rS" = (
+/mob/living/simple_animal/hostile/human/hermit/survivor,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"si" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sj" = (
+/obj/effect/turf_decal/road{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sR" = (
+/obj/machinery/conveyor{
+	id = "doohickey";
+	dir = 10
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"sS" = (
+/obj/effect/anomaly/plasmasoul/planetary{
+	effectrange = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"sW" = (
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = 10;
+	density = 0
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"sY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"tb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"tc" = (
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/turf_decal/box,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"tg" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/obj/item/trash/chips,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/mob/living/basic/cockroach,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ti" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = -3
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"tm" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/food)
+"tt" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"tz" = (
+/obj/structure/tank_dispenser/oxygen{
+	pixel_y = 16;
+	density = 0
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"tA" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/overmap_encounter/planetoid/sand/explored)
+"tL" = (
+/obj/structure/flora/ash/cacti,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tP" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"tS" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/ruin/whitesands/nomad_stop/laundry)
+"tX" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/rations,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"ul" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"ut" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w5";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"uy" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/laundry)
+"uF" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 1;
+	pixel_x = 6
+	},
+/obj/item/pen{
+	pixel_x = 7
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"uH" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop/engineering)
+"uI" = (
+/obj/machinery/modular_computer/console/preset/command,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"uQ" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uR" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/structure/sign/poster/rilena/tali{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"uS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"uX" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"uY" = (
+/obj/structure/filingcabinet/double{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"uZ" = (
+/obj/machinery/autolathe,
+/obj/machinery/light/small/directional/west,
+/obj/item/stack/sheet/glass/five,
+/obj/item/stack/sheet/metal/five{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"vk" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"vu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"vz" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vC" = (
+/obj/item/chainsaw{
+	pixel_y = -3
+	},
+/obj/structure/rack,
+/obj/item/clothing/head/welding{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/radio/headset/alt{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vE" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"vG" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vP" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/accessory/rilena_pin{
+	pixel_x = -8
+	},
+/obj/item/clothing/accessory/rilena_pin{
+	pixel_x = -6
+	},
+/obj/item/clothing/accessory/rilena_pin{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/rilenacup{
+	pixel_y = -5;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/food/drinks/rilenacup{
+	pixel_y = -5;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/rilenacup{
+	pixel_y = -5;
+	pixel_x = -4
+	},
+/obj/item/toy/plush/rilena{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/toy/plush/rilena{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/toy/plush/rilena{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/poster/random_rilena{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/toy/plush/sharai{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/obj/item/toy/plush/xader{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"vR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"wc" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"we" = (
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden,
+/obj/machinery/meter/atmos,
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"wj" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"wk" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/salvage/part/scanning,
+/obj/effect/spawner/random/salvage/part/scanning,
+/obj/effect/spawner/random/salvage/part/matter_bin,
+/obj/effect/spawner/random/salvage/part/matter_bin,
+/obj/effect/spawner/random/salvage/part/manipulator,
+/obj/effect/spawner/random/salvage/part/manipulator,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"wl" = (
+/obj/machinery/conveyor{
+	id = "twohickey";
+	dir = 4
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"wD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/chair/office,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"wH" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/e11,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"wK" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/sign/poster/clip/bard{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"wX" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"xc" = (
+/obj/mecha/working/ripley{
+	name = "\improper APLU MK-I 'Machine For Lifts'"
+	},
+/obj/effect/turf_decal/box,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"xj" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xn" = (
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop)
+"xr" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"xx" = (
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/ruin/whitesands/nomad_stop/warehouse)
+"xA" = (
+/obj/structure/flora/tree/dead/barren,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xL" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xO" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/quarters)
+"yc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"yo" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"yq" = (
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/waste/mechwreck,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yt" = (
+/obj/structure/chair/sofa/olive/old/left/directional/south,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"yz" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"yW" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"za" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/quarters)
+"zb" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zj" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zk" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/food/meat/steak/goliath,
+/obj/item/food/meat/steak/goliath,
+/obj/item/food/meat/steak/goliath,
+/obj/item/food/meat/steak/goliath,
+/obj/machinery/light/directional/west,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"zt" = (
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/food)
+"zx" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"zK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"zP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"zQ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"zR" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zY" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ae" = (
+/obj/effect/turf_decal/road,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ai" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Aj" = (
+/obj/effect/turf_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Am" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Aq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"As" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Av" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"AG" = (
+/obj/machinery/button/ignition{
+	id = "i2";
+	dir = 8;
+	pixel_x = 22;
+	pixel_y = -11
+	},
+/obj/machinery/button/door{
+	pixel_y = -2;
+	pixel_x = 23;
+	dir = 8;
+	id = "w6";
+	name = "window shutter control"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/computer/turbine_computer{
+	dir = 8;
+	pixel_x = 2;
+	id = "please"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"AQ" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"AT" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bb" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bc" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Bf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Bl" = (
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = 17;
+	pixel_y = 6
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"Bm" = (
+/turf/open/floor/plasteel/stairs/whitesand/lit{
+	dir = 8
+	},
+/area/ruin/whitesands/nomad_stop)
+"Bo" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w3"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"Bq" = (
+/obj/item/chainsaw,
+/obj/structure/rack,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bv" = (
+/obj/structure/platform/industrial_alt{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bw" = (
+/obj/structure/flora/tree/dead/barren,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bx" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop)
+"BK" = (
+/obj/effect/turf_decal/road{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"BP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/laundry)
+"BS" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cd" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"Ce" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Cj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Cl" = (
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Cp" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	dir = 4;
+	name = "Cargo Airlock"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Cv" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Db" = (
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Dl" = (
+/obj/effect/turf_decal/industrial/warning/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Do" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Dq" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"DG" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"DL" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/quarters)
+"DM" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 13;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/laundry)
+"DU" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"DZ" = (
+/obj/structure/railing{
+	max_integrity = 70;
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Eh" = (
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ev" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/tank_dispenser/oxygen{
+	pixel_y = 16;
+	density = 0
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Ex" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EB" = (
+/obj/structure/flora/ash/cap_shroom,
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EH" = (
+/obj/structure/platform/wood/corner,
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"EK" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ET" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"EV" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop)
+"Fj" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Fk" = (
+/obj/effect/anomaly/melter/planetary,
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fo" = (
+/obj/structure/platform/industrial_alt/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fr" = (
+/obj/structure/platform/industrial_alt/corner,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fx" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FM" = (
+/obj/structure/railing/thin,
+/obj/structure/closet/crate/trashcart,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"FP" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FT" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FV" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/sign/poster/retro/smile{
+	pixel_y = 30
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"FX" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Gj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gl" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Go" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Gp" = (
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Gq" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/button/door{
+	pixel_y = 10;
+	pixel_x = -23;
+	dir = 4;
+	id = "w2";
+	name = "window shutter control"
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/desk_flag/elysium{
+	pixel_y = 15;
+	pixel_x = -5
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Gs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller/directional/south,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/food)
+"Gt" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/fax/ruin,
+/obj/structure/table,
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Gw" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/sign/poster/contraband/d_day_promo{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/quarters)
+"GH" = (
+/obj/structure/platform/industrial_alt/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"GL" = (
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige/corner{
+	dir = 1
+	},
+/obj/item/folder/red{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/folder/red{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 7;
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"GS" = (
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"GT" = (
+/obj/structure/tank_dispenser/oxygen{
+	pixel_y = 16;
+	density = 0
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/garbage{
+	pixel_y = -12;
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"GW" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"Ha" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Hh" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/water/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Hn" = (
+/turf/template_noop,
+/area/template_noop)
+"Hp" = (
+/obj/machinery/conveyor_switch{
+	id = "doohickey";
+	pixel_y = -7;
+	pixel_x = -11
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Hv" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
+	dir = 1
+	},
+/obj/item/clothing/under/pants/tan,
+/obj/item/clothing/under/pants/tan,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Hw" = (
+/obj/machinery/power/compressor{
+	comp_id = "kill_me"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"HA" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HD" = (
+/obj/effect/turf_decal/road,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HG" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HK" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = -7;
+	pixel_x = -4
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = -4
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 17;
+	layer = 3.1;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 6;
+	pixel_x = 8;
+	layer = 3.2
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 12;
+	pixel_x = -2;
+	layer = 3.2
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"HM" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HO" = (
+/obj/machinery/power/smes/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HP" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"HQ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 8;
+	eject_range = 7;
+	name = "trash cannon"
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"HR" = (
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HX" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Ia" = (
+/obj/machinery/vending/boozeomat,
+/obj/structure/sign/warning/firingrange{
+	pixel_y = 30
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ij" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/food)
+"Iq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Iw" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"IA" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IB" = (
+/obj/structure/platform/industrial_alt,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IF" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"IH" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"IJ" = (
+/obj/structure/flora/ash/cap_shroom,
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IK" = (
+/obj/effect/turf_decal/road,
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IN" = (
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/dead/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IO" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"IY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IZ" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w5";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Jc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jg" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"Ji" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jw" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"JK" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"JR" = (
+/obj/structure/flora/rock,
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JT" = (
+/obj/effect/turf_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"JU" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Kg" = (
+/obj/machinery/power/compressor{
+	comp_id = "please"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Kh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/food)
+"Kn" = (
+/obj/machinery/power/terminal,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ko" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Kw" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Ky" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KB" = (
+/obj/structure/platform/industrial_alt,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KG" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/whitesands/nomad_stop/engineering)
+"KM" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/shotgun,
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"KO" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ld" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Lf" = (
+/obj/structure/platform/industrial_alt{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lg" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Li" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Lm" = (
+/turf/open/floor/plating/asteroid/snow/lit/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ln" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Lp" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"LI" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/neck/cloak/nanotrasen{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/clothing/gloves/color/captain/nt{
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -13;
+	pixel_x = -7
+	},
+/obj/item/clothing/under/nanotrasen/officer{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/nanotrasen/captain/parade{
+	pixel_x = 8
+	},
+/obj/item/clothing/head/caphat/parade{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/storage/belt/sabre{
+	pixel_x = -1
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LQ" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LR" = (
+/obj/structure/safe/floor{
+	tumblers = list(28, 69, 1)
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/beige,
+/obj/effect/turf_decal/spline/fancy/opaque/beige{
+	dir = 1
+	},
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/lighter{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/obj/item/clothing/under/shorts/jorts,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"LU" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LZ" = (
+/obj/structure/chair/plastic,
+/mob/living/simple_animal/hostile/human/hermit/ranged/tesla_rifle{
+	wander = 0
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop)
+"Mc" = (
+/obj/machinery/conveyor{
+	id = "twohickey"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Mm" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Mp" = (
+/turf/closed/wall/concrete,
+/area/ruin/whitesands/nomad_stop/food)
+"Mr" = (
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Mt" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Mx" = (
+/obj/structure/salvageable/computer{
+	name = "mostly broken computer";
+	desc = "It's barely clinging to life"
+	},
+/obj/structure/sign/poster/rilena/run{
+	pixel_y = 31;
+	pixel_x = -15
+	},
+/obj/structure/sign/poster/rilena/tali{
+	pixel_y = 4;
+	pixel_x = -29
+	},
+/obj/item/newspaper{
+	pixel_y = 9;
+	pixel_x = -6
+	},
+/obj/item/toy/plush/rilena{
+	pixel_y = -4;
+	pixel_x = 12
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"ME" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"MK" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ML" = (
+/obj/machinery/atmospherics/components/trinary/mixer/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"MS" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"MV" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"MW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Nc" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ne" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Nf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Ng" = (
+/obj/effect/decal/cleanable/food/flour,
+/mob/living/simple_animal/hostile/human/hermit/survivor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"Nh" = (
+/obj/structure/railing/thin,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Nm" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Nr" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Nt" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Nv" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/tesla_rifle,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"NJ" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/tesla_rifle{
+	wander = 0
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"NL" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"NM" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"NP" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"NQ" = (
+/obj/structure/closet/crate/secure/gear{
+	opened = 1;
+	anchored = 1
+	},
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/c46x30mm/tesla{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/c46x30mm/tesla{
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"NT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"NZ" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Ob" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Oc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Oj" = (
+/turf/open/floor/plasteel/stairs/whitesand/lit,
+/area/ruin/whitesands/nomad_stop)
+"Op" = (
+/obj/effect/turf_decal/techfloor/hole{
+	dir = 4
+	},
+/obj/machinery/computer/helm{
+	desc = "No way you're getting this thing off the ground.";
+	layer = 3.3;
+	name = "Locked Helm Console"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ou" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ow" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ON" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OQ" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/badstop{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/hypospray/medipen/badstop{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/hypospray/medipen/badstop{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/hypospray/medipen/combat_drug{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/hypospray/medipen/mammoth{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/hypospray/medipen/mammoth{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"OY" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Pi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Pp" = (
+/obj/effect/turf_decal/road{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"PF" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/structure/dresser,
+/obj/machinery/airalarm/directional/east,
+/obj/item/clothing/under/rank/cargo/miner/lavaland{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"PH" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"PI" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/ruin/whitesands/nomad_stop/food)
+"PJ" = (
+/obj/structure/table,
+/obj/item/gun/ballistic/automatic/pistol/challenger/no_mag,
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"PY" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Qe" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w6";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Qf" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Qj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Qm" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Qv" = (
+/obj/machinery/button/door{
+	pixel_y = -9;
+	pixel_x = 22;
+	dir = 8;
+	id = "w3";
+	name = "window shutter control"
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Qx" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"QB" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"QF" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"QT" = (
+/obj/structure/chair/sofa/olive/old/right/directional/north,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Rj" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Rn" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Rp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/igniter{
+	id = "i1"
+	},
+/obj/structure/sign/warning/nosmoking/burnt{
+	pixel_x = -24
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Rr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"RA" = (
+/obj/structure/flora/ash/cap_shroom,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4;
+	color = null
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RF" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"RX" = (
+/obj/structure/marker_beacon{
+	picked_color = "Cerulean"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sb" = (
+/obj/machinery/power/smes/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sc" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Sf" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 9
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Sh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Sn" = (
+/obj/machinery/conveyor{
+	id = "doohickey";
+	dir = 4
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Sp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Sq" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Su" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sw" = (
+/obj/structure/closet/crate/secure/gear,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/obj/item/food/energybar{
+	pixel_y = -2;
+	pixel_x = -3
+	},
+/obj/item/food/energybar{
+	pixel_x = -6
+	},
+/obj/item/food/energybar{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Sy" = (
+/obj/machinery/airalarm/directional/west,
+/obj/structure/rack,
+/obj/item/clothing/under/syndicate/gorlex{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/laundry)
+"SI" = (
+/obj/machinery/power/smes/engineering{
+	input_level = 10000
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SN" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SU" = (
+/obj/machinery/conveyor{
+	id = "doohickey"
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"SW" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SX" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SZ" = (
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "s1"
+	},
+/obj/machinery/door/poddoor{
+	id = "g1"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Te" = (
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Tf" = (
+/obj/structure/railing/thin{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Tl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 5
+	},
+/obj/item/clothing/under/syndicate/medic,
+/obj/item/clothing/under/syndicate/medic{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/suit/armor/vest/trauma{
+	pixel_y = -7;
+	pixel_x = 4
+	},
+/obj/item/storage/belt/medical/webbing/frontiersmen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Tm" = (
+/obj/effect/turf_decal/techfloor/hole{
+	dir = 4
+	},
+/obj/machinery/computer/helm{
+	desc = "No way you're getting this thing off the ground.";
+	layer = 3.3;
+	name = "Locked Helm Console"
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Tp" = (
+/turf/open/floor/carpet/nanoweave/beige,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Tt" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	id = "w3";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/food)
+"Tx" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ty" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Tz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TA" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"TX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Uh" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Us" = (
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"UC" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/bodypart/head/vox{
+	pixel_x = -7;
+	pixel_y = -11
+	},
+/obj/item/clothing/head/cowboy/sec/roumain/machinist{
+	pixel_x = -7;
+	pixel_y = 4;
+	layer = 3.71
+	},
+/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/drinks/breakawayflask/vintage/hearthwine{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = -1;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_y = -1;
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"UK" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/e11,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"UZ" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/whitesand/lit,
+/area/ruin/whitesands/nomad_stop)
+"Vb" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vf" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vj" = (
+/obj/structure/chair/sofa/olive/old/directional/east,
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Vk" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/small/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"Vl" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/food)
+"Vt" = (
+/obj/effect/turf_decal/atmos/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Vz" = (
+/obj/effect/turf_decal/road{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ruin/whitesands/nomad_stop/quarters)
+"VF" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wb" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"Wu" = (
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wy" = (
+/obj/structure/table,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/pizzabox/meat{
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"WA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"WE" = (
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/nomad_stop)
+"WF" = (
+/obj/machinery/conveyor{
+	id = "doohickey";
+	dir = 4
+	},
+/obj/structure/railing/thin{
+	dir = 10
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/nomad_stop/laundry)
+"WH" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WN" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/fulltile,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"WO" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"WP" = (
+/obj/machinery/button/door{
+	pixel_y = 9;
+	pixel_x = 22;
+	dir = 8;
+	id = "w4";
+	name = "window shutter control"
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Xj" = (
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xk" = (
+/obj/effect/turf_decal/atmos/nitrogen,
+/turf/open/floor/engine/n2,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Xl" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xz" = (
+/turf/closed/wall/concrete,
+/area/ruin/whitesands/nomad_stop)
+"XB" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 6;
+	pixel_x = -5
+	},
+/obj/item/pen{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_midori{
+	pixel_x = 12;
+	pixel_y = -3
+	},
+/obj/item/lighter{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/nomad_stop/engineering)
+"XD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/mining{
+	name = "Cargo Airlock"
+	},
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"XM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/whitesand{
+	dir = 4
+	},
+/area/ruin/whitesands/nomad_stop/laundry)
+"XN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"XS" = (
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/area/ruin/whitesands/nomad_stop/quarters)
+"XT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"XV" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"XX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yj" = (
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yk" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop)
+"Yo" = (
+/obj/structure/table,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/drinks/beer/light{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yp" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/concrete/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yt" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yw" = (
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yz" = (
+/obj/effect/turf_decal/road{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating/rust/plasma,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Ze" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/obj/machinery/door/window/southright,
+/obj/structure/sign/warning/incident{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/whitesands/nomad_stop/engineering)
+"Zk" = (
+/obj/structure/table,
+/obj/item/food/reti{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/turf/open/floor/carpet,
+/area/ruin/whitesands/nomad_stop/food)
+"Zt" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/whitesands/nomad_stop/food)
+"Zw" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
+	dir = 1
+	},
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"Zy" = (
+/obj/machinery/door/poddoor{
+	id = "g2";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ZC" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
+	dir = 1
+	},
+/obj/item/clothing/under/pants/blackjeans,
+/obj/item/clothing/under/pants/blackjeans,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/structure/sign/poster/contraband/space_cops{
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/quarters)
+"ZF" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/whitesands/nomad_stop/engineering)
+"ZH" = (
+/obj/machinery/button/door{
+	pixel_y = 22;
+	pixel_x = 8;
+	id = "g1";
+	name = "gate control"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_y = 21;
+	pixel_x = -1;
+	id = "s1"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/whitesands/lit,
+/area/ruin/whitesands/nomad_stop/warehouse)
+"ZQ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/ruin/whitesands/nomad_stop/engineering)
+"ZS" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/box,
+/obj/structure/closet/crate,
+/obj/item/seeds/coffee{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/seeds/coffee{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/circuitboard/machine/coffeemaker/premium{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/glass/coffeepot{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/storage/fancy/coffee_condi_display{
+	pixel_y = -3;
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZT" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+
+(1,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(2,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+Eh
+Eh
+Eh
+Eh
+Eh
+KO
+Eh
+Eh
+Eh
+Eh
+Eh
+KO
+KO
+KO
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+Hn
+KO
+KO
+KO
+aJ
+Ji
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(3,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+Yj
+Yw
+Yw
+AT
+aJ
+KO
+aJ
+Ji
+KO
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(4,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+KO
+KO
+rg
+Us
+KO
+KO
+ib
+aJ
+Ji
+Yw
+KO
+Yj
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(5,1,1) = {"
+Hn
+Hn
+Hn
+kJ
+kJ
+kJ
+KO
+Eh
+Eh
+Eh
+Eh
+Eh
+Fk
+Eh
+Eh
+Eh
+Eh
+Eh
+Fk
+Eh
+Eh
+Eh
+Eh
+gU
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+KO
+KO
+KO
+AT
+aJ
+ib
+aJ
+Ji
+Yw
+Yw
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(6,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+EH
+mQ
+IN
+Cp
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Yw
+Yw
+Nm
+aJ
+ib
+aJ
+cA
+KO
+KO
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(7,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+Eh
+EH
+Hh
+mQ
+Tf
+oG
+Cp
+Cp
+Ha
+Ha
+gy
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Yw
+Nm
+aJ
+ib
+aJ
+cA
+Yw
+Yw
+rg
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(8,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hh
+Hh
+ge
+Eh
+Eh
+EH
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+mQ
+Tf
+ZT
+ih
+Yw
+Yw
+Cp
+Cp
+Bw
+Ha
+Ha
+kJ
+kJ
+kJ
+kJ
+kJ
+Yw
+Nm
+aJ
+ib
+aJ
+cA
+Yw
+Yw
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+"}
+(9,1,1) = {"
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Yw
+Yw
+aH
+Hh
+Hh
+mQ
+Mp
+Mp
+Mp
+Mp
+Tt
+Tt
+dy
+PI
+ih
+PI
+rx
+rx
+PI
+PI
+Cp
+Ha
+Ha
+Ha
+kJ
+kJ
+kJ
+kJ
+kJ
+JU
+cY
+aJ
+ib
+aJ
+Su
+JU
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+"}
+(10,1,1) = {"
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Ko
+Ko
+lh
+lh
+Ko
+Nh
+HQ
+Mp
+Bl
+qa
+zs
+fr
+Vj
+nD
+cX
+PI
+cX
+kM
+uY
+Gq
+Mp
+Mp
+Ha
+Bw
+Ha
+gy
+kJ
+kJ
+kJ
+kJ
+bm
+hJ
+aJ
+ib
+aJ
+Su
+Te
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+"}
+(11,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+Ko
+yo
+Gp
+Hp
+FM
+Nh
+mC
+Mp
+Wy
+Ng
+Jw
+yt
+Zk
+QT
+Mt
+PI
+Mx
+hX
+MS
+wD
+uF
+Mp
+Ha
+Ha
+Ha
+kJ
+kJ
+kJ
+kJ
+kJ
+hb
+sz
+aJ
+si
+aJ
+gV
+Cp
+Cp
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+"}
+(12,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+Ko
+tc
+Gp
+Gp
+WF
+Nh
+jT
+Mp
+mr
+at
+Zt
+Bf
+Vr
+Go
+iX
+Ij
+nM
+nM
+jp
+Db
+kp
+Mp
+Yw
+Yw
+Ha
+kJ
+kJ
+kJ
+ht
+Yw
+Yw
+LQ
+aJ
+si
+XT
+gV
+Cp
+Cp
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+"}
+(13,1,1) = {"
+Hn
+kJ
+kJ
+Ko
+Ko
+Ko
+Ko
+Vk
+NM
+pP
+Sn
+Nh
+qn
+Mp
+wK
+iu
+fC
+Rr
+Rr
+nt
+Av
+PI
+GT
+Pi
+fx
+Cl
+hp
+Mp
+Yw
+Yw
+Ha
+kJ
+kJ
+kJ
+Ha
+Ha
+Ha
+LQ
+aJ
+si
+XT
+cA
+Cp
+Cp
+Cp
+Cp
+kJ
+kJ
+Hn
+Hn
+"}
+(14,1,1) = {"
+Hn
+kJ
+Ko
+tS
+Sy
+fY
+tS
+tS
+tS
+XM
+jo
+SU
+sR
+PI
+jE
+jE
+Mr
+UK
+jE
+jE
+cX
+Mp
+Mp
+gW
+HX
+RK
+cX
+Mp
+Yw
+Yw
+kJ
+kJ
+kJ
+kJ
+Ha
+Bw
+Ha
+LQ
+aJ
+ib
+aJ
+cA
+SN
+Cp
+Cp
+Te
+Nv
+JU
+Hn
+Hn
+"}
+(15,1,1) = {"
+kJ
+kJ
+Ko
+if
+NZ
+nL
+Li
+jB
+BP
+Jv
+vz
+os
+gL
+PI
+ek
+Sf
+WP
+Qv
+ps
+lM
+PI
+KO
+Mp
+Mp
+pJ
+tm
+PI
+QB
+Yw
+Yw
+Yw
+kJ
+kJ
+Ha
+Ha
+Ha
+Ha
+LQ
+aJ
+ib
+aJ
+uQ
+JR
+SX
+SX
+NP
+Am
+Am
+Hn
+Hn
+"}
+(16,1,1) = {"
+kJ
+kJ
+Ko
+tS
+uy
+DM
+tS
+tS
+tS
+aJ
+mG
+NL
+mX
+hm
+rF
+rF
+PI
+PI
+Tt
+Tt
+Bo
+KO
+KO
+PI
+bc
+Gs
+PI
+Yw
+VF
+KO
+KO
+KO
+Ha
+Bw
+Ha
+Ha
+Ha
+AT
+aJ
+ib
+aJ
+aJ
+aJ
+aJ
+XT
+XT
+aJ
+aJ
+aJ
+Hn
+"}
+(17,1,1) = {"
+Hn
+kJ
+kJ
+tS
+Ko
+Ko
+tS
+kJ
+kJ
+KO
+aJ
+dP
+mX
+Yw
+Yw
+Us
+Yw
+Yw
+Yw
+Us
+KO
+KO
+KO
+PI
+zw
+Kh
+PI
+xj
+Yw
+KO
+KO
+KO
+KO
+Ha
+Ha
+Ha
+pn
+IJ
+aJ
+fs
+Ae
+Ae
+Ae
+HD
+HD
+HD
+Ae
+Ae
+Hn
+Hn
+"}
+(18,1,1) = {"
+Hn
+kJ
+Lm
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+RX
+aJ
+dP
+RX
+Us
+Yw
+Yw
+VF
+Yw
+Yw
+KO
+KO
+KO
+Nm
+RX
+FT
+XX
+RX
+cA
+fe
+SX
+SX
+SX
+RF
+RF
+HM
+HM
+FX
+aJ
+aJ
+ib
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+Hn
+Hn
+aJ
+"}
+(19,1,1) = {"
+Hn
+Lm
+Lm
+Lm
+kJ
+kJ
+kJ
+kJ
+kJ
+Xz
+Bm
+hh
+Xz
+Xz
+Yw
+Yw
+Ha
+Ha
+Ha
+Ha
+KO
+HG
+AT
+aJ
+FT
+aJ
+aJ
+uQ
+yW
+aJ
+aJ
+aJ
+aJ
+XT
+aJ
+aJ
+aJ
+aJ
+ev
+Pp
+aJ
+hq
+zk
+fR
+zk
+Vf
+Vf
+Hn
+Hn
+Hn
+"}
+(20,1,1) = {"
+Hn
+Hn
+Lm
+Lm
+kJ
+kJ
+kJ
+Xz
+Xz
+Xz
+nj
+dh
+NQ
+Xz
+Xz
+RX
+HM
+HM
+fj
+Ha
+KO
+KO
+AT
+aJ
+FT
+XT
+XT
+XT
+aJ
+aJ
+aJ
+aJ
+XT
+aJ
+XT
+aJ
+ev
+BS
+Pp
+aJ
+ON
+Ne
+Ha
+Ha
+Yw
+xL
+JU
+Hn
+Hn
+Hn
+"}
+(21,1,1) = {"
+Hn
+Hn
+Hn
+Lm
+kJ
+Lm
+Lm
+Bv
+Yk
+LZ
+xn
+Qx
+yF
+yF
+Oj
+aJ
+aJ
+aJ
+ao
+KO
+KO
+pn
+FX
+aJ
+mi
+Vb
+TA
+Ob
+Ob
+Ob
+Ob
+Ob
+Ob
+TA
+TA
+Ob
+sj
+NL
+aJ
+ON
+Ne
+Ha
+Bw
+Ha
+Yw
+kJ
+kJ
+Hn
+Hn
+Hn
+"}
+(22,1,1) = {"
+Hn
+Hn
+Lm
+Lm
+Lm
+Lm
+Lm
+KB
+Yk
+xn
+xn
+Iw
+ET
+Cd
+UZ
+EK
+Bb
+XT
+rA
+RA
+pn
+FX
+aJ
+al
+BK
+aJ
+XT
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+XT
+XT
+QF
+aJ
+xA
+Ha
+Ha
+Ha
+Ha
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+"}
+(23,1,1) = {"
+Hn
+Hn
+Lm
+Lm
+Lm
+Lm
+Yw
+KB
+Xz
+Yk
+Yk
+Xz
+Xz
+Xz
+Xz
+RX
+QF
+XT
+aJ
+MV
+yW
+aJ
+aJ
+Fx
+aJ
+aJ
+hq
+zk
+zk
+zk
+zk
+zk
+zk
+Vl
+aJ
+aJ
+XT
+QF
+aJ
+Ji
+Ha
+Ha
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+"}
+(24,1,1) = {"
+Hn
+Lm
+Lm
+Lm
+Lm
+SX
+JR
+GH
+ji
+ji
+ji
+Fo
+SX
+SX
+yW
+aJ
+dP
+XT
+aJ
+aJ
+aJ
+al
+Vz
+BK
+aJ
+hq
+lk
+ht
+Yw
+Yw
+Yw
+Us
+Yw
+zY
+zk
+Vl
+XT
+QF
+aJ
+MV
+KO
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+kJ
+Hn
+"}
+(25,1,1) = {"
+Hn
+aJ
+Lm
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+dP
+XT
+XT
+aJ
+aJ
+Yz
+aJ
+aJ
+hq
+lk
+Yw
+Yw
+Yw
+SN
+Yw
+Yw
+Yw
+Yw
+Yw
+Nm
+aJ
+Tx
+EK
+eI
+Ld
+Ld
+XS
+Gw
+DL
+XS
+XS
+kJ
+kJ
+Hn
+"}
+(26,1,1) = {"
+Hn
+Lm
+Ae
+Lm
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+Ae
+IK
+mc
+mc
+mc
+mc
+oP
+aJ
+hq
+lk
+Op
+fc
+Sb
+FP
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+zY
+Vl
+aJ
+aJ
+bv
+za
+kP
+kc
+Kw
+mA
+Hv
+XS
+kJ
+kJ
+Hn
+"}
+(27,1,1) = {"
+Hn
+Lm
+Lm
+Lm
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+nX
+aJ
+Fr
+lj
+lj
+lj
+lj
+go
+aJ
+Yz
+aJ
+cA
+Yw
+hD
+Wu
+LI
+kN
+Yw
+Yw
+Op
+fc
+Sb
+FP
+Yw
+Nm
+aJ
+aJ
+pH
+Ld
+Ld
+XS
+hL
+hG
+XS
+XS
+kJ
+kJ
+kJ
+"}
+(28,1,1) = {"
+Hn
+Lm
+Lm
+JU
+JU
+Te
+Te
+kJ
+Xz
+Xz
+Xz
+ie
+ie
+ie
+IB
+Xz
+Yk
+Yk
+Xz
+Lf
+aJ
+Yz
+aJ
+cA
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+hD
+Xj
+tX
+ZS
+Yw
+zY
+Vl
+aJ
+IY
+aJ
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+kJ
+kJ
+"}
+(29,1,1) = {"
+Hn
+Hn
+Lm
+JU
+xL
+Te
+kJ
+kJ
+Xz
+qO
+KO
+KO
+eH
+ht
+KB
+Yk
+xn
+EV
+Yk
+HR
+aJ
+Yz
+aJ
+cA
+Yw
+Yw
+Yw
+QB
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Us
+Nm
+wH
+pM
+SW
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+"}
+(30,1,1) = {"
+Hn
+Hn
+Lm
+JU
+Te
+Te
+kJ
+kJ
+Xz
+KO
+KO
+ln
+KO
+Yw
+KB
+Yk
+xn
+xn
+Yk
+HR
+aJ
+Yz
+aJ
+cA
+Us
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+zY
+Vl
+sk
+aJ
+kJ
+kJ
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+"}
+(31,1,1) = {"
+Hn
+Hn
+Lm
+JU
+Yp
+kJ
+kJ
+Bx
+Bx
+HA
+nq
+KO
+qO
+Dl
+Xz
+Xz
+Jg
+GW
+Xz
+Xz
+aJ
+Yz
+aJ
+cA
+Yw
+Yw
+Yw
+Op
+fc
+Sb
+FP
+Yw
+Us
+Yw
+Tm
+Kn
+HO
+XV
+Nm
+sk
+aJ
+RX
+Ld
+Ld
+XS
+mq
+DL
+XS
+XS
+kJ
+"}
+(32,1,1) = {"
+Hn
+Hn
+Lm
+kJ
+kJ
+kJ
+kJ
+Bx
+vC
+bw
+Lg
+HA
+HA
+zb
+RX
+Xz
+nj
+nj
+Xz
+RX
+aJ
+Yz
+aJ
+cA
+Yw
+SN
+Yw
+hD
+Wu
+ki
+tX
+Yw
+Yw
+Yw
+hD
+Xj
+yq
+oU
+Nm
+qG
+Oc
+Oc
+VA
+JT
+Cv
+uX
+mA
+Zw
+XS
+kJ
+"}
+(33,1,1) = {"
+Hn
+Lm
+Lm
+kJ
+kJ
+kJ
+Bx
+Bx
+Bq
+rS
+XT
+XT
+lC
+XT
+XT
+is
+WE
+vu
+UZ
+EK
+EK
+Ex
+aJ
+uQ
+xj
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+Yw
+fe
+SX
+yW
+aE
+aJ
+RX
+Ld
+Ld
+XS
+hj
+vk
+XS
+XS
+kJ
+"}
+(34,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+Yw
+Yw
+Bx
+wj
+bw
+aJ
+XT
+XT
+XT
+XT
+is
+tZ
+dC
+Oj
+aJ
+aJ
+Yz
+aJ
+aJ
+cA
+Yw
+Yw
+bw
+bw
+bw
+Yw
+Yw
+Yw
+ht
+Yw
+fe
+yW
+Tz
+Iq
+ft
+aJ
+kJ
+kJ
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+"}
+(35,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+Yw
+Yw
+uH
+uH
+uH
+uH
+eB
+eB
+eB
+eB
+eB
+eB
+TX
+eB
+eB
+RX
+aJ
+Yz
+aJ
+aJ
+cA
+Yw
+pb
+IA
+cF
+IA
+zt
+Yw
+Yw
+Yw
+Yw
+Nm
+aJ
+aE
+aJ
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+"}
+(36,1,1) = {"
+kJ
+kJ
+kJ
+kJ
+Yw
+Yw
+eA
+Hw
+Rp
+Ln
+eB
+Rj
+ul
+cC
+eB
+Fj
+ew
+eB
+eB
+uH
+Yt
+Yz
+aJ
+aJ
+cA
+dV
+dV
+ra
+Zy
+nl
+dV
+dV
+dV
+dV
+dV
+iV
+aJ
+qy
+Ld
+Ld
+XS
+xO
+DL
+XS
+XS
+kJ
+kJ
+kJ
+kJ
+Hn
+"}
+(37,1,1) = {"
+kJ
+kJ
+kJ
+kJ
+KO
+uH
+uH
+uH
+IZ
+ut
+eB
+Ze
+lL
+iN
+eB
+eB
+kH
+uH
+Jc
+Jc
+WH
+Yz
+aJ
+aJ
+uQ
+dV
+ei
+Bc
+WO
+mV
+ob
+dV
+el
+Uh
+dV
+Nm
+aJ
+Gj
+As
+Aj
+kc
+Kw
+mA
+ZC
+XS
+kJ
+kJ
+Hn
+Hn
+Hn
+"}
+(38,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+KO
+uH
+uZ
+iO
+vE
+ZF
+eB
+rI
+Ce
+sY
+NT
+Aq
+PH
+uH
+LU
+SI
+WH
+Yz
+aJ
+aJ
+pb
+dV
+ZH
+TC
+MW
+cl
+wk
+dV
+Sw
+vP
+dV
+dV
+dV
+dV
+Ld
+Ld
+XS
+PF
+vk
+XS
+XS
+kJ
+Hn
+Hn
+Hn
+Hn
+"}
+(39,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+Yw
+uH
+XB
+db
+gk
+wX
+pG
+Hf
+ML
+tb
+yc
+Sh
+ct
+WN
+vG
+Jc
+WH
+Yz
+aJ
+bw
+yz
+SZ
+HP
+TC
+nN
+aC
+aC
+rK
+jk
+Lp
+dV
+Qf
+tt
+dV
+kJ
+kJ
+XS
+XS
+XS
+XS
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+"}
+(40,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+Yw
+uH
+oE
+Nf
+Do
+zQ
+uH
+cb
+nP
+tP
+eB
+Ev
+bM
+uH
+qt
+dz
+WH
+Yz
+aJ
+bw
+zj
+dA
+kk
+oa
+eZ
+zI
+vR
+Tl
+Hm
+XN
+XD
+OQ
+UC
+dV
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(41,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+Yw
+uH
+bF
+jX
+Sc
+Sq
+uH
+mu
+uS
+zK
+eB
+kg
+we
+uH
+Xl
+Jc
+WH
+Yz
+aJ
+bw
+yz
+oZ
+HP
+AQ
+DZ
+xx
+Dq
+im
+aB
+Ai
+dV
+uR
+tt
+dV
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(42,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+KO
+tA
+uH
+AG
+Nt
+OY
+uH
+Qj
+Mc
+wl
+eB
+Nr
+fQ
+KG
+KG
+KG
+Gl
+Yz
+aJ
+aJ
+dF
+ME
+JK
+aU
+gY
+xr
+xc
+ri
+dV
+Cq
+dV
+dV
+dV
+dV
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(43,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+KO
+KO
+uH
+uH
+Qe
+qk
+uH
+dj
+sS
+wl
+eB
+zP
+IO
+ZQ
+be
+KG
+aJ
+Yz
+aJ
+aJ
+bw
+ME
+ME
+ri
+tz
+Ow
+Rn
+ME
+FV
+op
+DU
+dV
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(44,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+KO
+KO
+eA
+Kg
+lb
+ly
+uH
+YS
+mx
+ld
+eB
+cw
+KG
+KG
+cw
+KG
+KG
+zR
+EK
+EK
+EK
+IH
+DG
+Wb
+IF
+MK
+am
+ME
+hx
+tg
+hx
+dV
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(45,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+KO
+KO
+eB
+eB
+eB
+eB
+uH
+uH
+eB
+Mm
+eB
+Cj
+Vt
+KG
+Ty
+Xk
+KG
+ib
+aJ
+aJ
+SW
+mt
+WA
+pj
+pT
+iD
+eV
+ME
+dV
+dV
+dV
+dV
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(46,1,1) = {"
+Hn
+Hn
+kJ
+kJ
+kJ
+KO
+uH
+Ia
+Qm
+dQ
+uH
+uH
+uH
+uH
+eB
+KG
+KG
+KG
+KG
+KG
+KG
+ib
+aJ
+aJ
+bw
+ME
+ME
+ri
+ME
+ej
+ME
+ME
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(47,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+uH
+PJ
+Yo
+dQ
+Yw
+Yw
+Yw
+QB
+Yw
+KG
+Yw
+Yw
+Yw
+Nm
+aJ
+ib
+aJ
+oF
+Nc
+KO
+ME
+ke
+Sp
+PY
+Gt
+ME
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(48,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+fX
+Yw
+Yw
+Yw
+Yw
+Cp
+Cp
+Yw
+Yw
+Yw
+Yw
+Yw
+EB
+aJ
+ib
+aJ
+Ji
+Yj
+KO
+mj
+sW
+KM
+Gg
+GS
+ME
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(49,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+fU
+fU
+Cp
+Cp
+Cp
+Yw
+Cp
+Yw
+ht
+Cp
+Cp
+Yw
+Nm
+aJ
+ib
+aJ
+Ji
+KO
+KO
+mj
+uI
+cf
+Tp
+LR
+ME
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(50,1,1) = {"
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+zx
+kJ
+Cp
+ku
+Cp
+Cp
+Cp
+Cp
+Cp
+Cp
+Yw
+ln
+AT
+aJ
+ib
+aJ
+tL
+KO
+KO
+mj
+ti
+Tp
+bq
+oW
+ME
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(51,1,1) = {"
+Hn
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Cp
+Cp
+Cp
+Cp
+Cp
+Cp
+Cp
+ku
+Cp
+KO
+AT
+aJ
+ib
+aJ
+Ji
+KO
+Yj
+ME
+ig
+HK
+js
+GL
+dV
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(52,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+Cp
+Cp
+Cp
+Cp
+Cp
+Te
+kJ
+Cp
+Cp
+Te
+gH
+aJ
+ib
+aJ
+wc
+Ky
+KO
+ME
+ME
+dV
+dV
+dV
+dV
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(53,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+kJ
+kJ
+kJ
+kJ
+kJ
+Cp
+Cp
+Te
+Te
+kJ
+kJ
+Ou
+NJ
+cY
+aJ
+ib
+aJ
+Su
+ba
+Te
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(54,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+kJ
+kJ
+JU
+Te
+Te
+Te
+kJ
+kJ
+kJ
+JU
+JU
+cY
+aJ
+ib
+aJ
+Su
+JU
+JU
+kJ
+kJ
+kJ
+KO
+kJ
+kJ
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(55,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+JU
+xL
+Te
+JU
+kJ
+KO
+kJ
+KO
+KO
+AT
+aJ
+ib
+aJ
+Ji
+KO
+KO
+KO
+KO
+KO
+KO
+kJ
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(56,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+JU
+JU
+JU
+JU
+KO
+KO
+KO
+KO
+KO
+AT
+aJ
+ib
+aJ
+Ji
+KO
+KO
+KO
+KO
+Hn
+Hn
+Hn
+kJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(57,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+KO
+Hn
+KO
+AT
+aJ
+ib
+aJ
+Ji
+KO
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(58,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+KO
+KO
+KO
+KO
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+ib
+aJ
+Ji
+KO
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(59,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+aJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}
+(60,1,1) = {"
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+aJ
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+Hn
+"}

--- a/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_settlement_raid.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SandRuins/whitesands_surface_settlement_raid.dmm
@@ -1,0 +1,17451 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ac" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ad" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ae" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/platform/corner,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ag" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"am" = (
+/obj/structure/flippedtable,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"an" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib4";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"ap" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"at" = (
+/turf/open/floor/plasteel/stairs/wood/maple/left,
+/area/ruin/whitesands/settlement/butcher)
+"au" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/item/clothing/suit/hooded/survivor/jermit{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/hooded/survivor/yellow{
+	pixel_x = -3;
+	pixel_y = 17
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -13;
+	pixel_y = -2
+	},
+/obj/item/rack_parts{
+	layer = 2.9
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"aw" = (
+/obj/machinery/button/door{
+	pixel_x = 0;
+	pixel_y = 24;
+	id = "bossdoor"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"az" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/bamboo{
+	dir = 1
+	},
+/area/ruin/whitesands/settlement)
+"aC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"aG" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/caution{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"aI" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"aJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"aO" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"aP" = (
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aT" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"aX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"aZ" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/flora/tree/tall/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bg" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"bh" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/turf/template_noop,
+/area/ruin/whitesands/settlement/greenhouse)
+"bj" = (
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "tantoruindoors2"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"bm" = (
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bq" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/internals,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bs" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/settlement/shuttle_two)
+"bt" = (
+/obj/structure/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"by" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement)
+"bz" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bC" = (
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"bE" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"bF" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"bH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"bI" = (
+/obj/structure/dresser,
+/obj/item/storage/pill_bottle/stardrop{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"bJ" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"bN" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"bS" = (
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"bW" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "polengine";
+	name = "Engine Shutters"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"cd" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/effect/abstract/turf_fire/magical,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cg" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hydroponics/wooden,
+/obj/item/food/grown/moonflower{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"cl" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cn" = (
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"co" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"cs" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"ct" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cw" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#332521"
+	},
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"cx" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"cz" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null;
+	anchored = 1
+	},
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/a762_40,
+/obj/item/storage/box/ammo/a762_40,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"cA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"cB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"cD" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/traffic,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"cF" = (
+/obj/machinery/autolathe,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"cG" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"cK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"cL" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"cO" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"cQ" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"cR" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/flora/ash/tall_shroom,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"cT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"cU" = (
+/obj/structure/rack{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf,
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/pen)
+"cW" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 6;
+	pixel_y = -11
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"cY" = (
+/obj/structure/barricade/sandbags,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"db" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dh" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dk" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/flippedtable,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"do" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"dt" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"du" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"dv" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/rack,
+/obj/item/ammo_box/a762_stripper/empty,
+/obj/item/ammo_box/a762_stripper/empty{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/ammo_box/a762_stripper/empty{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/ammo_box/a762_stripper/empty{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"dw" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/gun/ballistic/rifle/polymer,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dx" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"dz" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"dB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/maple{
+	dir = 1
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"dD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"dE" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"dG" = (
+/obj/structure/flora/ash/tall_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/doctor)
+"dO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"dP" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/chair/plastic,
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"dR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dT" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/structure/flora/ash/tall_shroom,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"dV" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman/super/not_very,
+/turf/open/floor/concrete,
+/area/ruin/whitesands/settlement/blackmarket)
+"dW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"ec" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/clothing/mask/gas{
+	pixel_x = -13;
+	pixel_y = -15
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"eg" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ej" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"ek" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"en" = (
+/obj/structure/flippedtable,
+/mob/living/simple_animal/hostile/human/hermit/ranged/tesla_rifle,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ep" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"et" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -21;
+	pixel_y = -13
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"ev" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_one)
+"eA" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"eD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/traffic,
+/obj/structure/salvageable/computer{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"eE" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/clothing/shoes/workboots/mining,
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/obj/item/spacecash/bundle/smallrand{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"eI" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"eM" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/frame,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"eN" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"eQ" = (
+/obj/structure/platform/wood,
+/obj/structure/railing/thin,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"eT" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/brawler,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"eU" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"fa" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"fj" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/doctor)
+"fk" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/internals,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"fn" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"fv" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fA" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"fG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"fH" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"fI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"fN" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals{
+	weapon_drop_chance = 100
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"fO" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fQ" = (
+/obj/item/chair/plastic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"fR" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"fT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"fW" = (
+/mob/living/basic/hivebot/core/frontier,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"fY" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"fZ" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"ga" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"gh" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"gi" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/directional/east,
+/obj/machinery/light_switch{
+	pixel_y = 22
+	},
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"gj" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gk" = (
+/obj/structure/crate_shelf,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"gl" = (
+/obj/structure/fence,
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gn" = (
+/obj/structure/flora/ash/fern,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gp" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"gz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"gC" = (
+/obj/structure/barricade/sandbags,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gD" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gI" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"gJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"gK" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/flora/ash/tall_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gL" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/wideband/table{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"gO" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1
+	},
+/obj/machinery/light/dim/directional/north,
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/workboots/mining,
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -2;
+	pixel_y = -7
+	},
+/obj/item/spacecash/bundle/smallrand{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"gP" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"gQ" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/rack,
+/obj/item/gun_maint_kit,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"gR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"gT" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"gU" = (
+/obj/structure/railing/thin/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"gW" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"gY" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"gZ" = (
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/wood/maple/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"hi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hl" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/crowbar{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"ho" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"hr" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ht" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"hw" = (
+/obj/structure/chair/wood/wings,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"hy" = (
+/obj/structure/platform/wood,
+/obj/structure/railing/thin,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/butcher)
+"hz" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bossdoor"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"hA" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/blackmarket)
+"hC" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"hD" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -13;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"hG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"hH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"hJ" = (
+/obj/structure/rack,
+/obj/item/ammo_box/a762_stripper{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/a762_stripper{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"hK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/greenhouse)
+"hL" = (
+/obj/structure/railing/thin/corner,
+/obj/item/grown/log/tree{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 15;
+	pixel_y = 1
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 14;
+	pixel_y = 5
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"hP" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/guardshouse)
+"hQ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hR" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"hT" = (
+/obj/item/grown/log/tree{
+	pixel_x = 14;
+	pixel_y = -2
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"hV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"hW" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 13;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger{
+	wander = 0
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"hY" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_x = -8;
+	pixel_y = 14
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"ia" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"ic" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ie" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"if" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ig" = (
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ij" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ik" = (
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"in" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"io" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"ir" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"is" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iu" = (
+/obj/structure/chair/office,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"iw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"iA" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"iB" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iF" = (
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/butcher)
+"iJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"iL" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor/brawler{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"iP" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"iQ" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"iR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/item/bedsheet{
+	pixel_x = -3;
+	pixel_y = 17
+	},
+/obj/item/bedsheet{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/bedsheet{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"iT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/shard,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"iX" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"je" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -11;
+	pixel_y = 9
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/food/cracker{
+	name = "hardtack";
+	desc = "Clack-clack.";
+	pixel_x = -11;
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"jj" = (
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"jn" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"jr" = (
+/obj/item/radio/headset{
+	pixel_x = -16;
+	pixel_y = -1
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"js" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#D2BC9D"
+	},
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/roboticist)
+"jt" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"ju" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/internals,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"jv" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"jw" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 2
+	},
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"jx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jz" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jB" = (
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/ruin/whitesands/settlement/butcher)
+"jC" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jD" = (
+/obj/structure/fireplace{
+	dir = 8;
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/obj/item/throwing_star/magspear{
+	name = "fire poker";
+	desc = "A small metal rod used to stir up fireplaces. This one is adorned with ornate golden filigree";
+	pixel_x = -15;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"jE" = (
+/obj/item/food/grown/wheat{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -1;
+	pixel_y = -4
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -12;
+	pixel_y = -3
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 12;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 1;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -14;
+	pixel_y = 10
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"jH" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "polengine"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"jJ" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/clothing/mask/gas/syndicate,
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"jK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"jO" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"jQ" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"jR" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"jT" = (
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"jU" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ka" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"kh" = (
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ki" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/residence)
+"kj" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"kk" = (
+/obj/structure/closet/secure_closet/cabinet,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"kl" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/weaponcrafting/stock,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"km" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"ko" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/item/chair/wood,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"kq" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/item/gun_maint_kit/small{
+	pixel_x = 10
+	},
+/obj/item/melee/energy/sword/saber/red{
+	pixel_x = 7
+	},
+/obj/item/storage/toolbox/ammo/a308{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/ammo_box/magazine/invictus_308_mag/empty{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/ammo_box/magazine/invictus_308_mag/empty{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/ammo_box/magazine/invictus_308_mag/empty{
+	pixel_x = -11;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"kt" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/robotics{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"ku" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/whitesands/settlement/shuttle_two)
+"kv" = (
+/obj/item/shard{
+	pixel_x = -1;
+	pixel_y = -11
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"kx" = (
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 10;
+	pixel_y = -11
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"ky" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"kz" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"kB" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"kC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/caution{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"kH" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"kK" = (
+/obj/structure/table,
+/obj/item/trash/can/food/peaches{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/obj/item/plate{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"kL" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/bed/roller,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"kN" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"kO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"kQ" = (
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1;
+	welded = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"kR" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters2"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"kV" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"kY" = (
+/obj/structure/table/wood,
+/obj/item/food/kebab/monkey{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/food/kebab/monkey{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/item/plate/large{
+	layer = 2.9;
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"kZ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24;
+	id = "bossdoor"
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"lb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"ld" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/railing/thin/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lf" = (
+/turf/open/floor/concrete/reinforced/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"lg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"lk" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/officer/internals,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"lm" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/whitesands/lit,
+/area/ruin/whitesands/settlement/shuttle_one)
+"ln" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "sandshuttle1"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/whitesands/settlement/shuttle_two)
+"lo" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"lp" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lr" = (
+/obj/structure/kitchenspike,
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	health = 0;
+	stat = 4;
+	icon_state = "ws_goliath_dead";
+	density = 0
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"ls" = (
+/obj/item/grown/log/tree{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 13;
+	pixel_y = 8
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 13;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"lu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#332521"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"lw" = (
+/obj/effect/turf_decal/box,
+/obj/item/chair/plastic,
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"ly" = (
+/obj/structure/curtain/cloth,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude{
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"lD" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/e11,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"lM" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/closet/secure_closet/cabinet,
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/item/spacecash/bundle/smallrand{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/turf/open/floor/wood/walnut/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"lN" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters2"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"lR" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"lT" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"lZ" = (
+/obj/structure/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"mb" = (
+/obj/item/shard{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/shard{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/shard{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"md" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"mf" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"mh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"ml" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"mn" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#332521"
+	},
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"mo" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"mp" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"mt" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/ruin/whitesands/settlement)
+"mu" = (
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mx" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"mz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"mG" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mH" = (
+/obj/machinery/power/smes/shuttle/micro/precharged{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters2"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"mI" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"mK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"mO" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"mQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"mS" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"mV" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"mZ" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/closed/mineral/random/whitesands/lit,
+/area/ruin/whitesands/settlement)
+"na" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nd" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"ng" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"nh" = (
+/obj/item/chair/plastic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"nj" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"nq" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"nw" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nx" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ny" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"nz" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"nC" = (
+/obj/item/broken_bottle,
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nD" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/structure/closet/secure_closet/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/suit/hooded/survivor/yellow{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/hooded/survivor/yellow{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/obj/item/spacecash/bundle/smallrand{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"nE" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing/thin/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"nG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"nI" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"nM" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/shotgun,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"nP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"nR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"nX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/clothing/suit/hooded/survivor,
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = 18;
+	pixel_y = -1
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"nY" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"nZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/structure/bonfire,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"od" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"of" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"og" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"oh" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/chair/plastic,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"oi" = (
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"oj" = (
+/turf/closed/wall/concrete/reinforced,
+/area/overmap_encounter/planetoid/sand/explored)
+"ol" = (
+/obj/item/chair/plastic,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"op" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"or" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"ot" = (
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"ou" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ov" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"ow" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"ox" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"oy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"oC" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8;
+	welded = 1
+	},
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"oD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"oF" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oG" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesands/settlement/shuttle_one)
+"oH" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/wood/walnut/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"oI" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/rack,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"oK" = (
+/obj/structure/platform/corner,
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oN" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"oO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flippedtable,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"oQ" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oS" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"oY" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pa" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"pe" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"pf" = (
+/obj/item/weldingtool{
+	pixel_x = 14;
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"pg" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_three)
+"ph" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/flora/ash/leaf_shroom,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pi" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"pk" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/item/food/meat/slab/goliath,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"pm" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"po" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pq" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"pr" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"pv" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pw" = (
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -3;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"pA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"pC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/residence)
+"pE" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -10;
+	pixel_y = -5
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"pM" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"pN" = (
+/obj/structure/cable,
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "polshield";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "sandshuttle1"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/whitesands/settlement/shuttle_two)
+"pO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"pQ" = (
+/obj/structure/platform/wood{
+	dir = 4;
+	layer = 3.07
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/butcher)
+"pS" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"pT" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"pX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"pY" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"pZ" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"qb" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"qc" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"qe" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"qi" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/item/seeds/potato{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/seeds/tea{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/seeds/potato{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/seeds/wheat{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/seeds/wheat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/seeds/wheat{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/seeds/tomato{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/item/seeds/tomato{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/seeds/onion{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/seeds/onion{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"qj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "polengine"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"qk" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/crowbar{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -12;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"ql" = (
+/obj/structure/railing/corner/wood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"qm" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/stairs/wood/maple/right,
+/area/ruin/whitesands/settlement/butcher)
+"qn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"qo" = (
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"qp" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"qt" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/sand/explored)
+"qu" = (
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"qw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"qA" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"qD" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"qH" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"qN" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement)
+"qO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"qP" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"qT" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit/smooth,
+/area/overmap_encounter/planetoid/sand/explored)
+"qU" = (
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"qX" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"qY" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"re" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"rh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"rj" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"rm" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/closet/crate/engineering,
+/obj/item/storage/box/stockparts/t2,
+/obj/item/stack/sheet/mineral/uranium/five,
+/turf/open/floor/concrete,
+/area/ruin/whitesands/settlement/blackmarket)
+"ro" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"rp" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"rs" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"rC" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/rack,
+/obj/item/storage/box/stockparts/basic,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"rG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"rI" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/blackmarket)
+"rK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"rL" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"rM" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"rO" = (
+/obj/item/clothing/suit/apron/chef{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/item/book/manual/wiki/cooking{
+	pixel_x = 0;
+	pixel_y = -4;
+	name = "Tasting The Eras";
+	desc = "An odd, old cookbook, describing archaic recipes from the distant pasts of many civilizations."
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"rR" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"rU" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"rW" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sa" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"sb" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"sf" = (
+/obj/structure/platform/corner{
+	dir = 9
+	},
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sg" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/squirt{
+	dir = 5
+	},
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/obj/item/chair/plastic,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"sh" = (
+/obj/structure/table/reinforced,
+/obj/structure/large_mortar,
+/obj/item/pestle{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/lighter{
+	pixel_x = 12;
+	pixel_y = -5
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"sk" = (
+/obj/structure/platform,
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sl" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/residence)
+"sn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"sv" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sw" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/ruin/whitesands/settlement)
+"sy" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/platform/wood/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sz" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"sB" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"sD" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"sF" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/platform/corner,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sI" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sJ" = (
+/obj/structure/platform,
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sK" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/rifle/internals,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/maple,
+/area/overmap_encounter/planetoid/sand/explored)
+"sQ" = (
+/obj/structure/table/wood,
+/obj/item/food/meat/steak/goliath{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/food/meat/steak/goliath{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/food/meat/steak/goliath{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/item/plate/large{
+	layer = 2.9;
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"sR" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"sS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"sW" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"sX" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"td" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"tj" = (
+/obj/structure/rack,
+/obj/item/chair/plastic{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/chair/plastic{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/chair/plastic{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/item/chair/plastic{
+	pixel_x = 4;
+	pixel_y = 15
+	},
+/obj/item/chair/plastic{
+	pixel_x = 4;
+	pixel_y = 17
+	},
+/obj/item/chair/plastic{
+	pixel_x = 4;
+	pixel_y = 21
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"tk" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/computer/monitor/retro,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/concrete,
+/area/ruin/whitesands/settlement/blackmarket)
+"tr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"ts" = (
+/obj/structure/rack,
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 11;
+	pixel_y = 6
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 1;
+	pixel_y = -6
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"tt" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"tC" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 6
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"tI" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"tK" = (
+/obj/structure/rack,
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"tL" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/flora/ash/fern,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"tS" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"tX" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"tY" = (
+/obj/structure/railing/thin,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"ud" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/concrete/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"uf" = (
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ui" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/spitter/internals,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uj" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"uk" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ul" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"un" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/traffic,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"uq" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"ut" = (
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset,
+/obj/item/binoculars{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uv" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uy" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"uA" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uC" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"uE" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uG" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"uO" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"uQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/traffic,
+/obj/structure/salvageable/computer{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"uR" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"uT" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"uU" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"uW" = (
+/obj/structure/rack,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/food/grown/ash_flora/mushroom_leaf{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/pen)
+"uX" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/flora/ash/fern,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"uZ" = (
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -13;
+	pixel_y = -3
+	},
+/obj/item/weldingtool/empty{
+	pixel_x = 19;
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"ve" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"vf" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vj" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"vr" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/item/stack/rods/ten{
+	pixel_x = -7;
+	pixel_y = -8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"vu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"vv" = (
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"vC" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"vE" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"vH" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vI" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24;
+	id = "tantoruindoors2";
+	name = "Doors"
+	},
+/obj/machinery/button/door{
+	pixel_x = -1;
+	pixel_y = 24;
+	name = "Shutters";
+	id = "tantoruinshutters2"
+	},
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"vK" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/rancher)
+"vT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"vU" = (
+/obj/item/chair/plastic,
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"vV" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter/sentry,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"vX" = (
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"vY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"vZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"wc" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"wd" = (
+/obj/structure/bonfire/prelit,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"wh" = (
+/turf/template_noop,
+/area/template_noop)
+"wk" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/ore/salvage/scrapplasma{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/stack/ore/salvage/scrapmetal/five{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"wl" = (
+/obj/structure/closet/body_bag,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"wn" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ws" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/bamboo{
+	dir = 1
+	},
+/area/ruin/whitesands/settlement/granary)
+"wu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/machinery/light/broken/directional/west,
+/obj/structure/closet/secure_closet/cabinet,
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/hooded/survivor/jermit{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -11;
+	pixel_y = -6
+	},
+/obj/item/spacecash/bundle/pocketchange,
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 4;
+	pixel_y = -7
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"wv" = (
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/guncloset{
+	anchored = 1
+	},
+/obj/item/gun/ballistic/rifle/polymer,
+/obj/item/gun/ballistic/rifle/polymer,
+/obj/item/gun/ballistic/rifle/polymer,
+/obj/item/gun/ballistic/automatic/smg/skm_carbine,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"wz" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/spider{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"wB" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"wD" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"wF" = (
+/obj/item/chair/wood,
+/obj/item/stack/tile/carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"wL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"wT" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"wX" = (
+/turf/closed/mineral/random/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xa" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "granary"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"xb" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/servingdish,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"xf" = (
+/obj/structure/platform,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xh" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 4;
+	pixel_y = 9;
+	layer = 2.79
+	},
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"xk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xo" = (
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/sand/explored)
+"xq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"xu" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/ammo/a762_40,
+/obj/item/storage/box/ammo/a762_40,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xy" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor/brawler{
+	wander = 0
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xz" = (
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = -13;
+	pixel_y = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xA" = (
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/ruin/whitesands/settlement)
+"xB" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"xC" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/platform/wood,
+/obj/structure/railing/thin,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xD" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xI" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/structure/rack,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"xJ" = (
+/obj/structure/flora/ash/cacti,
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xM" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xN" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"xO" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xQ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"xV" = (
+/obj/structure/platform/corner,
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"xY" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yb" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"yd" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"ye" = (
+/obj/structure/table/wood,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/binoculars{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"yh" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"yk" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"ym" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yo" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"yu" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"yx" = (
+/obj/machinery/hydroponics/wooden,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"yy" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"yz" = (
+/obj/item/chair/plastic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"yA" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yC" = (
+/obj/structure/bed/dogbed,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands{
+	faction = list("neutral")
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"yE" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"yF" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/shuttle_two)
+"yH" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "polshield"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "sandshuttle1"
+	},
+/turf/open/floor/plasteel/rockvault,
+/area/ruin/whitesands/settlement/shuttle_two)
+"yL" = (
+/obj/structure/platform,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"yO" = (
+/obj/item/rack_parts,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"yT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"yV" = (
+/obj/structure/chair/plastic,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"yX" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"yZ" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"za" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"zc" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"zd" = (
+/turf/open/floor/plasteel/stairs/wood/maple/right,
+/area/ruin/whitesands/settlement/butcher)
+"zg" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"zh" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"zi" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"zj" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zm" = (
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement)
+"zn" = (
+/obj/machinery/hydroponics/wooden,
+/obj/item/food/grown/wheat,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"zs" = (
+/obj/structure/flora/ash/fern,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zv" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"zw" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zx" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/obj/item/bedsheet{
+	pixel_x = 11;
+	pixel_y = 2
+	},
+/obj/item/bedsheet{
+	pixel_x = 16;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = -9;
+	pixel_y = 13
+	},
+/obj/item/stack/sheet/cotton/cloth,
+/obj/item/stack/sheet/cotton/cloth,
+/obj/item/stack/sheet/cotton/cloth{
+	pixel_x = -2;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"zz" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"zD" = (
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 0;
+	pixel_y = -5
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -14;
+	pixel_y = -4
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"zF" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"zL" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"zM" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/shotgun,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/ruin/whitesands/settlement)
+"zO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"zQ" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/skm_46_30,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"zR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"zT" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"zW" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"zY" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"zZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"Aa" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Ac" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ae" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"Af" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ah" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/old{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/radio/old{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/stack/cable_coil/cut/red{
+	pixel_x = -11;
+	pixel_y = -4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Aj" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"Al" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Am" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Ao" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/rifle/internals,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ar" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"As" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/double/red,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Au" = (
+/obj/structure/table/reinforced,
+/obj/item/food/sosjerky/healthy{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/food/sosjerky/healthy{
+	pixel_x = -15;
+	pixel_y = 9
+	},
+/obj/item/trash/sosjerky{
+	pixel_x = -14;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Av" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/greenhouse)
+"Aw" = (
+/obj/structure/table/wood,
+/obj/item/toy/nuke{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ax" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/wood/maple{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"Ay" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Az" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"AB" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"AC" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"AE" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"AG" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesands/settlement/shuttle_three)
+"AH" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"AI" = (
+/obj/item/stack/tile/carpet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"AJ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"AM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"AP" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"AQ" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"AR" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"AS" = (
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"AX" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"AY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Be" = (
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Bj" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken7"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Bm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"Bo" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Bp" = (
+/obj/structure/platform,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bs" = (
+/mob/living/simple_animal/hostile/human/frontier/internals,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bt" = (
+/turf/open/floor/wood/maple/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Bx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"BD" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken6"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"BG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"BH" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"BK" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"BO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/chair/bench/beige{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"BP" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"BW" = (
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"BX" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"BY" = (
+/obj/structure/platform/wood,
+/obj/structure/railing/thin,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ca" = (
+/obj/structure/dresser,
+/obj/structure/bedsheetbin/empty{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Cc" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"Cd" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Ce" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"Cg" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken6"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Ci" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cj" = (
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Cm" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"Cn" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter/sentry,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"Cv" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Cw" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/frontier/internals,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Cz" = (
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"CB" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"CF" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CH" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"CJ" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/spitter/internals,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CN" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"CO" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CR" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"CU" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/plate{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"CV" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/micro_laser,
+/obj/item/weaponcrafting/receiver{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"CW" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"CY" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Da" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Dc" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/ore/salvage/scrapmetal/five,
+/obj/item/stack/ore/salvage/scrapsilver{
+	pixel_x = -11;
+	pixel_y = 14
+	},
+/obj/item/stack/ore/salvage/scrapsilver{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"De" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Df" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Dg" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/residence)
+"Dh" = (
+/obj/structure/rack,
+/obj/structure/railing/wood{
+	dir = 6
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -11;
+	pixel_y = 0
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit,
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = -11;
+	pixel_y = -2
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/pen)
+"Dm" = (
+/obj/item/chair/plastic,
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Dn" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Dq" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/ruin/whitesands/settlement)
+"Dr" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Dx" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1;
+	welded = 1
+	},
+/obj/item/clothing/suit/hooded/survivor/jermit{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hooded/survivor/yellow{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -9;
+	pixel_y = -5
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/spacecash/bundle/smallrand{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"DB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"DC" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 13
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/settlement/shuttle_two)
+"DD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"DF" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"DG" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1;
+	welded = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/workboots/mining,
+/obj/item/clothing/shoes/workboots/mining,
+/obj/item/spacecash/bundle/pocketchange,
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 4;
+	pixel_y = -8
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"DI" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/overmap_encounter/planetoid/sand/explored)
+"DK" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/roboticist)
+"DL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"DP" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"DR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "polengine"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"DU" = (
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"DX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/curtain/cloth,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"DY" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ed" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Ef" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Eg" = (
+/obj/machinery/door/airlock/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ei" = (
+/obj/effect/turf_decal/box,
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"El" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Eo" = (
+/obj/structure/table/reinforced,
+/obj/item/blackmarket_uplink{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/item/stack/cable_coil/cut/red{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Er" = (
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "tantoruindoors"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"Es" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/reinforced/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Et" = (
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Eu" = (
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Ev" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ew" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ex" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EA" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EB" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"EC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"EE" = (
+/obj/structure/bookcase,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"EF" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"EG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"EL" = (
+/obj/machinery/power/smes/shuttle/micro/precharged{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"EM" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1;
+	welded = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/item/clothing/suit/hooded/survivor/jermit{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -12;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/spacecash/bundle/pocketchange,
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 9;
+	pixel_y = -5
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/residence)
+"EO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"EQ" = (
+/obj/structure/curtain/cloth,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"ER" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/item/food/meat/slab/goliath,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"ES" = (
+/obj/item/flashlight/lantern{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"ET" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"EU" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"EW" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/effect/decal/cleanable/blood/splatter/over_window,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"EY" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fa" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fe" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bossdoor"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Fg" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fh" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fi" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Fl" = (
+/obj/item/stack/rods/ten{
+	pixel_x = 11;
+	pixel_y = -8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"Fn" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Fs" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Ft" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Fu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8;
+	color = "#332521"
+	},
+/obj/structure/fluff/hedge,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"Fv" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement)
+"Fz" = (
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter/sentry,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"FB" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"FC" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FD" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"FH" = (
+/obj/item/chair/plastic,
+/obj/effect/decal/cleanable/glass,
+/obj/item/broken_bottle{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/plate_shard{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/plate_shard{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/plate_shard{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"FI" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"FL" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"FM" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"FO" = (
+/obj/structure/rack,
+/obj/structure/railing/wood{
+	dir = 10
+	},
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit,
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/food/grown/ash_flora/cactus_fruit{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/pen)
+"FP" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"FU" = (
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = 1;
+	pixel_y = 7
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/obj/item/stack/sheet/animalhide/goliath_hide{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"FV" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"FY" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Ga" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"Gb" = (
+/obj/machinery/power/smes/shuttle/micro/precharged{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters2"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"Ge" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Gj" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/girder,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Gl" = (
+/obj/structure/crate_shelf,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Gm" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"Go" = (
+/obj/item/chair/plastic,
+/obj/structure/flippedtable,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Gp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#332521"
+	},
+/obj/structure/fluff/hedge,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"Gr" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"Gx" = (
+/obj/item/stack/tile/carpet{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Gy" = (
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"GF" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"GG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken7"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"GH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"GK" = (
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/shotgun,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"GN" = (
+/obj/structure/railing/thin/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"GO" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"GP" = (
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/dried,
+/area/overmap_encounter/planetoid/sand/explored)
+"GS" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"GV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"GX" = (
+/obj/structure/guncloset{
+	anchored = 1
+	},
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Ha" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Hc" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/greenhouse)
+"Hd" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Hf" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Hh" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/fortress)
+"Hj" = (
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/frame,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Hn" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Hr" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/granary)
+"Ht" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Hu" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -9;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"Hw" = (
+/obj/structure/bookcase,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Hx" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken7"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"Hz" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"HA" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HD" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"HH" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"HP" = (
+/obj/effect/mob_spawn/human/corpse/frontier/internals,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"HQ" = (
+/obj/machinery/hydroponics/wooden,
+/obj/item/food/grown/wheat,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"HT" = (
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = 13;
+	pixel_y = -10
+	},
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = -18;
+	pixel_y = -6
+	},
+/obj/item/electronics/airlock{
+	pixel_x = 13;
+	pixel_y = -6
+	},
+/obj/item/stack/sheet/metal{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"HU" = (
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"HY" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Ia" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"Ib" = (
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Id" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Ie" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#332521"
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/hunter/sentry,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"Ii" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/spitter/internals,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Io" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ir" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Is" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"It" = (
+/obj/machinery/door/airlock/wood{
+	welded = 1
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Iz" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"ID" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"IE" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"IF" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"IK" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"IM" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"IP" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"IS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/concrete/tiles/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"IV" = (
+/obj/item/chair/plastic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"IX" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Jb" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Jc" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Jd" = (
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"Je" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/flippedtable,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jh" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Ji" = (
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = 11;
+	pixel_y = 11
+	},
+/obj/item/stack/sheet/mineral/wood{
+	pixel_x = -13;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Jj" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Jo" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/internals,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Jq" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Js" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Jt" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Jx" = (
+/obj/effect/decal/cleanable/ash/large,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Jz" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JB" = (
+/obj/structure/grille,
+/obj/item/shard{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/shard{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/shard{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"JC" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/structure/table/wood,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"JE" = (
+/obj/item/chair/plastic,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"JF" = (
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"JK" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"JR" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JS" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/whitesands/settlement/shuttle_two)
+"JW" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/structure/platform/corner,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"JY" = (
+/obj/structure/bookcase,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"JZ" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/internals,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Kb" = (
+/obj/item/food/grown/wheat{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -10;
+	pixel_y = 7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -13;
+	pixel_y = 6
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = -8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -2;
+	pixel_y = -7
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -11;
+	pixel_y = -8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"Kf" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Kg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ki" = (
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Kj" = (
+/obj/structure/filingcabinet/double{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = 0;
+	density = 0
+	},
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Kk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Ko" = (
+/obj/item/radio{
+	pixel_x = -16;
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Kp" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/item/stack/sheet/metal/five,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ks" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"Kw" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Kx" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"KD" = (
+/obj/machinery/power/smes/shuttle/micro/precharged{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tantoruinshutters"
+	},
+/turf/open/floor/engine/hull/reinforced/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"KE" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/suit/hooded/survivor,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"KF" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/lit/smooth,
+/area/overmap_encounter/planetoid/sand/explored)
+"KG" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D"
+	},
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/butcher)
+"KI" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/concrete/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"KK" = (
+/obj/item/chair/wood,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"KL" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KM" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"KQ" = (
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"KU" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"KY" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"KZ" = (
+/obj/machinery/smartfridge/drying_rack,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"Lc" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Ld" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Lf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/greenhouse)
+"Lh" = (
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Li" = (
+/obj/item/inducer{
+	pixel_x = -2;
+	pixel_y = -9
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lj" = (
+/obj/effect/decal/cleanable/blood/squirt,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lk" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Ll" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Lp" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Lw" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Ly" = (
+/obj/item/pipe/binary/bendable{
+	pixel_x = 7;
+	pixel_y = 5;
+	color = "#0000ff"
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LA" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"LE" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LH" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"LI" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"LL" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"LP" = (
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"LQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/wood/maple{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"LS" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Mb" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Me" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/obj/item/stock_parts/cell/gun/upgraded,
+/turf/open/floor/concrete,
+/area/ruin/whitesands/settlement/blackmarket)
+"Mg" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/item/stack/sheet/metal/five,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Mi" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"Mj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"Mn" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Mq" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Mv" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Mw" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"MA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/chair/handrail{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"MC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/settlement/shuttle_two)
+"MD" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"MG" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"MP" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"MR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"MT" = (
+/obj/item/shard,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"MW" = (
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"MX" = (
+/obj/structure/closet/secure_closet/cabinet,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/workboots/mining,
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"MY" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Na" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Nc" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit/smooth,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ne" = (
+/obj/effect/mob_spawn/human/corpse/frontier/internals,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"Nh" = (
+/turf/open/floor/concrete/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Nj" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/obj/item/pipe/binary/bendable{
+	pixel_x = 16;
+	pixel_y = -11;
+	icon = 'icons/obj/atmospherics/components/unary_devices.dmi';
+	icon_state = "passive_vent_map-3"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Nl" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Nn" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Nq" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Ns" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Nu" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "bossdoor"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"NA" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"NB" = (
+/obj/structure/table/reinforced,
+/obj/structure/large_mortar,
+/obj/item/pestle{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"NE" = (
+/obj/structure/fermenting_barrel,
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"NF" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"NG" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"NL" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"NN" = (
+/obj/item/melee/knife/butcher,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"NP" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"NS" = (
+/obj/structure/dresser{
+	climbable = 1
+	},
+/obj/item/weldingtool{
+	pixel_x = -7;
+	pixel_y = -11
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"NT" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood{
+	dir = 4;
+	icon_state = "gib3"
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -19;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/residence)
+"NV" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/item/radio{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/settlement/shuttle_two)
+"NW" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"NY" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"NZ" = (
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Of" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"Oi" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Oo" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ot" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Ox" = (
+/obj/structure/girder/reinforced,
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/whitesands/lit,
+/area/ruin/whitesands/settlement/shuttle_one)
+"Oy" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Oz" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"OG" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"OJ" = (
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"OP" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/obj/item/storage/box/ammo/c9mm_surplus,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"OQ" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/butcher)
+"OR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OT" = (
+/obj/structure/platform,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OU" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"OY" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/internals,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Pa" = (
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"Pe" = (
+/obj/structure/barricade/sandbags,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ph" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Pj" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Pl" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Pm" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Pn" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Pw" = (
+/obj/structure/flora/ash/cacti,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"Px" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Py" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Pz" = (
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"PA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"PC" = (
+/obj/structure/closet/crate/engineering,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/bot_assembly/cleanbot{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/bot_assembly/floorbot{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"PE" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"PH" = (
+/obj/structure/railing/corner/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"PI" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/greenhouse)
+"PN" = (
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"PO" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"PP" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"PQ" = (
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"PS" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"PW" = (
+/obj/structure/girder,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"PY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"PZ" = (
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood/ebony,
+/area/ruin/whitesands/settlement/fortress)
+"Qa" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Qb" = (
+/turf/closed/mineral/random/whitesands/lit,
+/area/ruin/whitesands/settlement)
+"Qd" = (
+/obj/structure/closet/secure_closet/armorycage,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gun/ballistic/automatic/zip_pistol,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Qg" = (
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Qh" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/pen{
+	pixel_x = 3;
+	pixel_y = 13
+	},
+/obj/item/pen/charcoal{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/item/paper/crumpled/fluff/ruin{
+	pixel_x = 5;
+	pixel_y = 0;
+	default_raw_text = "Stores for winter should be enough. I hope so. The nearby travelers have told me that the coming winter chills are the coldest this planet has ever seen. I worry. This settlement had stood for eight years. We will not die from starvation. But even with our supplies, I worry again. Spacers have been circling us. Hungry, I am sure. I do not want to fend them off, but I will if I must.";
+	name = "journal"
+	},
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Qi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/structure/closet/crate,
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Qm" = (
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"Qn" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Qp" = (
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/ruin/whitesands/settlement/greenhouse)
+"Qt" = (
+/turf/closed/wall/mineral/sandstone,
+/area/ruin/whitesands/settlement/pen)
+"Qu" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Qv" = (
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Qx" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Qz" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"QB" = (
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -19;
+	pixel_y = -15
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 13;
+	pixel_y = -14
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"QD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"QE" = (
+/turf/closed/wall/mineral/sandstone,
+/area/overmap_encounter/planetoid/sand/explored)
+"QH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"QK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/item/weldingtool{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = 10;
+	pixel_y = 21
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"QP" = (
+/obj/structure/platform/wood,
+/obj/structure/railing/thin,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"QQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"QR" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"QT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"QX" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"QY" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/table_frame/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Rd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement)
+"Re" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Rf" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/wallframe/button{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/wallframe/button{
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Rh" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Ri" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Rj" = (
+/obj/structure/table/wood,
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Rl" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = 16;
+	pixel_y = 20
+	},
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = 6;
+	pixel_y = 20
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"Ro" = (
+/obj/structure/platform,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Rp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Rq" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/chair/bench/beige{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Rs" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/abstract/turf_fire/magical,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Rt" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Rv" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"RF" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"RJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"RL" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RN" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RO" = (
+/obj/structure/table/wood,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"RQ" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/whitesands/settlement/shuttle_two)
+"RS" = (
+/obj/item/shard{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/shard{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"RV" = (
+/turf/open/floor/plating/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RW" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/rack,
+/obj/item/clothing/head/welding{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/chainsaw{
+	pixel_y = -2;
+	pixel_x = 1
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"RX" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"RZ" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"Sb" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/structure/flora/ash/cacti,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sc" = (
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Sd" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 0;
+	id = "granary"
+	},
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"Sf" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/chlorine,
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sl" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Sm" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"So" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sp" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Sq" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Su" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "polwindow";
+	name = "Blast Shield";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Sw" = (
+/obj/structure/table/wood,
+/obj/item/radio/old{
+	pixel_x = 3;
+	pixel_y = 8;
+	name = "decommissioned uplink";
+	desc = "An old, banged up Coalition equipment uplink offered to elite Gorlex strike forces during the ICW. This one is completely unusable."
+	},
+/obj/item/stack/telecrystal{
+	pixel_x = -1;
+	pixel_y = -5
+	},
+/obj/item/stack/telecrystal{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/turf/open/floor/wood/ebony/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Sy" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib6"
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"SA" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"SB" = (
+/obj/item/chair/plastic,
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"SF" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/fortress)
+"SG" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SL" = (
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/item/clothing/under/syndicate/gorlex{
+	pixel_x = -7;
+	pixel_y = 11
+	},
+/obj/item/clothing/shoes/combat{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/storage/belt/mining/alt{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/storage/backpack/satchel/explorer{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/clothing/suit/armor/vest/syndie{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/helmet/syndie{
+	pixel_x = 4;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"SP" = (
+/obj/item/flashlight/lantern{
+	pixel_x = -10;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"SQ" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast{
+	health = 0;
+	stat = 4;
+	icon_state = "ws_goliath_dead";
+	density = 0
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"SS" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit/smooth,
+/area/overmap_encounter/planetoid/sand/explored)
+"ST" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/wood/maple/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"SU" = (
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"SV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"SX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"SZ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/five{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/obj/item/weldingtool{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Ta" = (
+/obj/item/chair/plastic,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Td" = (
+/obj/structure/platform/corner,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Te" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Tf" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/ranged/gunslinger{
+	wander = 0
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Tg" = (
+/obj/effect/mob_spawn/human/corpse/frontier/ranged/internals,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_2/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Tj" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"Tk" = (
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"To" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Tp" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 5
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/brawler,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Tq" = (
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Tt" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/mob/living/simple_animal/hostile/human/hermit/survivor/brawler{
+	wander = 0
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Tv" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Tw" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Tx" = (
+/obj/structure/railing/thin/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Tz" = (
+/obj/item/stack/sheet/leather,
+/obj/item/stack/sheet/leather,
+/obj/item/stack/sheet/leather,
+/obj/item/stack/sheet/leather,
+/obj/structure/table/reinforced,
+/turf/open/floor/concrete/slab_3/icemoon,
+/area/ruin/whitesands/settlement/butcher)
+"TI" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"TJ" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TN" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"TS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"TU" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"TW" = (
+/obj/structure/fireplace{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"TY" = (
+/obj/structure/platform/wood/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ub" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flippedtable{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Uc" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/structure/railing/thin,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Ug" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Um" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Un" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"Uo" = (
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Up" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ur" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Uy" = (
+/turf/open/floor/plasteel/stairs/wood/maple{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/sand/explored)
+"UB" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"UE" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"UF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"UJ" = (
+/obj/item/stack/tile/wood/maple{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"UR" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"UT" = (
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"UV" = (
+/obj/item/chair/plastic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/blackmarket)
+"UW" = (
+/obj/structure/platform/wood/corner,
+/obj/structure/flora/ash/leaf_shroom,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Ve" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Vf" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Vh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Vk" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 1
+	},
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 2
+	},
+/turf/open/floor/plasteel/patterned/brushed/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"Vn" = (
+/obj/effect/turf_decal/corner/opaque/red/border{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/hatchet{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Vo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Vq" = (
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/structure/barricade/sandbags,
+/obj/structure/flippedtable,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Vr" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/rancher)
+"Vw" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/wood/walnut/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Vx" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/white/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Vz" = (
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/structure/flora/ash/fern,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VB" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VD" = (
+/obj/structure/railing/thin{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"VF" = (
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VI" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"VL" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VN" = (
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 1
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"VO" = (
+/mob/living/basic/hivebot/strong/frontier,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair/handrail,
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24;
+	id = "tantoruindoors";
+	name = "Doors"
+	},
+/obj/machinery/button/door{
+	pixel_x = -1;
+	pixel_y = 24;
+	name = "Shutters";
+	id = "tantoruinshutters"
+	},
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"VR" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"VS" = (
+/obj/machinery/door/airlock/wood{
+	dir = 8;
+	welded = 1
+	},
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"VV" = (
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"VW" = (
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"VX" = (
+/obj/item/stack/tile/wood/walnut{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"VY" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/wood/maple/whitesands,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wa" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Wb" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 2;
+	color = "#D2BC9D"
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Wc" = (
+/obj/structure/girder,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"We" = (
+/obj/structure/railing/wood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/ruin/whitesands/settlement/pen)
+"Wg" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/platform/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Wh" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Wl" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Wm" = (
+/obj/item/grown/log/tree{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/grown/log/tree{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/grown/log/tree{
+	pixel_x = -12;
+	pixel_y = -2
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Wn" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Wr" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 1
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"Wt" = (
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"Ww" = (
+/obj/structure/flora/tree/tall/whitesands,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WE" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/splatter{
+	icon_state = "gib5";
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/residence)
+"WI" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"WK" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"WN" = (
+/obj/structure/platform/wood/corner,
+/obj/effect/abstract/turf_fire/magical,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WO" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/wasp/internals,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"WQ" = (
+/obj/machinery/suit_storage_unit/inherit,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"WV" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/rancher)
+"WZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Xb" = (
+/obj/structure/curtain/cloth,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude{
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Xc" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Xd" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Xe" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xg" = (
+/obj/structure/dresser,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Xj" = (
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.3;
+	opacity = 1
+	},
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"Xk" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/flippedtable,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xn" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xo" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/walnut/chlorine,
+/area/ruin/whitesands/settlement/blackmarket)
+"Xq" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Xr" = (
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Xs" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/chair/plastic{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"Xt" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = -8;
+	pixel_x = -25;
+	name = "window shutters";
+	id = "polwindow"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_y = 7;
+	pixel_x = -25;
+	name = "engine shutters";
+	id = "polengine"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/structure/chair/plastic,
+/turf/open/floor/plasteel/tech,
+/area/ruin/whitesands/settlement/shuttle_two)
+"Xv" = (
+/obj/structure/table/reinforced,
+/obj/item/shovel/spade{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/item/cultivator{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/glass/bottle/ammonia{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/ammonia{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/glass/bottle/ammonia{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/glass/bottle/ammonia{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"Xw" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Xx" = (
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"Xy" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 5
+	},
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/item/bedsheet{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/bedsheet{
+	pixel_x = 14;
+	pixel_y = 12
+	},
+/obj/item/bedsheet{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/bedsheet{
+	pixel_x = -1;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/walnut/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Xz" = (
+/turf/open/floor/concrete/slab_3,
+/area/ruin/whitesands/settlement/granary)
+"XA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"XB" = (
+/obj/structure/railing/wood,
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/ruin/whitesands/settlement/pen)
+"XK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"XR" = (
+/obj/structure/closet/secure_closet/cabinet{
+	anchored = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spacecash/bundle/pocketchange{
+	pixel_x = 11;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/hooded/survivor{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hooded/survivor/brown{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"XS" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_one)
+"XV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"XW" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Yc" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"Yj" = (
+/obj/structure/rack,
+/obj/item/ammo_box/a762_stripper{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement)
+"Ym" = (
+/obj/effect/abstract/turf_fire/magical,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/rancher)
+"Yn" = (
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"Yo" = (
+/obj/item/chair/plastic,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Yr" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 6
+	},
+/obj/item/stack/tile/wood/maple{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/whitesands{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/whitesands/settlement/doctor)
+"Yu" = (
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YA" = (
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"YC" = (
+/obj/item/chair/plastic{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/roboticist)
+"YF" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/obj/structure/platform/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YH" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	id = "polwindow";
+	name = "Blast Shield"
+	},
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/shuttle_two)
+"YI" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/whitesands/settlement/shuttle_two)
+"YJ" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/light/directional/east,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/magazine/spitter_9mm{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/spitter_9mm{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/gun/ballistic/automatic/pistol/spitter{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/turf/open/floor/engine/hull/interior/whitesands,
+/area/ruin/whitesands/settlement/shuttle_two)
+"YL" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/concrete/pavement/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YR" = (
+/obj/structure/flora/ash/fern,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YS" = (
+/obj/structure/platform/wood/corner{
+	dir = 8
+	},
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"YU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+"YV" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/item/trash/sosjerky,
+/mob/living/simple_animal/hostile/human/hermit/survivor/passive,
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/butcher)
+"YY" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/structure/railing/thin,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/suit/hooded/survivor/brown,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"YZ" = (
+/obj/effect/turf_decal/trimline/transparent/lightgrey/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Zc" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D";
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#D2BC9D"
+	},
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/greenhouse)
+"Zd" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null;
+	anchored = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/storage/box/ammo/c46x30mm,
+/turf/open/floor/concrete/slab_4/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Zi" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"Zj" = (
+/turf/open/floor/plating/asteroid/whitesands/dried/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Zl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/hermit/mayor{
+	wander = 0;
+	health = 300;
+	maxHealth = 300
+	},
+/turf/open/floor/carpet/black/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Zn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/pod/whitesands,
+/area/ruin/whitesands/settlement/shuttle_three)
+"Zo" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"Zt" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Zv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 2
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/fortress)
+"Zw" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"Zx" = (
+/obj/structure/flora/ash/cacti,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"Zy" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut/whitesands,
+/area/ruin/whitesands/settlement/guardshouse)
+"ZC" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating/asteroid/whitesands/grass/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZE" = (
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = -5
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -12;
+	pixel_y = 10
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -9;
+	pixel_y = -8
+	},
+/obj/item/food/grown/wheat{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/turf/open/floor/concrete/tiles/whitesands,
+/area/ruin/whitesands/settlement/granary)
+"ZN" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 6
+	},
+/turf/open/floor/wood/walnut/whitesands{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/whitesands/settlement/guardshouse)
+"ZQ" = (
+/obj/structure/platform/corner,
+/turf/open/floor/plating/asteroid/whitesands/lit,
+/area/overmap_encounter/planetoid/sand/explored)
+"ZR" = (
+/obj/effect/turf_decal/siding/wood{
+	color = "#D2BC9D"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/maple/chlorine{
+	icon_state = "wood-broken2"
+	},
+/area/ruin/whitesands/settlement/blackmarket)
+"ZU" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green/whitesands,
+/area/ruin/whitesands/settlement/residence)
+"ZV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/end{
+	color = "#D2BC9D";
+	dir = 8
+	},
+/turf/open/floor/wood/maple/whitesands{
+	icon_state = "wood-broken5"
+	},
+/area/ruin/whitesands/settlement/roboticist)
+"ZZ" = (
+/obj/machinery/door/airlock/wood,
+/obj/effect/turf_decal/siding/wood{
+	color = "#543C30";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/concrete/slab_1/whitesands,
+/area/ruin/whitesands/settlement/doctor)
+
+(1,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(2,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(3,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(4,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(5,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+SU
+SU
+SU
+ZQ
+SS
+SS
+AQ
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(6,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+SU
+SU
+Fv
+Fv
+by
+by
+Fv
+jU
+jU
+QE
+QE
+QE
+RV
+Cn
+RV
+QE
+QE
+QE
+jU
+jU
+jU
+QE
+QE
+QE
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(7,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+xA
+Qb
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+QE
+QE
+Fv
+BP
+vV
+cx
+Fv
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+oj
+lf
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(8,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+QE
+QE
+Fv
+hJ
+MW
+ES
+Fv
+QE
+QE
+QE
+oj
+QE
+QE
+QE
+QE
+QE
+oj
+QE
+QE
+QE
+QE
+QE
+oj
+QE
+QE
+QE
+QE
+QE
+ud
+Es
+lf
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(9,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+xA
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+mu
+Fv
+Fv
+Dq
+Fv
+Fv
+Ww
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Zj
+VF
+VF
+zs
+Ww
+VF
+dG
+VF
+SU
+SU
+oj
+Nh
+Nh
+Nh
+lf
+lf
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+"}
+(10,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Da
+dG
+VF
+VF
+VF
+zs
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Zj
+Zj
+Zj
+Da
+VF
+VF
+VF
+SU
+SU
+SU
+SU
+lf
+Es
+Nh
+Nh
+Hp
+Es
+lf
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+"}
+(11,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+zs
+VF
+VF
+VF
+VF
+VF
+Zj
+Zj
+Qu
+SU
+Mi
+Mi
+Av
+Mi
+Mi
+Zj
+Zj
+Zj
+VF
+VF
+SU
+SU
+SU
+Zj
+SU
+SU
+lf
+lf
+Hp
+Nh
+ud
+oj
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+"}
+(12,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+kB
+VF
+VF
+VF
+Zj
+Zj
+Zj
+Zj
+Zj
+Mi
+Mi
+Mi
+kN
+UT
+kN
+Mi
+Mi
+Mi
+Zj
+SU
+SU
+Zj
+Zj
+Zj
+Zj
+SU
+Zj
+Zj
+lf
+lf
+Hp
+QE
+QE
+QE
+ZQ
+SS
+SS
+AQ
+SU
+SU
+SU
+SU
+SU
+"}
+(13,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+Zj
+Zj
+Zj
+Zj
+SU
+Mi
+Av
+zn
+zn
+pM
+Hc
+cT
+Qp
+Qp
+Av
+Mi
+SU
+Qu
+Zj
+El
+Zj
+SU
+SU
+Zj
+SU
+Zj
+lf
+oj
+QE
+QE
+Fv
+Fv
+by
+by
+Fv
+jU
+jU
+jU
+QE
+SU
+"}
+(14,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+Qb
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Ww
+dG
+Zj
+Zj
+Zj
+Zj
+SU
+SU
+Mi
+yx
+uq
+ow
+tJ
+DL
+mh
+PI
+uq
+Qp
+Mi
+SU
+SU
+SU
+SU
+SU
+Tk
+SU
+SU
+SU
+Zj
+SU
+VF
+QE
+QE
+Fv
+SP
+Fz
+cx
+Fv
+QE
+QE
+QE
+jU
+SU
+"}
+(15,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+Zj
+Zj
+SU
+SU
+SU
+Mi
+zn
+uq
+Lf
+Xv
+qi
+Rl
+ng
+uq
+Qp
+Mi
+SU
+SU
+SU
+SU
+SU
+Tk
+Zj
+Zj
+SU
+SU
+SU
+dG
+QE
+QE
+Fv
+Yj
+ho
+pZ
+Fv
+QE
+QE
+QE
+jU
+SU
+"}
+(16,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+zs
+Da
+Zj
+Tv
+SU
+SU
+SU
+SU
+Mi
+zn
+uq
+EG
+jn
+zW
+Gr
+Zc
+uq
+Qp
+Mi
+SU
+Zj
+SU
+Zj
+SU
+SU
+Zj
+SU
+SU
+SU
+Zj
+Zj
+VF
+kB
+Fv
+Fv
+Dq
+Fv
+Fv
+Da
+QE
+QE
+jU
+SU
+"}
+(17,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+SU
+SU
+SU
+SU
+SU
+Mi
+Av
+zn
+HQ
+cA
+hK
+tC
+Pw
+Qp
+Av
+Mi
+SU
+Zj
+Zj
+Tk
+SU
+Zj
+SU
+SU
+xJ
+TY
+TY
+vv
+Zj
+VF
+VF
+VF
+VF
+VF
+VF
+VF
+QE
+QE
+QE
+SU
+"}
+(18,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+SU
+SU
+SU
+El
+SU
+SU
+Mi
+Mi
+Av
+bh
+Av
+bh
+Av
+Mi
+Mi
+SU
+VF
+Zj
+Zj
+Tk
+Zj
+Zj
+VF
+fj
+fj
+fj
+fj
+fj
+fj
+SU
+VF
+VF
+VF
+VF
+Ww
+VF
+oj
+QE
+QE
+SU
+"}
+(19,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+xA
+xA
+xA
+xA
+Qb
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+mu
+Zj
+SU
+SU
+SU
+SU
+SU
+ep
+OR
+OR
+OR
+DD
+OR
+na
+hi
+na
+hi
+na
+na
+hi
+Ri
+Tk
+Zj
+ig
+fj
+fj
+cg
+Cj
+TW
+Wm
+fj
+TY
+TY
+TY
+SU
+VF
+dG
+VF
+QE
+QE
+QE
+SU
+"}
+(20,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+xA
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+SU
+SU
+SU
+Qu
+pT
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Zj
+Zj
+VF
+SU
+SU
+Zj
+Tk
+HA
+RL
+VB
+fj
+oI
+kz
+ko
+rL
+Ld
+fj
+fj
+fj
+fj
+fj
+Ex
+VF
+VF
+QE
+QE
+jU
+SU
+"}
+(21,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Hr
+Hr
+Hr
+Hr
+Hr
+Qb
+SU
+SU
+pT
+SU
+SU
+Zj
+Zj
+SU
+SU
+Tk
+Tk
+Tk
+SU
+Zj
+zT
+CO
+Zj
+SU
+SU
+DF
+dB
+jv
+Lw
+ID
+oi
+sD
+zh
+fj
+PP
+NA
+Cc
+fj
+YF
+SU
+SU
+QE
+QE
+jU
+SU
+"}
+(22,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+Qb
+Qb
+Qb
+Hr
+Hr
+Hr
+Hu
+je
+tS
+Hr
+Qb
+Qb
+Jz
+SU
+Tk
+SU
+SU
+Tk
+Tk
+SU
+Zj
+SU
+Zj
+Zj
+Tk
+Tk
+Tk
+zT
+SU
+SU
+VF
+JW
+fj
+FB
+kH
+AI
+oi
+hG
+fj
+Cm
+Iz
+Dx
+Oi
+AX
+SU
+Zj
+QE
+QE
+jU
+SU
+"}
+(23,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+NE
+Sd
+Xz
+rO
+Aj
+Hr
+Hr
+Qb
+aX
+Tk
+Tk
+Zj
+SU
+SU
+SU
+Tk
+SU
+Zj
+SU
+zT
+SU
+SU
+Tk
+OU
+Zj
+SU
+VF
+sk
+Is
+Ub
+ga
+KK
+wF
+km
+ZZ
+hH
+sa
+ek
+Oi
+AX
+SU
+Zj
+QE
+QE
+QE
+SU
+"}
+(24,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+NE
+Xz
+NB
+sh
+cB
+fa
+ws
+az
+qc
+Tk
+Zj
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Xq
+zT
+SU
+El
+SU
+Zj
+SU
+zT
+xf
+Oi
+HY
+qp
+BG
+BG
+Wr
+dK
+gA
+Rp
+Yr
+fj
+kh
+Zj
+Zj
+oj
+QE
+QE
+SU
+"}
+(25,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+NE
+Xz
+Xz
+hT
+Fl
+Hr
+Hr
+Qb
+sS
+Zj
+Tk
+SU
+VF
+zs
+SU
+El
+Zj
+VF
+Zj
+Tv
+SU
+SU
+Zj
+SU
+Zj
+SU
+Xq
+rp
+fj
+WK
+lD
+RF
+PA
+mK
+fj
+aT
+NA
+Ib
+fj
+HH
+Zj
+Zj
+QE
+QE
+QE
+SU
+"}
+(26,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+wh
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+Hr
+xa
+xa
+Hr
+nZ
+Hr
+Qb
+Qb
+sS
+Zj
+SU
+VF
+ig
+ig
+ig
+iQ
+ig
+ig
+VF
+VF
+SU
+SU
+Zj
+SU
+SU
+SU
+UR
+Wg
+fj
+fj
+aI
+Cj
+YU
+pq
+fj
+fj
+fj
+fj
+fj
+gl
+dh
+dh
+QE
+QE
+Cn
+SU
+"}
+(27,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+zD
+Kb
+Hr
+Hr
+Hr
+Qb
+mu
+jx
+Tk
+SU
+TY
+DK
+DK
+DK
+DK
+DK
+DK
+DK
+gP
+VF
+Zj
+Zj
+Tk
+SU
+SU
+fW
+SU
+Zj
+fj
+fj
+fj
+IK
+fj
+fj
+Vn
+Px
+fj
+SU
+SU
+SU
+Zj
+QE
+QE
+Cn
+SU
+"}
+(28,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+jE
+ZE
+Hr
+Qb
+Qb
+Qb
+VF
+aX
+SU
+SU
+ae
+DK
+ZV
+CB
+cs
+CB
+XK
+DK
+jC
+SU
+Zj
+Tk
+SU
+Zj
+Qn
+VF
+SU
+Zj
+Td
+fj
+kL
+AM
+YB
+qu
+bg
+jj
+fj
+HH
+SU
+SU
+SU
+QE
+QE
+RV
+SU
+"}
+(29,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hr
+Hr
+Hr
+Hr
+Qb
+Qb
+Qb
+SU
+CY
+SU
+SU
+xf
+Ha
+Hw
+Wb
+dO
+dO
+DG
+Ha
+Fn
+Cv
+UR
+SU
+Tk
+VO
+Qn
+hR
+VF
+SU
+Bp
+Oi
+Nl
+fA
+qu
+Yc
+Aa
+UE
+fj
+HH
+SU
+VF
+VF
+QE
+QE
+QE
+SU
+"}
+(30,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+aP
+nC
+Tk
+Tk
+VF
+sJ
+Ha
+EE
+yu
+pf
+Rt
+zZ
+DK
+Vz
+VF
+SU
+VO
+Ci
+Tk
+Ci
+Zx
+oF
+Xe
+lT
+fj
+Vx
+oD
+qu
+Yc
+Tp
+gY
+fj
+HH
+VF
+VF
+zs
+oj
+QE
+QE
+SU
+"}
+(31,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+mu
+VF
+Qb
+Qb
+Qb
+Zj
+VF
+rR
+uf
+Tk
+Tk
+VF
+IM
+DK
+js
+Yn
+Xg
+tj
+gI
+DK
+DK
+pv
+Xq
+zT
+oQ
+uA
+jQ
+hR
+vf
+hD
+Sf
+fj
+fj
+pm
+wl
+wl
+fj
+fj
+fj
+HH
+dG
+VF
+mu
+QE
+QE
+QE
+SU
+"}
+(32,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+zs
+VF
+SU
+SU
+SU
+Zj
+Zj
+VF
+zs
+KM
+SU
+Zj
+SU
+Xe
+if
+DK
+DK
+DK
+Xb
+ly
+DK
+DK
+DK
+Ex
+SU
+Xe
+YA
+SU
+ZC
+VF
+zs
+Zj
+VF
+Zj
+fj
+fj
+fj
+fj
+fj
+Sp
+iB
+VF
+VF
+VF
+VF
+QE
+QE
+SU
+SU
+"}
+(33,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+dG
+VF
+OQ
+pQ
+OQ
+OQ
+OQ
+OQ
+SU
+VF
+VF
+aX
+VF
+SU
+SU
+nw
+Zj
+Td
+DK
+RZ
+Ks
+uU
+jK
+PC
+DK
+AQ
+Qn
+uA
+Xn
+SU
+Ci
+wT
+VF
+NZ
+VF
+Zj
+Qb
+iB
+iB
+po
+Zj
+Zj
+Zj
+VF
+VF
+kB
+Zj
+QE
+QE
+SU
+SU
+"}
+(34,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+hy
+Pn
+Uo
+at
+at
+iF
+Tk
+Zj
+Tk
+aX
+JZ
+Tk
+Zj
+VF
+VF
+Ro
+jO
+wz
+YC
+Xx
+cW
+wk
+jO
+Fn
+Zj
+SU
+Xn
+fv
+SU
+Ci
+ZC
+VF
+VF
+Qb
+Qb
+Qb
+Zj
+Al
+Zj
+zs
+VF
+VF
+VF
+VF
+Zj
+QE
+QE
+SU
+SU
+"}
+(35,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+hy
+XA
+Uo
+qm
+zd
+jB
+Tk
+Zj
+SU
+EC
+mI
+UR
+Zj
+Zj
+VF
+OT
+jO
+kt
+xh
+Vo
+Zo
+Dc
+DK
+fO
+Rs
+Xn
+Ci
+Zj
+Ci
+Ci
+jQ
+hR
+Ww
+Qb
+Qb
+Qb
+SU
+Al
+SU
+VF
+kB
+VF
+VF
+VF
+Zj
+QE
+QE
+QE
+SU
+"}
+(36,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+Qb
+Qb
+VF
+VF
+VF
+vv
+OQ
+Mv
+OQ
+OQ
+OQ
+OQ
+VF
+VF
+dR
+ad
+OR
+KI
+VF
+Zj
+uv
+Af
+DK
+sz
+mf
+rK
+DP
+sB
+DK
+jC
+is
+sv
+jz
+fv
+jQ
+SU
+Ci
+VF
+Qb
+Qb
+Qb
+Qb
+SU
+QE
+Zj
+VF
+ie
+VF
+VF
+kB
+VF
+oj
+QE
+QE
+SU
+"}
+(37,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Qb
+Qb
+VF
+mu
+Qu
+SU
+OQ
+kQ
+og
+Am
+AB
+OQ
+OQ
+Tq
+od
+OQ
+OQ
+SU
+Mb
+vZ
+ui
+dB
+cO
+Wl
+qP
+lZ
+MP
+qX
+NW
+Fg
+lp
+gj
+VR
+jQ
+jQ
+hR
+hR
+Qb
+Qb
+Qb
+Qb
+Zj
+SU
+GF
+Zj
+mu
+VF
+VF
+VF
+VF
+VF
+QE
+QE
+QE
+SU
+"}
+(38,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+zs
+VF
+SU
+NP
+OQ
+AY
+EU
+FH
+bN
+OQ
+PS
+nG
+Cg
+WI
+OQ
+OQ
+DY
+Zj
+Zj
+Jq
+DK
+Nn
+UB
+KQ
+jD
+ls
+DK
+YS
+Ci
+Zj
+YL
+uA
+Ir
+EA
+Da
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+GF
+Zj
+VF
+VF
+VF
+VF
+VF
+VF
+QE
+QE
+jU
+SU
+"}
+(39,1,1) = {"
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+OQ
+OQ
+XV
+rj
+kK
+CU
+OQ
+AC
+SQ
+NN
+yb
+FU
+OQ
+of
+Tk
+Tk
+NP
+DK
+DK
+DK
+DK
+DK
+DK
+DK
+ij
+Ci
+Xq
+PO
+fv
+EA
+nw
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+GF
+VF
+VF
+VF
+zs
+VF
+VF
+dG
+QE
+QE
+jU
+SU
+"}
+(40,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Hh
+CV
+hV
+Pz
+SZ
+Hh
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+OQ
+JY
+hE
+iP
+Ht
+YV
+OQ
+nR
+ER
+lr
+GG
+Tz
+vj
+gD
+mS
+Tk
+Zj
+if
+KF
+Nc
+VF
+VF
+Yu
+Yu
+hR
+VF
+fv
+Qn
+Qn
+cY
+hR
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+QE
+Zj
+Zj
+VF
+VF
+VF
+VF
+VF
+QE
+QE
+jU
+SU
+"}
+(41,1,1) = {"
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Fv
+Qb
+Hh
+kl
+qn
+QH
+VI
+Hh
+wn
+YZ
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+VF
+Zj
+OQ
+JY
+mx
+SV
+DB
+KG
+OQ
+Rv
+AS
+pk
+yb
+KZ
+vj
+gD
+Zj
+Zj
+Zj
+Tk
+VF
+Zj
+Tk
+Tk
+SU
+Li
+ut
+Zj
+jQ
+hR
+VF
+Cv
+hR
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+Zj
+Al
+SU
+Zj
+Zj
+ie
+kB
+zs
+VF
+QE
+QE
+QE
+SU
+"}
+(42,1,1) = {"
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Hh
+Jc
+Jc
+NL
+Hh
+Hh
+Kf
+yZ
+LL
+gk
+Hh
+Qb
+Qb
+VF
+Zj
+SU
+OQ
+OQ
+OQ
+nI
+OQ
+OQ
+OQ
+kO
+dE
+BD
+zg
+ts
+vj
+gD
+Tk
+Tk
+SU
+Tk
+Tk
+Tk
+SU
+Tk
+Tk
+Ao
+Tk
+Zj
+Xn
+Ci
+gC
+hR
+Zj
+VF
+Qb
+Qb
+Qb
+VF
+Zj
+Zj
+Al
+SU
+ac
+Zj
+VF
+VF
+VF
+VF
+oj
+QE
+QE
+SU
+"}
+(43,1,1) = {"
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+Qd
+Tt
+Ve
+Hh
+RW
+wL
+ou
+Pz
+sc
+Hh
+Qb
+Zj
+VF
+Tv
+SU
+OQ
+Ar
+mo
+nX
+Oy
+OQ
+hL
+iX
+GN
+FD
+Bj
+tK
+OQ
+oY
+Tk
+SU
+SU
+VF
+SU
+DU
+NZ
+Zj
+Zj
+uA
+hR
+lp
+jQ
+YL
+Ci
+fv
+GS
+Zj
+Qb
+Qb
+Qb
+Zj
+Zj
+Zj
+ab
+TY
+TY
+TY
+Zj
+VF
+VF
+VF
+QE
+QE
+QE
+SU
+"}
+(44,1,1) = {"
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+Qb
+Qb
+Fv
+Hh
+Hh
+Hh
+EQ
+Hh
+gQ
+Ve
+iL
+Gl
+OP
+Hh
+Qb
+Zj
+Zj
+Zj
+SU
+OQ
+uG
+CN
+FY
+xI
+OQ
+tY
+wd
+VD
+Hx
+pY
+OQ
+OQ
+vE
+SU
+Zj
+ig
+sF
+qT
+SS
+xO
+gP
+VF
+ZC
+hR
+LS
+fv
+Tk
+jQ
+uA
+ym
+Zj
+VF
+Qb
+Zj
+Zj
+Zj
+SU
+Qt
+Qt
+Qt
+Qt
+Qt
+Zj
+VF
+zs
+QE
+QE
+VF
+SU
+"}
+(45,1,1) = {"
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Qb
+Qb
+Hh
+PZ
+cw
+aC
+mz
+Hh
+Hh
+EQ
+Hh
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+SU
+SU
+OQ
+Ar
+Ur
+ox
+mV
+OQ
+gU
+vr
+Tx
+sQ
+kY
+OQ
+SU
+sS
+Zj
+Zj
+Dg
+Dg
+EW
+EW
+Dg
+Dg
+zs
+hR
+bz
+Ph
+fv
+SU
+Zj
+tI
+wT
+hR
+VF
+VF
+Zj
+Zj
+vv
+Qt
+Qt
+Wt
+FL
+Wt
+Qt
+Qt
+gP
+VF
+QE
+QE
+VF
+SU
+"}
+(46,1,1) = {"
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+Hh
+cw
+Ie
+GV
+SX
+Ia
+VW
+WZ
+Kw
+JC
+Rj
+Hh
+Qb
+Qb
+VF
+VF
+dG
+OQ
+uG
+Ur
+Be
+nD
+OQ
+OQ
+vj
+OQ
+vj
+OQ
+OQ
+VF
+vY
+MY
+Dg
+Dg
+Sl
+ol
+sg
+uC
+Dg
+Dg
+VL
+lp
+xY
+Qn
+YL
+fv
+LE
+rW
+lp
+Ww
+VF
+SU
+SU
+NP
+Qt
+fY
+Wt
+FL
+Wt
+fY
+Qt
+Yu
+VF
+QE
+QE
+SU
+SU
+"}
+(47,1,1) = {"
+Qb
+Qb
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Gp
+lu
+FM
+Sm
+Ef
+gh
+LP
+BW
+eI
+xQ
+nM
+Hh
+Hh
+Hh
+Qb
+zs
+VF
+OQ
+OQ
+Xj
+Xj
+OQ
+OQ
+Qg
+MG
+uE
+MG
+JR
+cl
+VF
+eQ
+Ax
+Dg
+au
+NT
+rh
+bJ
+Ta
+Qa
+Dg
+aZ
+hR
+Zj
+Tk
+SU
+fv
+Re
+SU
+jQ
+hR
+VF
+SU
+SU
+SU
+mO
+Ne
+FL
+FL
+FL
+Wt
+Wt
+VF
+kB
+QE
+QE
+QE
+SU
+"}
+(48,1,1) = {"
+Qb
+Hh
+Hh
+Kj
+gL
+Qh
+Hh
+Hh
+ul
+VW
+td
+cn
+nh
+qw
+en
+yz
+gR
+ht
+bF
+BO
+Rq
+Hh
+Fv
+Fv
+Zj
+if
+Py
+uE
+MG
+Vq
+zw
+SU
+SU
+SU
+OY
+SU
+SU
+XW
+eQ
+gZ
+HT
+ec
+Sq
+Xs
+fN
+Ot
+mp
+Dg
+mu
+VF
+Cv
+Pe
+SU
+YL
+fv
+Zj
+Ge
+zs
+Zj
+Zj
+Zj
+SU
+mO
+Wt
+KY
+FL
+FL
+uj
+Wt
+VF
+VF
+oj
+QE
+QE
+SU
+"}
+(49,1,1) = {"
+Qb
+Hh
+QR
+EO
+iu
+pe
+Hh
+vu
+qO
+ny
+Ev
+Hh
+pA
+cn
+jT
+Hh
+MD
+vX
+WZ
+vX
+kZ
+Hh
+aw
+Un
+Zj
+VF
+Zj
+VF
+SU
+Wc
+Lj
+zT
+dw
+VF
+Tk
+Zj
+vH
+SU
+xC
+Bt
+Dg
+ki
+vG
+pC
+sm
+Bx
+xq
+Dg
+Dg
+gP
+hR
+Tk
+jQ
+YL
+jQ
+jQ
+uA
+wT
+Zj
+Zj
+SU
+SU
+Qt
+FL
+CH
+HP
+ql
+KU
+Qt
+dG
+VF
+QE
+QE
+QE
+SU
+"}
+(50,1,1) = {"
+Qb
+Hh
+Aw
+jT
+zO
+du
+Hh
+Zv
+Zl
+fR
+Zt
+JE
+fQ
+jT
+jT
+oO
+bS
+VW
+WZ
+ju
+VX
+hz
+zz
+Rd
+Tk
+Zj
+Tk
+Tk
+Tk
+Je
+PW
+OU
+Tk
+Tk
+SU
+Zj
+Tk
+sK
+nE
+Dg
+Dg
+Dg
+VS
+Dg
+Dg
+Dg
+BH
+Dg
+Dg
+gP
+hR
+hR
+SU
+ZC
+jQ
+Sb
+Ci
+jQ
+Qb
+SU
+TY
+Qt
+Qt
+FO
+Wt
+hC
+XB
+cU
+Qt
+Qt
+gP
+QE
+QE
+Cn
+SU
+"}
+(51,1,1) = {"
+Qb
+Hh
+As
+jT
+md
+RJ
+Eg
+vx
+hw
+RO
+Hd
+Mw
+pr
+pi
+uk
+Dm
+uR
+fk
+Wh
+ht
+ht
+Nu
+MW
+zm
+Zj
+Zj
+Zj
+Zj
+Zj
+SU
+SU
+Tk
+SU
+Zj
+Zj
+SU
+SU
+SU
+CR
+Dg
+FP
+Te
+EM
+QK
+Dg
+XR
+TU
+gT
+Dg
+uX
+ZC
+ZC
+Ci
+VR
+uA
+Qn
+jQ
+Qb
+Qb
+SU
+NP
+Qt
+Qt
+Dh
+Wt
+Wt
+We
+uW
+Qt
+Qt
+Yu
+QE
+QE
+Cn
+SU
+"}
+(52,1,1) = {"
+Qb
+Hh
+bI
+jT
+eN
+nY
+Hh
+Zv
+ic
+ye
+NF
+vU
+lg
+jT
+fH
+am
+MD
+Pa
+SX
+VW
+sR
+Fe
+Mj
+sw
+Tk
+VF
+EA
+nw
+Tk
+SU
+Zj
+Zj
+Zj
+hQ
+Tk
+SU
+Zj
+Zj
+cR
+Dg
+gT
+qe
+Nq
+Jt
+Dg
+Cw
+an
+FP
+xB
+Fn
+ZC
+Tk
+hR
+fv
+jQ
+Qn
+hR
+Qb
+Qb
+Zj
+SU
+SU
+Qt
+yo
+Wt
+Wt
+PH
+PN
+Qt
+VF
+VF
+QE
+QE
+Cn
+SU
+"}
+(53,1,1) = {"
+Qb
+Hh
+SL
+SA
+xM
+du
+Hh
+xk
+zi
+SF
+ov
+Hh
+pA
+jT
+qw
+Hh
+MD
+Pa
+xz
+lk
+Mg
+Hh
+cQ
+cQ
+FV
+VF
+VF
+SU
+Zj
+CO
+Xk
+Wc
+SU
+zT
+Oo
+Zj
+Zj
+VF
+CR
+Dg
+yy
+Dn
+ZU
+gT
+Dg
+To
+WE
+Sy
+xB
+Fn
+Ci
+SU
+Qn
+YL
+VR
+Ci
+Qn
+Qb
+Qb
+Qb
+SU
+SU
+ia
+Wt
+HP
+FL
+FL
+FL
+Wt
+VF
+mu
+QE
+QE
+QE
+SU
+"}
+(54,1,1) = {"
+Qb
+Hh
+Hh
+kq
+Sw
+jJ
+Hh
+Hh
+QT
+EB
+cG
+JE
+Kg
+qw
+Go
+mQ
+wB
+GH
+GO
+Kp
+sX
+Hh
+Fv
+Fv
+VF
+gn
+OR
+OR
+ct
+SU
+dk
+aP
+SU
+CJ
+VF
+Zj
+VF
+VF
+ph
+Dg
+Dg
+xB
+xB
+Dg
+Dg
+FP
+gT
+Tj
+Dg
+fO
+jQ
+Xn
+Qn
+TN
+Ci
+jQ
+mZ
+Qb
+Qb
+SU
+SU
+SU
+ia
+Wt
+KY
+Wt
+FL
+Wt
+Wt
+VF
+VF
+oj
+QE
+QE
+SU
+"}
+(55,1,1) = {"
+Qb
+Qb
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Fu
+aJ
+ky
+Io
+Gm
+Pj
+Qv
+PE
+qA
+fT
+Tg
+qH
+qH
+Hh
+Qb
+Qb
+qN
+Da
+UW
+gP
+Fa
+Zj
+TY
+cd
+VF
+VF
+VF
+VF
+SU
+SU
+aX
+NP
+Ug
+uE
+uE
+kh
+Dg
+Dg
+Dg
+Dg
+Dg
+Yu
+Ci
+Ci
+jQ
+fv
+Ci
+Ci
+Qn
+Qb
+Qb
+SU
+SU
+TY
+Qt
+zc
+JK
+Wt
+Wt
+zc
+Qt
+hr
+VF
+QE
+QE
+QE
+SU
+"}
+(56,1,1) = {"
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+Hh
+mn
+aJ
+VW
+WZ
+nx
+IV
+WZ
+fI
+JC
+QY
+re
+xA
+xA
+Qb
+Qb
+Qb
+qN
+hP
+hP
+Et
+rG
+hP
+hP
+VF
+WN
+hr
+dG
+dR
+Ii
+xD
+mG
+Zj
+Zj
+Zj
+SU
+SU
+Yu
+Ns
+iB
+iB
+Zj
+SU
+jQ
+YL
+Qn
+Ci
+Qn
+Zj
+SU
+SU
+SU
+SU
+NP
+Qt
+Qt
+Wt
+Wt
+JK
+Qt
+Qt
+iB
+wX
+wX
+QE
+SU
+SU
+"}
+(57,1,1) = {"
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Qb
+Qb
+Hh
+PZ
+mn
+dD
+Cp
+Hh
+Hh
+EQ
+Hh
+Hh
+Hh
+Hh
+zM
+xA
+xA
+Qb
+Qb
+Qb
+hP
+Mq
+qD
+xN
+fG
+hP
+Zj
+hP
+hP
+Jj
+zY
+hP
+hP
+VF
+FC
+Zj
+SU
+SU
+Zj
+Zj
+Zj
+Zj
+SU
+Bs
+SU
+SU
+SU
+jQ
+Qn
+Zj
+Zj
+SU
+El
+SU
+SU
+SU
+SU
+Qt
+Qt
+Qt
+Qt
+Qt
+wX
+wX
+wX
+wX
+wX
+wX
+SU
+"}
+(58,1,1) = {"
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+Qb
+Qb
+Hh
+Hh
+Hh
+Hh
+EQ
+Hh
+rC
+Ve
+iL
+xu
+Gl
+Hh
+Qb
+mt
+xA
+Qb
+Qb
+hP
+hP
+vC
+Qx
+Qx
+kj
+hP
+hP
+hP
+AH
+GK
+wv
+zF
+hP
+hP
+YR
+WO
+Zj
+VF
+VF
+Zj
+Zj
+Zj
+SU
+Zj
+El
+SU
+SU
+Tk
+Zj
+Qn
+Zj
+SU
+SU
+Hn
+SU
+SU
+SU
+SU
+HH
+HH
+iB
+iB
+wX
+wX
+wX
+wX
+wX
+wX
+wX
+"}
+(59,1,1) = {"
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+yE
+xy
+gJ
+Hh
+dv
+IX
+ou
+sc
+Pz
+Hh
+Qb
+xA
+xA
+xA
+Qb
+hP
+AR
+Rh
+rU
+Tf
+Zy
+AR
+hP
+eU
+bt
+ot
+Ll
+QQ
+xb
+hP
+TJ
+sb
+hi
+na
+tL
+oK
+dT
+bE
+sy
+gp
+hi
+OR
+ct
+Tk
+Zj
+Zj
+Zj
+Zj
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Zj
+wX
+wX
+wX
+wX
+wX
+wX
+wX
+"}
+(60,1,1) = {"
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Hh
+Wn
+yT
+Xd
+Hh
+Hh
+Kf
+yZ
+zQ
+Gl
+Hh
+Qb
+xA
+xA
+Qb
+Qb
+hP
+IP
+IP
+IP
+IP
+uy
+AE
+DX
+zL
+PQ
+Yo
+hW
+VV
+wD
+hP
+Yu
+Zj
+SU
+VF
+hA
+hA
+Lk
+Lk
+hA
+hA
+Zj
+Zj
+aX
+SU
+Tk
+Zj
+Zj
+uf
+So
+aP
+SU
+in
+SU
+aP
+SU
+SU
+SU
+Zj
+Zj
+Zj
+wX
+wX
+wX
+wX
+SU
+"}
+(61,1,1) = {"
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Fv
+Qb
+Hh
+VN
+Ew
+MR
+MX
+Hh
+BX
+aO
+Hh
+Hh
+Hh
+Qb
+xA
+xA
+Qb
+Qb
+hP
+lo
+Wa
+Wa
+Wa
+lo
+Wa
+Lc
+Um
+qo
+Zi
+nd
+VV
+Au
+hP
+Yu
+Zj
+SU
+hA
+hA
+SB
+pw
+pO
+Hz
+hA
+hA
+VF
+jx
+SU
+Zj
+Zj
+Tk
+db
+SU
+SU
+aP
+So
+SU
+SU
+SU
+El
+SU
+Zj
+Zj
+SU
+SU
+QE
+QE
+jU
+SU
+"}
+(62,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Hh
+yE
+iA
+dt
+kk
+Hh
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+hP
+KE
+pX
+Uc
+Zd
+tt
+pX
+hP
+Xc
+zR
+iJ
+QD
+Ce
+uO
+hP
+HH
+SU
+NP
+hA
+Ah
+Ko
+ik
+kx
+Zw
+cK
+hA
+QB
+sS
+Zj
+Zj
+Tk
+Tk
+SU
+aP
+sf
+oS
+zj
+Gj
+Ex
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+QE
+QE
+jU
+SU
+"}
+(63,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+hP
+WQ
+nP
+YY
+cz
+Lh
+GX
+hP
+Js
+oN
+eT
+hP
+LH
+hP
+hP
+hP
+SU
+xV
+hA
+Eo
+jr
+yV
+qU
+ST
+uZ
+hA
+CF
+Jo
+SU
+Tk
+Tk
+SU
+SU
+vK
+Vr
+RS
+mb
+vK
+vK
+SU
+aP
+eg
+SU
+SU
+SU
+SU
+QE
+QE
+jU
+SU
+"}
+(64,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+hP
+hP
+hP
+hP
+hP
+hP
+hP
+hP
+hP
+LH
+hP
+hP
+Xw
+Qz
+ET
+hP
+Yu
+yL
+Lk
+rs
+Jh
+UV
+mJ
+pS
+ZR
+It
+sN
+UF
+vZ
+OR
+hi
+ct
+Vr
+fn
+NG
+kv
+Ft
+fn
+qb
+SU
+Uy
+TY
+KL
+SU
+SU
+SU
+QE
+QE
+QE
+SU
+"}
+(65,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+hP
+ET
+ml
+qD
+yh
+hP
+ET
+OG
+De
+Bo
+hP
+Yu
+yL
+Qm
+qk
+co
+qU
+Ed
+bC
+yO
+hA
+Nj
+gz
+SU
+Tk
+Zj
+aX
+Vr
+Eu
+wc
+qY
+JF
+OJ
+vK
+vK
+BK
+vK
+vK
+SU
+SU
+SU
+oj
+QE
+QE
+SU
+"}
+(66,1,1) = {"
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+Qb
+Qb
+Fv
+Fv
+Fv
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+hP
+Bo
+ag
+pa
+ZN
+hP
+Bo
+vT
+dz
+eE
+hP
+iB
+Fh
+hA
+dW
+UJ
+Pl
+Sc
+lR
+Gi
+hA
+EY
+Ly
+bq
+Tk
+QP
+LQ
+vK
+Vf
+Eu
+cL
+Dr
+Ay
+vK
+WV
+Ga
+fn
+vK
+vK
+SU
+SU
+QE
+QE
+QE
+SU
+"}
+(67,1,1) = {"
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+hP
+hP
+gO
+Bo
+ET
+hP
+hP
+Jj
+hP
+hP
+hP
+iB
+NP
+hA
+Kk
+oy
+bH
+Qi
+pE
+jt
+hA
+Sk
+Bs
+Zj
+Tk
+BY
+VY
+Ji
+Gx
+tX
+HU
+dx
+Ki
+vK
+Cz
+za
+Gy
+Ga
+vK
+HH
+SU
+QE
+QE
+SU
+SU
+"}
+(68,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+hP
+hP
+hP
+Jj
+hP
+dG
+VF
+Sp
+SG
+VF
+SU
+NP
+hA
+hA
+do
+hA
+hA
+hA
+fZ
+hA
+hA
+sI
+Zj
+SU
+ld
+Jq
+vK
+jR
+io
+Ae
+Jx
+sn
+TS
+Ym
+yX
+Eu
+sW
+vK
+HH
+VF
+QE
+QE
+SU
+SU
+"}
+(69,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Yu
+Yu
+zs
+VF
+VF
+VF
+VF
+VF
+VF
+SU
+hA
+hA
+Xo
+iR
+uT
+hA
+rm
+jt
+Id
+hA
+hA
+Ex
+Zj
+SU
+TY
+vK
+op
+Eu
+nj
+JF
+IE
+vK
+fn
+Jd
+lb
+Oz
+vK
+Yu
+VF
+QE
+QE
+SU
+SU
+"}
+(70,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Zj
+VF
+Ww
+VF
+VF
+VF
+SU
+SU
+VF
+VF
+NP
+hA
+uT
+oH
+Vw
+Ca
+hA
+Me
+EF
+yd
+hY
+hA
+Pm
+SU
+SU
+SU
+vK
+vK
+yk
+gr
+ro
+QX
+vK
+Az
+eA
+Fi
+lb
+vK
+Yu
+Ww
+QE
+QE
+QE
+SU
+"}
+(71,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Zj
+Zj
+VF
+mu
+VF
+VF
+SU
+SU
+El
+SU
+SU
+Sp
+hA
+FI
+Xy
+zx
+lM
+hA
+tk
+NY
+et
+IS
+Lk
+sl
+SU
+xo
+xo
+TY
+vK
+vK
+vK
+oC
+vK
+vK
+ap
+HD
+ej
+vK
+vK
+Yu
+dG
+oj
+QE
+QE
+SU
+"}
+(72,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Zj
+Zj
+Zj
+VF
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Sp
+hA
+hA
+hA
+Lk
+hA
+hA
+dV
+Cd
+AJ
+cF
+hA
+bm
+SU
+xo
+xo
+TY
+vK
+Xr
+wu
+NS
+ir
+vK
+vK
+vK
+vK
+vK
+SU
+mu
+Da
+QE
+QE
+QE
+SU
+"}
+(73,1,1) = {"
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+AG
+bj
+AG
+xA
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+zm
+Zj
+Tv
+Zj
+Zj
+SU
+SU
+SU
+SU
+SU
+Up
+SU
+Zj
+Zj
+iB
+Ac
+gK
+kh
+hA
+hA
+rI
+Kx
+hA
+hA
+HH
+xo
+qt
+xo
+GP
+vK
+CW
+TI
+PY
+yC
+vK
+NP
+NP
+NP
+SU
+SU
+VF
+VF
+QE
+QE
+Cn
+SU
+"}
+(74,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+AG
+AG
+vI
+AG
+AG
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Zj
+Zj
+Zj
+Zj
+yF
+yH
+ln
+pN
+YI
+SU
+SU
+Zj
+Zj
+Zj
+VF
+Ww
+VF
+Zj
+hA
+hA
+hA
+hA
+VF
+VF
+VF
+xo
+xo
+xo
+vK
+vK
+Vh
+hl
+ka
+vK
+HH
+SU
+SU
+SU
+VF
+Ww
+VF
+QE
+QE
+RV
+SU
+"}
+(75,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+kR
+eD
+tr
+MA
+lN
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+Zj
+rM
+YI
+Rf
+aG
+Jb
+ku
+SU
+SU
+Zj
+Zj
+Qu
+SU
+VF
+VF
+mu
+VF
+Yu
+Yu
+Yu
+VF
+mu
+SU
+xo
+xo
+xo
+xo
+vK
+vK
+JB
+vK
+vK
+HH
+SU
+SU
+VF
+VF
+dG
+VF
+QE
+QE
+RV
+SU
+"}
+(76,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+Gb
+cD
+Zn
+jw
+mH
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+VF
+VF
+yA
+ku
+Hf
+ve
+zv
+ku
+Lp
+Zj
+Zj
+Zj
+SU
+SU
+VF
+zs
+Ww
+VF
+VF
+Da
+zs
+VF
+VF
+SU
+xo
+xo
+SU
+xo
+NP
+HH
+SU
+NP
+HH
+SU
+SU
+VF
+Ww
+VF
+VF
+Ww
+QE
+QE
+QE
+SU
+"}
+(77,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+Qb
+Qb
+Qb
+Qb
+Qb
+Qb
+xA
+xA
+xA
+pg
+AG
+Of
+AG
+pg
+xA
+xA
+xA
+Qb
+Qb
+Qb
+Qb
+Qb
+Fv
+QE
+VF
+RN
+Hj
+JS
+LA
+ve
+Df
+JS
+eM
+MT
+Zj
+SU
+SU
+SU
+VF
+Da
+VF
+VF
+VF
+VF
+SU
+oj
+lf
+lf
+lf
+Es
+lf
+oj
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+Da
+VF
+VF
+VF
+QE
+QE
+QE
+SU
+"}
+(78,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+qN
+qN
+qN
+xA
+xo
+AG
+bj
+AG
+xo
+xo
+SU
+xo
+SU
+qN
+Qb
+Qb
+Qb
+Fv
+QE
+SU
+SU
+iT
+bW
+AP
+Tw
+Fs
+DR
+nq
+Zj
+oj
+QE
+QE
+QE
+QE
+QE
+oj
+QE
+QE
+QE
+QE
+QE
+Hp
+Nh
+Nh
+Nh
+Nh
+QE
+QE
+QE
+QE
+QE
+QE
+oj
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+jU
+SU
+"}
+(79,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+xo
+xo
+xo
+xo
+xo
+SU
+SU
+SU
+SU
+qN
+qN
+Qb
+Qb
+QE
+QE
+QE
+SU
+SU
+YH
+lw
+ve
+Ei
+YH
+SU
+Zj
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+ud
+Nh
+Hp
+Nh
+KJ
+Cn
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+QE
+jU
+SU
+"}
+(80,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+xo
+xo
+xo
+xo
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+QE
+QE
+SU
+SU
+SU
+YH
+dP
+ve
+Ei
+YH
+SU
+QE
+QE
+QE
+jU
+jU
+LI
+QE
+QE
+QE
+SU
+SU
+QE
+QE
+Hp
+Nh
+oG
+Er
+Ox
+SU
+Up
+Cn
+RV
+Cn
+QE
+QE
+QE
+SU
+SU
+SU
+QE
+QE
+jU
+SU
+DI
+SU
+"}
+(81,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+ku
+gi
+kC
+YJ
+ku
+SU
+SU
+Zj
+Zj
+Zj
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+oj
+lf
+oG
+oG
+VP
+oG
+lm
+RX
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+"}
+(82,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+kV
+JS
+ku
+MC
+ku
+JS
+RQ
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+IF
+uQ
+Bm
+iw
+nz
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(83,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+Mn
+jH
+Xt
+bs
+DC
+qj
+gW
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+KD
+un
+XS
+Vk
+EL
+SU
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(84,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+YH
+oh
+NV
+Na
+YH
+SU
+SU
+SU
+Zj
+SU
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+SU
+ev
+oG
+or
+oG
+ev
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(85,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+ku
+Su
+Su
+Su
+ku
+SU
+Zj
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+oG
+Er
+oG
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(86,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+Zj
+SU
+Zj
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+SU
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(87,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+Zj
+Zj
+SU
+SU
+SU
+Zj
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+SU
+SU
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(88,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(89,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}
+(90,1,1) = {"
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+wh
+"}

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -899,6 +899,20 @@
 	cost = 3
 	ruin_tags = list(RUIN_TAG_HARD_COMBAT, RUIN_TAG_MEDIUM_LOOT, RUIN_TAG_SHELTER)
 
+/datum/map_template/ruin/whitesands/nomads_stop
+	name = "Hermit Nomads Stop"
+	id = "nomads-stop"
+	description = "A set of structures born of ancient prefabs and quick-pour cement, turned into a place for trade on the planet's surface."
+	suffix = "whitesands_surface_nomads_stop.dmm"
+	cost = 3
+
+/datum/map_template/ruin/whitesands/settlements_raid
+	name = "Frontier Settlement Raid"
+	id = "settlements-raid"
+	description = "A settlement leading a solitary salvaging life under the direction of a former Gorlex Marauder, now being raided by the brutal Frontiersmen Fleet."
+	suffix = "whitesands_surface_settlement_raid.dmm"
+	cost = 4
+
 //							///
 //		MARK: Plasma
 //							///


### PR DESCRIPTION
## Описание / Что этот PR делает
Перенос оффовских руин для песчаной планеты.
## Причина создания ПР / Почему это хорошо для игры
Хорошо сделанные руины, расширение пулла.
## Демонстрация изменений / Тестирование
<img width="2880" height="2400" alt="image" src="https://github.com/user-attachments/assets/117fa04b-4f24-4cbb-a11b-a40abc19f8e7" />
<img width="1920" height="1600" alt="image" src="https://github.com/user-attachments/assets/70c3f727-bfed-4d6b-8de7-9f82173ca75b" />

## Список изменений

```yml
🆑
map: добавляет на песок Settelment Raid, Nomads Stop.
/🆑
```
