### PR TITLE
FIX-BALANCE: 8x58 больше не имеет рандомные характеристики.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -124,14 +124,6 @@
 */
 //[/СELADON-REMOVE]
 
-// 8x58mm caseless (SG-669)
-
-/obj/projectile/bullet/a858
-	name = "8x58mm caseless bullet"
-	speed = 0.3
-	damage = 35
-	armour_penetration = 40
-
 // .299 Eoehoma Caseless (E-40)
 
 /obj/projectile/bullet/c299


### PR DESCRIPTION
## Описание / Что этот PR делает
У нас в коркоде был участок кода, который оффами был удален год назад. Этот пр чистит этот участок кода и фиксит калибр 8x58, который до этого имел неверные характеристики из-за этого участка кода.
ЕСЛИ ЧТО ЭТО СНАЙПЕРСКИЙ КАЛИБР
## Причина создания ПР / Почему это хорошо для игры
Фиксы.
## Демонстрация изменений / Тестирование
Скрины не грузятся. Файл у оффов. https://github.com/shiptest-ss13/Shiptest/blob/master/code/modules/projectiles/projectile/bullets/rifle.dm
## Список изменений

```yml
🆑
fix: Характеристики 8x58mm. Убран лишний участок кода, который рандомно оверрайдил данные его значения.
/🆑
```
