### PR TITLE
TWEAK: Maphelpers pipes - hidden pipes!

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -138,4 +138,4 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible
 	hide = FALSE
 	layer = GAS_PIPE_VISIBLE_LAYER
-	alpha = 255
+	alpha = 255	// [CELADON-ADD]

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -11,6 +11,7 @@
 	volume = 260
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
+	alpha = 128	// [CELADON-ADD]
 
 	FASTDMM_PROP(\
 		pipe_type = PIPE_TYPE_STRAIGHT,\
@@ -137,3 +138,4 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible
 	hide = FALSE
 	layer = GAS_PIPE_VISIBLE_LAYER
+	alpha = 255

--- a/code/modules/atmospherics/machinery/pipes/mapping.dm
+++ b/code/modules/atmospherics/machinery/pipes/mapping.dm
@@ -29,6 +29,7 @@
 	##Fulltype/hidden {					\
 		hide = TRUE;					\
 		FASTDMM_PROP(pipe_group = "atmos-[piping_layer]-"+Type+"-hidden");\
+		alpha = 128;					\
 	}									\
 	##Fulltype/hidden/layer2 {			\
 		piping_layer = 2;				\


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет прозрачность к скрытым трубам под полом для sDMM

## Причина создания ПР / Почему это хорошо для игры
Позволить меньше ошибаться мапперам где какая труба у них стоит.

## Демонстрация изменений / Тестирование
<img width="481" height="316" alt="image" src="https://github.com/user-attachments/assets/181853fa-0d12-4a32-88ce-b518742f2db6" />

## Список изменений

```yml
🆑
add: Визуальное отображение скрытых труб как прозрачных
/🆑
```
