### PR TITLE
FIX-NERF: Chameleon NO-PIXEL-SHIFT-ITEM

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -15,6 +15,22 @@
 	var/can_use = 1
 	var/obj/effect/dummy/chameleon/active_dummy = null
 	var/saved_appearance = null
+// [CELADON-ADD] - NO-PIXEL-SHIFT-ITEM
+	var/static/list/black_list_projector = list(
+		/obj/item/radio,
+		/obj/machinery/light,
+		/obj/machinery/newscaster,
+		/obj/machinery/airalarm,
+		/obj/machinery/firealarm,
+		/obj/machinery/button,
+		/obj/machinery/advanced_airlock_controller,
+		/obj/machinery/camera,
+		/obj/structure/mirror,
+		/obj/structure/extinguisher_cabinet,
+		/obj/structure/sign,
+		/obj/structure/closet/wall,
+		)
+// [/CELADON-ADD]
 
 /obj/item/chameleon/Initialize()
 	. = ..()
@@ -49,6 +65,8 @@
 		return
 	if(istype(target, /obj/structure/falsewall))
 		return
+	if(is_type_in_list(target, black_list_projector))	// [CELADON-ADD] - NO-PIXEL-SHIFT-ITEM
+		return											// [/CELADON-ADD]
 	if(target.alpha != 255)
 		return
 	if(target.invisibility != 0)


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет черный список предметов у холо-проектора в которые нельзя превращаться.

## Причина создания ПР / Почему это хорошо для игры
Превращение в смещенные пиксель-шифтом обьекты не является фичей, ломающей игровой баланс если превращаться в лампочку которая смешена на тайл в бок. Это не должно так работать.

## Список изменений

```yml
🆑
fix: Нефр голо-проектора
/🆑
```
