### PR TITLE
FIX: Чиним ИИ возможность записывать имена

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -128,7 +128,7 @@
 	return
 /atom/proc/AIShiftClick()
 	return
-/atom/proc/AICtrlShiftClick(mob/living/silicon/ai/user) // CELADON-EDIT (QoL)
+/atom/proc/AICtrlShiftClick(mob/living/silicon/ai/user) // [CELADON-EDIT] (QoL)
 	CtrlShiftClick(user)
 
 /* Airlocks */

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -128,8 +128,8 @@
 	return
 /atom/proc/AIShiftClick()
 	return
-/atom/proc/AICtrlShiftClick()
-	return
+/atom/proc/AICtrlShiftClick(mob/living/silicon/ai/user) // CELADON-EDIT (QoL)
+	CtrlShiftClick(user)
 
 /* Airlocks */
 /obj/machinery/door/airlock/AICtrlClick() // Bolts doors

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -111,6 +111,8 @@ CELADON_QOL_LOADOUT
 - EDIT `code\modules\mob\mob_helpers.dm`: `/proc/slur`
 - EDIT `code\modules\mob\mob_helpers.dm`: `/proc/stutter`
 
+- EDIT `code\_onclick\ai.dm` -> Чиним для ИИ возможность узнавать экипаж
+
 Радио для лежачих персонажей
 - EDIT `code/game/objects/items/devices/radio/radio.dm`: `/obj/item/radio/AltClick(mob/user)` - добавлен параметр `floor_okay = TRUE` в `canUseTopic`
 - EDIT `code/game/objects/items/devices/radio/radio.dm`: `/obj/item/radio/CtrlShiftClick(mob/user)` - добавлен параметр `floor_okay = TRUE` в `canUseTopic`


### PR DESCRIPTION


## Описание / Что этот PR делает
Чиним ИИ возможность давать имена экипажу И не ломает кнопку выставления экстренного доступа к шлюзам
## Причина создания ПР / Почему это хорошо для игры
Fix #2540
## Демонстрация изменений / Тестирование
<img width="1135" height="709" alt="image" src="https://github.com/user-attachments/assets/96fd19b8-88f7-4679-843f-1ba41bb22399" />

## Список изменений

```yml
🆑Azzy.Dreemurr
fix: ИИ вновь может на Ctrl+Shift+Click записывать имена кукол (при этом не ломая возможность активации экстренного доступа)
/🆑
```
