### PR TITLE
MAP: Space Ruins

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/onehalftwo.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/onehalftwo.dmm
@@ -1,0 +1,8214 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/capacitor,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"ak" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"aI" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"aJ" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"aK" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"aN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"aU" = (
+/obj/machinery/light/dim/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4;
+	welded = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"aV" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"aW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "refuelingbridge"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"aY" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelinghangar"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"aZ" = (
+/obj/item/storage/firstaid/brute{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/storage/firstaid/medical{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/structure/closet/crate/medical,
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/item/clothing/neck/stethoscope,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"bh" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"bi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"bj" = (
+/obj/structure/chair/bench/blue/directional/south,
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"bl" = (
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"bp" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"bD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/item/reagent_containers/food/drinks/coffee/empty{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"bE" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space)
+"bX" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"bZ" = (
+/mob/living/basic/hivebot/ranged,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"cb" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/mining{
+	dir = 4;
+	name = "Cargo"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "fuelingcargo"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"cg" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"ci" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"cj" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargospacewindow"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"cl" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"cv" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fuelingengineering"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"cz" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"cD" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"cG" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/item/paper_bin{
+	pixel_x = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"cL" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"dc" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "cargospacewindow"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"dh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "fuelingarea"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"du" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelhallwayturret"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"dz" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/cell/crap,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"dA" = (
+/obj/structure/chair/comfy/blue/corpo/directional/west,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"dC" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/cell/crap,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"dI" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/borderfloor{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"dL" = (
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/light/dim/directional/east,
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 9;
+	pixel_y = -20;
+	id = "cargospacewindow";
+	name = "Cargo Windows"
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/mining_scanner,
+/obj/item/mecha_parts/mecha_equipment/thrusters/ion,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"dP" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"dX" = (
+/obj/machinery/computer/atmos_control/tank/toxin_tank,
+/obj/effect/turf_decal/borderfloorblack,
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"en" = (
+/obj/effect/turf_decal/industrial/caution{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	piping_layer = 5;
+	icon_state = "pump_map-5"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"eq" = (
+/obj/structure/chair/comfy/blue/corpo/directional/west,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"et" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"ev" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"eA" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"eH" = (
+/obj/machinery/airalarm/directional/east,
+/obj/item/stack/tile/plasteel,
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fa" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"ff" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fh" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "fuelingengineering"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fj" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fk" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"fr" = (
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"fA" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"fP" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"fT" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	dir = 8;
+	piping_layer = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fU" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"fV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/analyzer{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"fW" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"fZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"gm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"gp" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"gr" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"gt" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "conveyors"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"gx" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"gB" = (
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"gE" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"gU" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelhallwayturret"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"ha" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"hb" = (
+/obj/effect/turf_decal/corner/opaque/white/three_quarters,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"hd" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"hg" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"hh" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"hq" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"hw" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"hy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/mono/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"hA" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom/wideband/table{
+	dir = 4
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"hG" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -22;
+	pixel_y = 9;
+	id = "fuelingarea";
+	name = "Refueling Shutters"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"hI" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/hivebotshuttle)
+"hT" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"hU" = (
+/obj/structure/filingcabinet/double{
+	dir = 1
+	},
+/obj/item/folder/documents,
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"ig" = (
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"ik" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "0";
+	pixel_x = -16;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"im" = (
+/obj/machinery/telecomms/relay/preset/nanotrasen,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"io" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"is" = (
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"it" = (
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"iv" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"ix" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"iF" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/end{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"iG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"iJ" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 8
+	},
+/obj/item/newspaper{
+	pixel_x = 11;
+	pixel_y = 14
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"iL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"iM" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/half,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4;
+	welded = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"iO" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-5"
+	},
+/obj/structure/cable{
+	icon_state = "5-6"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/mob/living/basic/hivebot/strong,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"iQ" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/crayon{
+	pixel_x = -8;
+	pixel_y = -34;
+	color = "#FF0000"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"iT" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"iW" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/space/stormtrooper/shotgun,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"iZ" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"jc" = (
+/obj/structure/frame,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/stock_parts/capacitor/quadratic,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/hivebotshuttle)
+"ji" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"jj" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"jv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/advanced_airlock_controller/directional/east,
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"jz" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/engineering,
+/obj/item/extinguisher/advanced{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/extinguisher/advanced{
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/item/watertank/atmos{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"jI" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"jO" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"jR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "fuelingsecurity"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"jS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"ka" = (
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/hivebotshuttle)
+"ke" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"km" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"kq" = (
+/obj/structure/closet/wall/red/directional/west,
+/obj/item/ammo_box/magazine/co9mm,
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = -4
+	},
+/obj/item/ammo_box/magazine/co9mm{
+	pixel_x = -9
+	},
+/obj/item/stock_parts/cell/gun/upgraded{
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/item/gun/energy/e_gun/e_old/iot{
+	pixel_y = -8
+	},
+/obj/item/gun/ballistic/automatic/pistol/challenger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/mono/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"kr" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"ku" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	piping_layer = 5;
+	icon_state = "mvalve_map-5"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"kC" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"kD" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"kK" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/engineering,
+/obj/item/circuitboard/machine/shuttle/engine/plasma,
+/obj/item/circuitboard/machine/shuttle/engine/plasma,
+/obj/item/circuitboard/machine/shuttle/heater,
+/obj/item/circuitboard/machine/shuttle/heater,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"kN" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"kQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"kR" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"kU" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"kV" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"lc" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	pixel_x = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"le" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"lj" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/turretid{
+	pixel_x = -1;
+	pixel_y = 3;
+	id = "fuelingpost"
+	},
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"lm" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 10
+	},
+/obj/structure/closet/firecloset/wall/directional/south,
+/obj/structure/sign/warning/fire{
+	pixel_x = -23;
+	pixel_y = 10
+	},
+/obj/structure/sign/warning{
+	pixel_x = -23;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"lp" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 1;
+	piping_layer = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"lB" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/closet/emcloset/wall/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"lK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "&";
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"lQ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"me" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 19;
+	pixel_y = 10;
+	id = "fuelinghangar"
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 8;
+	pixel_x = 18;
+	id = "fuelingholo"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"mh" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/solar_assembly,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"mk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"mq" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"mr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"ms" = (
+/obj/item/stack/tile/plasteel/white,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"mC" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"mI" = (
+/obj/effect/decal/cleanable/crayon{
+	pixel_x = 4;
+	pixel_y = 5;
+	color = "#FF0000"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"mM" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "refuelingbridge"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"mX" = (
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	welded = 1
+	},
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"nh" = (
+/obj/item/stack/rods,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"nk" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"nn" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/corner/transparent/ntblue/three_quarters{
+	dir = 1
+	},
+/obj/item/kirbyplants/dead{
+	name = "dead potted plant";
+	pixel_x = -1;
+	pixel_y = 9;
+	desc = "A dead potted plant."
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/warning{
+	pixel_x = 8;
+	pixel_y = -21
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"ns" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"nt" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"nK" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister{
+	icon_state = "orange";
+	name = "plasma canister"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"nR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/mono/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"nT" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"oi" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"oq" = (
+/obj/structure/chair/bench/blue/directional/south,
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"ot" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/obj/item/melee/knife/combat,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor4"
+	},
+/obj/effect/mob_spawn/human/corpse/ramzi/space/soft,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"oD" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"oK" = (
+/obj/structure/salvageable/server,
+/obj/item/stack/rods,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/plating/rust/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"oP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"oT" = (
+/turf/closed/wall/rust,
+/area/ruin/space/hivebotshuttle)
+"oW" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"oZ" = (
+/obj/structure/lattice,
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"pf" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ripleyfueling"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"pr" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"pu" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"px" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"pA" = (
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"pC" = (
+/mob/living/basic/hivebot/ranged,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"pE" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"pH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"pJ" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "conveyors"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"pP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"qf" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"qh" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only/closed,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Armory";
+	welded = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"ql" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/three_quarters,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"qv" = (
+/obj/structure/salvageable/destructive_analyzer,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"qz" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"qD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"qH" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"qI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"qJ" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"qV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"ra" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/manipulator,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	icon_state = "mvalve_map-5"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"rd" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	piping_layer = 5;
+	icon_state = "mvalve_map-5"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"rl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fuelingengineering"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"rm" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"ro" = (
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"ry" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"rF" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"rK" = (
+/obj/structure/spawner/hivebot,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/hivebotshuttle)
+"rX" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"sd" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/hivebotshuttle)
+"sf" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4;
+	welded = 1
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"sm" = (
+/obj/structure/girder,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"sr" = (
+/turf/open/space/basic,
+/area/ruin/space/refuelingsolars)
+"ss" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"su" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 4;
+	piping_layer = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"sw" = (
+/obj/item/stack/tile/plasteel/dark,
+/obj/item/pipe/binary/bendable{
+	dir = 4;
+	color = "#FF0000";
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"sO" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"sQ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"sS" = (
+/obj/machinery/suit_storage_unit/inherit{
+	state_open = 1
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = 10;
+	id = "fuelingsolarwindow";
+	name = "window shutters"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"sV" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating/rust/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"sW" = (
+/turf/open/floor/plasteel/mono/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"tj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"tm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	welded = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"tn" = (
+/obj/structure/table/chem,
+/obj/item/hypospray/mkii{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/three_quarters{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorwhite/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"tp" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "+";
+	pixel_x = -12;
+	pixel_y = -11
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"tq" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelinghangar"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	dir = 4;
+	id = "fuelingholo"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"tw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"tz" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"tA" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"tB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"tD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/item/stack/tile/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"tO" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"uk" = (
+/obj/item/trash/energybar{
+	pixel_x = -14;
+	pixel_y = -20
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"uv" = (
+/obj/structure/railing/thin{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"uJ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"uQ" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	piping_layer = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"uR" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/micro_laser,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"uV" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"vg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"vp" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/machinery/button/door{
+	pixel_x = -8;
+	pixel_y = 8;
+	name = "cargo lockdown button";
+	id = "fuelingcargo"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"vq" = (
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"vr" = (
+/obj/item/stack/tile/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"vs" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"vB" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"vH" = (
+/mob/living/basic/hivebot/mechanic,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"vK" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"vP" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"vQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"vV" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"wc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "fuelingarea"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"we" = (
+/obj/machinery/door/airlock/external{
+	welded = 1
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"wl" = (
+/obj/structure/marker_beacon{
+	picked_color = "Lime"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"wm" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"wn" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"wr" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	name = "Emergency Repressurization"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/mono/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"wu" = (
+/obj/item/stack/tile/plasteel/dark,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"wz" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 5
+	},
+/obj/item/stack/tile/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"wB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/transparent/yellow/filled/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/micro_laser,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"wO" = (
+/obj/structure/table/chem,
+/obj/item/reagent_containers/syringe/stasis,
+/obj/item/reagent_containers/syringe/stasis{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/glass/bottle/chitosan{
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorwhite,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"wP" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/hivebotshuttle)
+"wU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"wZ" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"xl" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/command/glass{
+	dir = 4;
+	name = "Command"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"xn" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"xq" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"xC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"xD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"xG" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"xI" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"xK" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/hivebotshuttle)
+"xP" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"xT" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"xV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"yc" = (
+/obj/structure/lattice,
+/obj/item/stack/sheet/metal,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"yh" = (
+/obj/machinery/computer/solar_control,
+/obj/effect/turf_decal/borderfloor,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"yi" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"yl" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	id = "fuelingsecurity"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"yn" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"yo" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"yt" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"yQ" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"yS" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"yW" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"yY" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"ze" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/porta_turret/ruin/nt/light/sniper{
+	dir = 6;
+	id = "fuelingpost"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"zi" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/space/basic,
+/area/ruin/space)
+"zm" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"zq" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "refuelingbridge"
+	},
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"zt" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"zL" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"Aj" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"At" = (
+/turf/template_noop,
+/area/template_noop)
+"Ay" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/capacitor,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -1;
+	name = "engine shutters";
+	id = "bonnieengine"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -19;
+	pixel_y = 9;
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"AC" = (
+/obj/item/stack/ore/salvage/scraptitanium,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"AD" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/solar_assembly,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"AN" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"AS" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Ba" = (
+/obj/structure/salvageable/autolathe,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"Bf" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Bo" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/west,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer5{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Bu" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"BA" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"BR" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/structure/door_assembly{
+	dir = 4
+	},
+/obj/structure/firelock_frame/border{
+	dir = 4
+	},
+/obj/structure/firelock_frame/border{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Ci" = (
+/obj/structure/closet/firecloset/wall/directional/south,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 21;
+	pixel_y = 9;
+	id = "fuelingarea";
+	name = "Refueling Shutters"
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Cn" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Cs" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ct" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/hivebotshuttle)
+"Cv" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Cw" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 9;
+	pixel_y = 8;
+	id = "refuelingbridge";
+	name = "bridge shutters"
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 9;
+	pixel_y = -4;
+	name = "hallway turret shutters";
+	id = "fuelhallwayturret"
+	},
+/obj/item/paper/crumpled/fluff/fueling/command{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"CE" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"CI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"CN" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "fuelingcargo"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"CR" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Dd" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/border{
+	dir = 1
+	},
+/mob/living/basic/hivebot,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Dg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "credit";
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "3";
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/storage/backpack/satchel/flat/onehalftwo,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"Dk" = (
+/obj/effect/spawner/bunk_bed,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Dl" = (
+/obj/machinery/vending/cola,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"Du" = (
+/obj/item/stack/sheet/metal,
+/turf/open/space/basic,
+/area/ruin/space/refuelingsolars)
+"Dw" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Dy" = (
+/obj/structure/girder/reinforced,
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"DA" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/ruin/space/refuelingsolars)
+"DP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Ec" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ed" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Em" = (
+/obj/structure/closet/wall/red/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/suit/armor/nanotrasen,
+/obj/item/clothing/head/helmet/m10/nanotrasen,
+/obj/item/clothing/head/nanotrasen/cap/security,
+/obj/item/clothing/under/nanotrasen/security,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/plasteel/mono/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"En" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Dorms"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Ew" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"Ey" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"EL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"ES" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/structure/door_assembly,
+/obj/structure/firelock_frame/border,
+/obj/structure/firelock_frame/border{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"ET" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/mob/living/basic/hivebot/core,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Fe" = (
+/obj/machinery/suit_storage_unit/inherit{
+	state_open = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Fg" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Fv" = (
+/obj/structure/girder,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"Fw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"FA" = (
+/obj/structure/safe/floor,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/corner/opaque/black,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/hand_tele,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"FB" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"FG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"FO" = (
+/turf/open/floor/plasteel/mono/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"FW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"FY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Gb" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Gf" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/light/broken/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	welded = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"Gn" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"Gq" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Gs" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/structure/closet/crate/secure/exo,
+/obj/item/pickaxe/drill,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Gu" = (
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"GE" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/dim/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	piping_layer = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"GL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"GN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"GP" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"GQ" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"GR" = (
+/obj/machinery/portable_atmospherics/canister{
+	icon_state = "orange";
+	name = "plasma canister"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"GU" = (
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Ha" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Hb" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/micro_laser/high,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	icon_state = "mvalve_map-5"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Hc" = (
+/obj/effect/turf_decal/borderfloor/full,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"Hd" = (
+/obj/structure/table/glass,
+/obj/item/documents/nanotrasen,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Hf" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/hivebotshuttle)
+"Hi" = (
+/obj/item/stack/tile/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8;
+	welded = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Hl" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/energybar{
+	pixel_x = 20;
+	pixel_y = -41
+	},
+/obj/item/trash/energybar{
+	pixel_x = 29;
+	pixel_y = -22
+	},
+/obj/item/stamp/qm{
+	pixel_x = 26;
+	pixel_y = -1
+	},
+/obj/item/clipboard{
+	pixel_x = 13;
+	pixel_y = 2
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/trash/energybar{
+	pixel_x = -3;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"HB" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/atmos/plasma,
+/obj/machinery/air_sensor/atmos/toxin_tank{
+	pixel_x = 12;
+	pixel_y = 11
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"HC" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer5{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"HF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/hivebotshuttle)
+"HJ" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"HK" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/tracker,
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"HS" = (
+/obj/structure/lattice,
+/obj/machinery/light/small/broken/directional/north,
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"HV" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Ie" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 1;
+	icon_state = "computer-middle"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ig" = (
+/obj/item/stack/tile/plasteel/dark,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Ik" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"Iu" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/ruin/space/hivebotshuttle)
+"ID" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/trash/energybar{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"IF" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/scanning_module/adv,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"IG" = (
+/obj/structure/chair/comfy/blue/corpo/directional/south,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"IJ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"IV" = (
+/obj/structure/sign/warning{
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8;
+	name = "Emergency Repressurization"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plasteel/mono/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"IY" = (
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ja" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	dir = 8;
+	name = "Security";
+	welded = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Jm" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/border,
+/mob/living/basic/hivebot,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Jn" = (
+/obj/machinery/power/smes/shuttle/precharged,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "bonnieengine"
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Jt" = (
+/obj/structure/lattice,
+/obj/item/stack/ore/salvage/scraptitanium,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"JD" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/refuelingsolars)
+"JF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/internals{
+	populate = 0;
+	name = "EVA crate"
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/suit/space/syndicate/ramzi/surplus,
+/obj/item/clothing/head/helmet/space/syndicate/ramzi/surplus,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"JG" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"JK" = (
+/obj/machinery/light/dim/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	welded = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"JM" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/caution,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"JN" = (
+/obj/structure/door_assembly/door_assembly_med{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/structure/firelock_frame/border{
+	dir = 4
+	},
+/obj/structure/firelock_frame/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/dark/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"JU" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"JV" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Ka" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/three_quarters{
+	dir = 8
+	},
+/obj/structure/table_frame,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Ki" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible/layer2{
+	dir = 9
+	},
+/obj/item/wrench/crescent{
+	pixel_x = 17;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/obj/item/pipe/binary/bendable{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = -10;
+	color = "#8000b6"
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Km" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/black,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/manipulator,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Ko" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Kq" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/poddoor_assembly,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/hivebotshuttle)
+"Kw" = (
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Kz" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"KB" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 4;
+	name = "Emergency Repressurization"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"KE" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"KF" = (
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 1
+	},
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/hardsuit/engine/atmos,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"KH" = (
+/obj/machinery/light/dim/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"KI" = (
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/structure/closet/firecloset/wall/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"KL" = (
+/obj/structure/lattice,
+/obj/item/stack/rods,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"KT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"KX" = (
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"La" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ld" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/curtain/cloth,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Lg" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"Lt" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"Lz" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"LI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8;
+	welded = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"LV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"LY" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/salvageable/computer{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Ma" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Mg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "fuelingengineering"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ms" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line,
+/obj/effect/turf_decal/trimline/opaque/nsorange/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Mt" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"MA" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5,
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"MB" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"MG" = (
+/obj/effect/turf_decal/industrial/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"MI" = (
+/obj/machinery/door/airlock/engineering{
+	dir = 8;
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"ML" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/industrial/caution,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"MO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fuelingmedbay"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"MW" = (
+/obj/structure/grille/broken,
+/obj/item/stack/ore/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"MX" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4;
+	color = "#FF0000"
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"MY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/space/refuelingsolars)
+"Na" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Infirmary"
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/closed,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Ni" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"NE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"NF" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 1;
+	id = "bonniefield"
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "bonnieblast"
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"NH" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"NI" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"NJ" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"NM" = (
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/mono/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"NV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/mono/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Oa" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ou" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"Ow" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"OE" = (
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"OF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/space/refuelingsolars)
+"Pg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Pi" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Pl" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/marker_beacon{
+	picked_color = "Burgundy"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"Pp" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Pt" = (
+/obj/structure/spawner/hivebot,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Pv" = (
+/obj/effect/turf_decal/rechargefloor,
+/obj/mecha/working/ripley/mkii,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Px" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"PC" = (
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"PD" = (
+/obj/machinery/vending/snack/orange,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"PH" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/dim/directional/east,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"PJ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"PO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Qb" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/broken/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Qh" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/mob/living/basic/hivebot/ranged,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Qk" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Qz" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"QD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/corner,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"QP" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"QQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass_large{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"QR" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"QS" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "conveyors"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"QT" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorwhite,
+/obj/structure/closet{
+	icon_state = "med"
+	},
+/obj/item/reagent_containers/hypospray/medipen/tramal{
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/hypospray/medipen/tramal{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/hypospray/medipen/morphine{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/hypospray/medipen/morphine{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"QU" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/effect/decal/cleanable/glass,
+/obj/item/stack/rods,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"QX" = (
+/obj/machinery/power/shuttle/engine/electric,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Ra" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Rb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Rr" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "conveyors"
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "cargoconveyors"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Rt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/plasteel/mono/dark/plasma,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"Rv" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"Rx" = (
+/obj/structure/chair/comfy/blue/corpo/directional/north,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"RE" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 9
+	},
+/obj/structure/closet/emcloset/wall/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"RG" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/sign/warning{
+	pixel_x = 32;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"RI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"RK" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"RO" = (
+/obj/structure/girder,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"RR" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"RY" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/industrial/caution,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"Sa" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Sn" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/turretid{
+	pixel_x = -26;
+	pixel_y = 1;
+	id = "bonnieguns"
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor4"
+	},
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"So" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/borderfloor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"Su" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Sv" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/stock_parts/manipulator,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Sw" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"SB" = (
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"SF" = (
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"SO" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/bordercorner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/transparent/yellow/filled/warning{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"SP" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"SQ" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Td" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/item/clipboard{
+	pixel_x = -13
+	},
+/obj/item/stamp/nanotrasen/captain,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Tk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4;
+	welded = 1
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/refuelingpost/lower)
+"Tr" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Tu" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/corner/transparent/ntblue/three_quarters{
+	dir = 4
+	},
+/obj/item/newspaper{
+	pixel_x = 5
+	},
+/obj/item/paper/crumpled/fluff,
+/obj/item/paper/crumpled/fluff{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/obj/item/paper/crumpled/fluff{
+	pixel_x = 21;
+	pixel_y = -22
+	},
+/obj/machinery/button/door{
+	pixel_x = 8;
+	pixel_y = 21;
+	id = "fuelingmedbay";
+	name = "window shutters"
+	},
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Ty" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/structure/closet/crate/engineering{
+	name = "internals crate"
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_y = -3
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"TE" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"TG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"TH" = (
+/obj/machinery/computer/helm{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/railing/thin,
+/obj/machinery/button/door{
+	pixel_x = 4;
+	pixel_y = 23;
+	name = "blast door control";
+	id = "bonnieblast"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_x = -6;
+	pixel_y = 21;
+	id = "bonniefield"
+	},
+/obj/item/radio/intercom/wideband/directional/east,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"TL" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"TP" = (
+/obj/effect/turf_decal/borderfloor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"TR" = (
+/obj/effect/turf_decal/corner/opaque/grey/three_quarters,
+/obj/machinery/light/broken/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"TU" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister{
+	icon_state = "orange";
+	name = "plasma canister"
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"TY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/starboard)
+"Ud" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/effect/spawner/random/food_or_drink/ration,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Ui" = (
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4;
+	piping_layer = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Ur" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Ut" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = -10;
+	pixel_y = -18;
+	id = "fuelingengineering";
+	name = "window shutters"
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	dir = 1;
+	icon_state = "computer-right"
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"UB" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"UJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	dir = 4;
+	id = "fuelingcargo"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Vn" = (
+/obj/machinery/firealarm/directional/east,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/coffee/empty{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/food/drinks/coffee/empty{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/cardboard{
+	pixel_x = -8;
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Vz" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"VB" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/hivebotshuttle)
+"VF" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"VL" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "bonniefield"
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "bonnieblast"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"VO" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"VU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/green/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/grid,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"VV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"VW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/hidden,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"VY" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating,
+/area/ruin/space/refuelingsolars)
+"Wb" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "refuelingbridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Wc" = (
+/mob/living/basic/hivebot,
+/obj/item/pipe/binary/bendable{
+	pixel_x = 7;
+	pixel_y = 5;
+	color = "#0000ff"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Wg" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating/rust,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Wm" = (
+/obj/structure/catwalk,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Wr" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/sign/warning/fire{
+	pixel_x = -24;
+	pixel_y = 10
+	},
+/obj/structure/sign/warning{
+	pixel_x = -24;
+	pixel_y = -2
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer5{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Wt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4,
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Wu" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2{
+	dir = 1;
+	welded = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/advanced_airlock_controller/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"Ww" = (
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/warning,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"WC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	welded = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"WF" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/refuelingsolars)
+"WH" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 10
+	},
+/obj/item/shard,
+/turf/open/floor/plasteel/dark/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"WJ" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"WW" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/small/broken/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/porta_turret/ruin/nt/light/sniper{
+	id = "fuelingpost"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"Xh" = (
+/obj/effect/turf_decal/corner/transparent/ntblue/half{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/plasteel/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Xm" = (
+/turf/open/floor/plasteel/patterned/cargo_one,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Xn" = (
+/obj/structure/bed/bunk,
+/obj/item/stack/rods,
+/turf/open/floor/carpet/blue/airless,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"Xw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	welded = 1
+	},
+/turf/open/floor/plasteel/mono/white/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"XA" = (
+/obj/item/stack/tile/plasteel/dark,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"XD" = (
+/turf/open/floor/carpet/blue/plasma,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"XE" = (
+/turf/open/floor/plating,
+/area/ruin/space/refuelingsolars)
+"XI" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 1
+	},
+/obj/structure/railing/thin,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"XK" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"XR" = (
+/obj/structure/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"XT" = (
+/turf/open/space/basic,
+/area/ruin/space)
+"XU" = (
+/obj/structure/girder/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"Ya" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"Ym" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/green/hidden,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/infirmary)
+"Yo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "fuelingsolarwindow"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/solarstorage)
+"Yp" = (
+/obj/effect/turf_decal/siding/white/end,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1;
+	welded = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/end,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"Yt" = (
+/obj/structure/frame,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"Yu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8;
+	welded = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	piping_layer = 5;
+	icon_state = "mvalve_map-5"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Yv" = (
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF0000";
+	icon_state = "skull";
+	pixel_x = -2;
+	pixel_y = -21
+	},
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF0000";
+	icon_state = "skull";
+	pixel_x = 10;
+	pixel_y = -36
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/refuelingsolars)
+"YD" = (
+/obj/machinery/power/smes,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ruin/space/hivebotshuttle)
+"YG" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/atmos/air,
+/obj/machinery/air_sensor/atmos/air_tank{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"YH" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	id = "fuelingsecurity";
+	pixel_x = 9;
+	pixel_y = -18
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"YI" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelhallwayturret"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/upper)
+"YJ" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "refuelingbridge"
+	},
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/bridge)
+"YP" = (
+/obj/structure/filingcabinet{
+	dir = 1
+	},
+/obj/structure/railing/thin,
+/obj/effect/turf_decal/corner/opaque/black/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"YT" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/refuelingpost/armory)
+"YX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/obj/item/storage/fancy/coffee_cart_rack{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"YY" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "fuelinghangar"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/shieldwallgen/atmos/strong/roundstart{
+	dir = 8;
+	id = "fuelingholo"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Zi" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "fuelingsecurity"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Zp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light/broken/directional/south,
+/obj/machinery/computer/atmos_control/tank/toxin_tank{
+	dir = 1;
+	icon_state = "computer-left"
+	},
+/obj/effect/turf_decal/borderfloor/cee,
+/obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"Zr" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"Zz" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/has_grav/refuelingpost/cargobay)
+"ZC" = (
+/obj/structure/salvageable/protolathe,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plasteel/telecomms_floor/airless,
+/area/ruin/space/hivebotshuttle)
+"ZI" = (
+/obj/structure/girder,
+/obj/item/stack/ore/salvage/scrapmetal,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/refuelingpost/dorms)
+"ZK" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/purple/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+"ZM" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/energybar,
+/obj/item/trash/energybar{
+	pixel_x = 2;
+	pixel_y = 15
+	},
+/obj/machinery/button/door{
+	pixel_x = 6;
+	pixel_y = 9;
+	name = "cargo shutters";
+	id = "fuelingcargo"
+	},
+/obj/machinery/button/door{
+	pixel_x = 6;
+	name = "mechbay shutters";
+	id = "ripleyfueling"
+	},
+/obj/machinery/button/door{
+	pixel_x = -6;
+	pixel_y = 9;
+	name = "conveyor shutters";
+	id = "cargoconveyors"
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/refuelingpost/cargo)
+"ZN" = (
+/turf/open/floor/engine/hull,
+/area/ruin/space/has_grav/refuelingpost/engineering)
+
+(1,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(2,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(3,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(4,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(5,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+xq
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(6,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+JD
+JD
+JD
+VF
+JD
+JD
+JD
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+"}
+(7,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+At
+At
+XT
+XT
+XT
+XT
+At
+XT
+XT
+At
+At
+XT
+XT
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+"}
+(8,1,1) = {"
+At
+At
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+"}
+(9,1,1) = {"
+At
+At
+XT
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+xq
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+JD
+JD
+mh
+JD
+bE
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+"}
+(10,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+xq
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+xq
+XT
+XT
+XT
+XT
+mh
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+"}
+(11,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+JD
+JD
+mh
+JD
+JD
+XT
+XT
+XT
+XT
+Gn
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+mh
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+"}
+(12,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+JD
+VF
+JD
+JD
+JD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+JD
+VF
+JD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+"}
+(13,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+JD
+VF
+JD
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XU
+is
+XU
+XU
+XU
+XT
+VF
+XT
+XT
+XT
+XT
+mh
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+"}
+(14,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+XT
+OF
+XT
+XT
+XT
+XT
+XT
+XT
+fr
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+VF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+"}
+(15,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+OF
+XT
+XT
+bh
+hw
+hw
+GP
+jj
+hw
+hw
+hw
+uV
+zi
+XT
+fr
+XT
+XT
+XT
+OF
+XT
+XT
+XT
+XT
+OF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+"}
+(16,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+bh
+hw
+jj
+hw
+hw
+XR
+PJ
+PJ
+fh
+Mg
+fh
+PJ
+PJ
+dP
+PJ
+PJ
+PJ
+PJ
+bh
+hw
+jj
+hw
+hw
+hw
+hw
+XR
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+"}
+(17,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+xP
+vV
+vV
+Yo
+Yo
+vV
+PJ
+KF
+GL
+pA
+PC
+fV
+cv
+cg
+Ni
+YG
+NE
+PJ
+xP
+XT
+fr
+CI
+CI
+CI
+CI
+fr
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+"}
+(18,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+wm
+XT
+XT
+xP
+vV
+So
+Dg
+lK
+sS
+PJ
+lB
+Ec
+gm
+IY
+Ut
+PJ
+dP
+PJ
+PJ
+PJ
+PJ
+xP
+XT
+CI
+CI
+nK
+kK
+CI
+CI
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(19,1,1) = {"
+At
+At
+At
+XT
+XT
+XT
+VF
+XT
+bh
+XR
+vV
+yh
+tp
+ik
+vB
+PJ
+KI
+su
+lp
+Wt
+Ie
+PJ
+dP
+ZN
+ZN
+XT
+XT
+xP
+fr
+CI
+GE
+PO
+Pi
+TU
+CI
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(20,1,1) = {"
+At
+XT
+XT
+XT
+JD
+XT
+VF
+XT
+xP
+vV
+vV
+vV
+aU
+TG
+dI
+PJ
+pE
+FW
+uQ
+mk
+Zp
+PJ
+dP
+PJ
+PJ
+PJ
+PJ
+xP
+XT
+CR
+IJ
+en
+MG
+Zz
+CI
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(21,1,1) = {"
+At
+At
+XT
+XT
+JD
+sO
+yW
+MY
+fA
+hd
+Wu
+tO
+yo
+Hc
+jI
+VO
+GQ
+uv
+Px
+SQ
+Ma
+rl
+ZK
+xG
+HB
+ff
+PJ
+xP
+fr
+CI
+dX
+Mt
+zm
+Ci
+CI
+CI
+CI
+CI
+CI
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(22,1,1) = {"
+At
+XT
+XT
+XT
+JD
+XT
+aK
+XT
+kD
+vV
+vV
+vV
+vV
+PJ
+PJ
+PJ
+fj
+kU
+ix
+La
+Sw
+PJ
+Cn
+PJ
+PJ
+PJ
+PJ
+XK
+CI
+CI
+CI
+dh
+wc
+CI
+CI
+sf
+KH
+KB
+CI
+CI
+CI
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(23,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+AD
+XT
+kD
+kD
+kD
+PJ
+qf
+PJ
+Oa
+Ty
+AN
+Uq
+fa
+fT
+Ki
+PJ
+RK
+yY
+yY
+yY
+yY
+Ik
+VV
+ku
+Bo
+nt
+Pp
+Wr
+hG
+Pp
+HC
+QR
+tq
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(24,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+aK
+XT
+XT
+XT
+kD
+PJ
+EL
+Ko
+RI
+uJ
+Cs
+jz
+sQ
+oP
+iT
+PJ
+YT
+YT
+YT
+YT
+YT
+YT
+CI
+IF
+Yu
+nT
+Zr
+Zr
+Zr
+nT
+rd
+tA
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(25,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+AD
+XT
+XU
+XT
+kD
+PJ
+PJ
+PJ
+GR
+GR
+eH
+TR
+tm
+mr
+iZ
+PJ
+Em
+kq
+nR
+YT
+Km
+GN
+CI
+Ow
+nT
+nT
+nT
+QX
+nT
+nT
+nT
+tA
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(26,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+NJ
+XT
+XU
+XT
+kD
+kD
+cz
+cz
+cz
+cz
+cz
+cz
+kN
+MI
+kN
+kN
+mX
+Rt
+NV
+qh
+xD
+YH
+CI
+Ey
+nT
+NI
+nT
+Jn
+nT
+Fe
+nT
+Su
+aY
+hg
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(27,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+im
+XT
+XU
+fr
+fr
+kD
+cz
+Tu
+iJ
+pr
+nn
+cz
+RE
+rm
+lm
+kN
+kN
+YT
+YT
+YT
+ET
+jO
+Zi
+Ow
+nT
+kC
+Ay
+iO
+Sn
+lc
+nT
+oD
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(28,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+kD
+MO
+bj
+XD
+XD
+wr
+Ym
+gr
+VW
+ns
+Dl
+kN
+uR
+yt
+cl
+SF
+bX
+yl
+Ow
+nT
+JV
+Tr
+AS
+ot
+JF
+nT
+oD
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(29,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XU
+fr
+fr
+kD
+MO
+oq
+XD
+XD
+iM
+cz
+Gf
+fW
+TP
+PD
+kN
+Pt
+xT
+cl
+WC
+bp
+CI
+Sa
+ke
+nT
+TH
+Dd
+dC
+nT
+ke
+oD
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(30,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+kD
+cz
+Ka
+Xh
+Ra
+ql
+Na
+kV
+iL
+hT
+kN
+kN
+vp
+MB
+mC
+dz
+Qb
+CI
+Sv
+yi
+ke
+nT
+xC
+Jm
+nT
+ig
+Su
+aY
+hg
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(31,1,1) = {"
+At
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+kD
+cz
+cz
+cz
+JN
+cz
+kN
+kN
+wZ
+yQ
+kN
+kN
+YT
+YT
+jR
+Ja
+zt
+CI
+oW
+ig
+yi
+nT
+wB
+SO
+nT
+yi
+oD
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(32,1,1) = {"
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XU
+fr
+fr
+kD
+MO
+QT
+FO
+FY
+cz
+ML
+YI
+JM
+SB
+Lt
+wU
+it
+ms
+zL
+iv
+Tk
+QQ
+DP
+Hb
+bZ
+nT
+VL
+NF
+nT
+ra
+RR
+aY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(33,1,1) = {"
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+kD
+MO
+wO
+Xw
+hy
+cz
+WW
+gU
+qH
+KT
+vQ
+Ou
+pH
+KE
+px
+PH
+hb
+tD
+VU
+fZ
+Bu
+le
+le
+MA
+MA
+aV
+me
+YY
+yi
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(34,1,1) = {"
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XU
+fr
+fr
+kD
+cz
+tn
+km
+aZ
+cz
+RY
+du
+cL
+JG
+Gb
+mM
+aW
+Gb
+xl
+Gb
+Gb
+CI
+MX
+RG
+kQ
+Qh
+ss
+ad
+gt
+CI
+CI
+CI
+CI
+CI
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(35,1,1) = {"
+At
+At
+At
+XT
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+Yv
+cz
+cz
+cz
+cz
+cz
+kN
+kN
+qz
+TE
+Gb
+IV
+et
+Fg
+rX
+et
+vK
+Gq
+cb
+Gq
+CN
+UJ
+CN
+Gq
+Rr
+Gq
+sr
+kD
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(36,1,1) = {"
+At
+At
+At
+At
+XT
+XT
+XT
+XT
+XU
+XT
+XT
+kD
+sO
+we
+Lg
+FG
+Rv
+qI
+TY
+SP
+fU
+Gb
+Ya
+CE
+GU
+gB
+WH
+sV
+Gq
+ci
+fP
+Hl
+ID
+XI
+pJ
+QS
+Gq
+sr
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(37,1,1) = {"
+At
+XT
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+kD
+sO
+we
+NH
+jv
+hh
+mI
+JK
+tj
+qV
+Gb
+xn
+IG
+Hd
+FA
+Rx
+Qz
+Gq
+xI
+uk
+ZM
+qJ
+YP
+KX
+QS
+Gq
+Wm
+sO
+sO
+sO
+sO
+sO
+sO
+wl
+XT
+XT
+"}
+(38,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+iQ
+nk
+nk
+nk
+nk
+nk
+nk
+nk
+En
+BR
+Gb
+vr
+wz
+dA
+eq
+Ed
+lQ
+Gq
+Ur
+pP
+LV
+QD
+qD
+Yp
+BA
+cj
+hq
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(39,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+kD
+kD
+nk
+Dk
+Ui
+tB
+nk
+Ig
+jS
+Kw
+Gb
+oK
+Hi
+aI
+JU
+HV
+hU
+Gq
+vq
+bl
+aN
+Ms
+Ud
+gx
+QP
+cj
+hq
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(40,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+kD
+nk
+Xn
+Ui
+ev
+ES
+Wc
+XA
+vg
+Gb
+lj
+fk
+bi
+sW
+NM
+cG
+Gq
+YX
+Vn
+bD
+iW
+Xm
+Xm
+Aj
+cj
+hq
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(41,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+kD
+nk
+HS
+Wg
+Gu
+Ld
+UB
+jS
+Rb
+Gb
+iG
+LY
+Cw
+hA
+Kz
+Td
+Gq
+Gq
+Gq
+Bf
+xV
+ak
+Lz
+wn
+Gq
+Wm
+sO
+sO
+sO
+Pl
+XT
+XT
+XT
+XT
+XT
+"}
+(42,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+nk
+XT
+XT
+XT
+XT
+Cv
+oZ
+XT
+TL
+Cv
+Cv
+nk
+yc
+Pg
+Dw
+Gb
+Gb
+Wb
+YJ
+zq
+aW
+Gb
+Gq
+qJ
+Ww
+pf
+iF
+Xm
+Xm
+mq
+Gq
+kD
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+"}
+(43,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+nk
+Cv
+XT
+XT
+XT
+XT
+XT
+HK
+aJ
+aJ
+QU
+HJ
+nh
+LI
+wu
+nk
+fr
+fr
+gp
+ry
+fr
+fr
+Gq
+Pv
+Ww
+pf
+Qk
+Gs
+dL
+Gq
+Gq
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+"}
+(44,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+sm
+cD
+XT
+XT
+XT
+XT
+ka
+oT
+ka
+ka
+RO
+Ct
+io
+sw
+OE
+nk
+fr
+sO
+ji
+sO
+MW
+fr
+Gq
+FB
+Ha
+Gq
+Gq
+dc
+Gq
+Gq
+kD
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+"}
+(45,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+cD
+XT
+XT
+XT
+xK
+Iu
+hI
+Ba
+Yt
+oT
+ha
+oi
+XT
+ro
+nk
+fr
+sO
+ze
+sO
+Vz
+tw
+Gq
+Gq
+Gq
+Gq
+VY
+VY
+VY
+VY
+kD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+"}
+(46,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+Hf
+oT
+YD
+vH
+tz
+ZC
+ka
+HF
+oZ
+TL
+nk
+tw
+sO
+sO
+sO
+yS
+VY
+VY
+VY
+VY
+VY
+VY
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+"}
+(47,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+Hf
+oT
+gE
+vs
+kr
+wP
+Kq
+sd
+KL
+Kw
+nk
+kD
+yS
+yS
+yS
+yS
+XT
+DA
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+"}
+(48,1,1) = {"
+XT
+XT
+XT
+cD
+AC
+XT
+XT
+XT
+XT
+Jt
+XT
+Hf
+oT
+jc
+yn
+Ew
+pC
+RO
+HF
+XT
+nk
+nk
+kD
+XT
+XT
+XT
+XE
+XT
+WF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+"}
+(49,1,1) = {"
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+xK
+Iu
+rK
+Fw
+qv
+ka
+ka
+Fv
+Du
+kD
+kD
+kD
+XT
+XT
+WF
+WF
+WF
+WF
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+"}
+(50,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+oT
+ka
+ka
+oT
+oT
+rF
+kR
+XT
+XT
+sO
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+"}
+(51,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+pu
+eA
+eA
+eA
+VB
+XT
+WJ
+Dy
+XU
+XU
+XU
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+"}
+(52,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+Cv
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+oZ
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+"}
+(53,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+cD
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(54,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+Cv
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(55,1,1) = {"
+At
+XT
+XT
+XT
+XT
+nk
+sm
+XT
+XT
+XT
+Jt
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+vP
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(56,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+vP
+XT
+XT
+XT
+Cv
+Cv
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(57,1,1) = {"
+At
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+ZI
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(58,1,1) = {"
+At
+At
+At
+XT
+XT
+At
+At
+XT
+XT
+XT
+At
+XT
+XT
+At
+XT
+XT
+At
+XT
+XT
+At
+At
+XT
+XT
+At
+At
+XT
+At
+XT
+At
+XT
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}
+(59,1,1) = {"
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+XT
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+At
+"}

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/vi_deepstorage.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/vi_deepstorage.dmm
@@ -1,0 +1,14824 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"ad" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"af" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Director's Quarters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"an" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = -13;
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"ao" = (
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"ap" = (
+/obj/structure/table/reinforced,
+/obj/item/cutting_board{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"as" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/table{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"au" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"ax" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/chair/bench/blue/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"aB" = (
+/obj/structure/chair/bench/blue/directional/north,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"aK" = (
+/obj/item/food/burrito{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"aQ" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"aV" = (
+/obj/structure/filingcabinet/chestdrawer/wheeled,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/button/door{
+	pixel_x = 0;
+	pixel_y = 22;
+	name = "lockdown override (WARNING)";
+	id = "vigilockdown"
+	},
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"bc" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/security)
+"be" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"bf" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Checkpoint"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"bi" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/med)
+"bk" = (
+/obj/item/rack_parts{
+	pixel_x = 6;
+	pixel_y = -25
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"bt" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"bu" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"bv" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"bx" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"by" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/closet/crate/large,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"bz" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"bC" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"bF" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 5;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"bI" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"bJ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 5;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"bL" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/space/deepstorage)
+"bT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"bX" = (
+/obj/item/clothing/gloves/combat,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"cd" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"ce" = (
+/obj/item/stack/tile/plasteel/tech/techmaint{
+	pixel_x = -2;
+	pixel_y = 14
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"ch" = (
+/obj/structure/chair/bench/blue/directional/west,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ck" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "vigilockdown"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"cl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"cn" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"co" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"cr" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"cB" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"cE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"cG" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"cH" = (
+/obj/structure/lattice,
+/obj/item/stack/tile/plasteel/dark,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"cI" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"cM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"cO" = (
+/obj/structure/girder,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/shuttle2)
+"cP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/airlock/public{
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"cS" = (
+/obj/machinery/door/poddoor{
+	id = "vicargodoor"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "viholo"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"cY" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"dd" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"dg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/corner,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"dh" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"dl" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod3"
+	},
+/obj/item/stack/rods,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/shuttle3)
+"dm" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"dq" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"ds" = (
+/obj/structure/chair/sofa/blue/corpo/corner/directional/east,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"dv" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/structure/grille/broken,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"dI" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"dO" = (
+/obj/structure/table/chem,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"dP" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"dQ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/orders,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"dR" = (
+/obj/item/chair,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"dS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"dX" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner,
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"ea" = (
+/obj/structure/safe,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/obj/item/spacecash/bundle/c1000,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"ed" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"ee" = (
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"ef" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"ei" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ek" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"eo" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ep" = (
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"er" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ev" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"ey" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"eB" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"eC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"eK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "vigiert1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security)
+"eN" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/rabbit{
+	pixel_x = 9;
+	pixel_y = 5;
+	list_reagents = null
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/med)
+"eV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"eY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"fd" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"fe" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/porta_turret/ruin/nt{
+	dir = 4;
+	faction = list("Deathsquad","turret")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"fh" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"fl" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"fm" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 5;
+	layer = 2.040
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "trails_2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"fn" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse/vigilitas_director,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"fr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"fs" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"ft" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040;
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"fC" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "vigiturret2"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"fE" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/security_unit/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"fF" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Checkpoint"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "vigilockdown";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"fH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"fK" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"fQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"fU" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"fX" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"fY" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/shuttle1)
+"gk" = (
+/obj/structure/window/plasma/reinforced/plastitanium/indestructible,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"gl" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"gm" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"gn" = (
+/obj/structure/chair/bench/red/directional/west,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"go" = (
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"gu" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"gz" = (
+/obj/structure/guncloset,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 5
+	},
+/obj/item/gun/energy/sharplite/al607,
+/obj/item/gun/energy/e_gun/e_old,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"gI" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"gN" = (
+/obj/structure/chair/bench/blue/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"gO" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"gP" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"gT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "frontiepod2"
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/shuttle2)
+"gV" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"gX" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/has_grav/deepstorage/hallway)
+"gY" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"ha" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/obj/item/shard/plastitanium{
+	pixel_x = -14;
+	pixel_y = -8
+	},
+/obj/item/stack/rods{
+	pixel_x = 13;
+	pixel_y = -8
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"hb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"hc" = (
+/obj/structure/rack,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"hf" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"hk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/has_grav/deepstorage/cargo)
+"hn" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"ht" = (
+/obj/item/stack/rods/ten,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"hu" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"hy" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"hz" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"hA" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"hB" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"hC" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/porta_turret/ruin/nt/heavy{
+	dir = 8;
+	faction = list("Deathsquad","turret")
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"hG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"hH" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"hL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"hM" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"hP" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"hR" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"hU" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ic" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"id" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"if" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"ig" = (
+/obj/structure/chair/comfy/blue/corpo/directional/east,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"ih" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"ij" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"ik" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"il" = (
+/obj/structure/guncloset,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"in" = (
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/obj/structure/closet/crate/freezer,
+/obj/effect/mob_spawn/human/corpse/assistant/husked,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"io" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"is" = (
+/obj/structure/safe{
+	name = "'EMERGENCY' safe"
+	},
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/melee/energy/sword/saber/blue,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/south,
+/obj/item/clothing/mask/gas/vigilitas,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"it" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/med)
+"iu" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	pixel_x = -20;
+	pixel_y = 0;
+	id = "vigiturret1";
+	dir = 4;
+	name = "turret release"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"iv" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"ix" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"iB" = (
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	pixel_x = 21;
+	pixel_y = 8;
+	id = "vigiert1";
+	dir = 8;
+	name = "emergency gear access"
+	},
+/obj/machinery/button/door{
+	pixel_x = 21;
+	pixel_y = -5;
+	id = "vigiturret2";
+	dir = 8;
+	name = "turret release"
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"iD" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"iE" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 6
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"iH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/has_grav/deepstorage/cargo)
+"iI" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"iJ" = (
+/obj/item/stack/ore/salvage/scraptitanium/five,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"iL" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"iM" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"iN" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 9;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"iQ" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"iR" = (
+/obj/machinery/computer/security{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"iV" = (
+/obj/item/stack/ore/salvage/scrapmetal/ten{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"iY" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"jd" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/structure/filingcabinet/double/grey{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"jh" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod3"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/shuttle3)
+"jn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"jr" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"ju" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"jv" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"jw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"jx" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"jC" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"jG" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 0;
+	pixel_y = -3
+	},
+/obj/item/storage/bag/tray/cafeteria,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"jH" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040;
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"jL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"jM" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"jP" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"jU" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"jV" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040;
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"jW" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"jX" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/small/directional/west,
+/obj/item/storage/backpack/duffelbag/sec{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"jZ" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"ka" = (
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"kc" = (
+/obj/structure/table_frame,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"kd" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"kj" = (
+/obj/structure/table/chem,
+/obj/item/reagent_containers/hypospray/medipen/atropine{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/medical{
+	pixel_x = -11;
+	pixel_y = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"ku" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"kA" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 0;
+	pixel_y = 18;
+	density = 0
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"kF" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"kG" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"kI" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"kK" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"kL" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"kX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"la" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"ld" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"le" = (
+/obj/structure/sign/poster/rilena/tali{
+	pixel_x = 29;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"lf" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"li" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"ll" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/diary{
+	pixel_x = -9;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"lm" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+	piping_layer = 4
+	},
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"ls" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "frontiepod2"
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/shuttle2)
+"lu" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"lv" = (
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"lz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/obj/machinery/newscaster/security_unit/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"lD" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"lR" = (
+/obj/structure/chair/sofa/blue/corpo/directional/south,
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"lS" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"lU" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"lW" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/directional/north,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"ma" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"mb" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"mi" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/button/door{
+	pixel_x = 0;
+	pixel_y = 22;
+	name = "lockdown override (WARNING)";
+	id = "vigilockdown"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"mo" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/advanced_airlock_controller/directional/west,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"mu" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"mB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"mD" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"mJ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"mM" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"mO" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"mQ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"mS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"mX" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"mZ" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"nc" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"nf" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"ng" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 10;
+	layer = 2.040
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"nn" = (
+/turf/open/space/basic,
+/area/ruin/space)
+"no" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"nw" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"nx" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"ny" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"nz" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"nG" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"nI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/stock_parts/cell/gun,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"nK" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"nN" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"nR" = (
+/obj/structure/chair/handrail{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -22;
+	id = "Vishitter";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	name = "privacy lock"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"nT" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"nX" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"nY" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"oj" = (
+/obj/item/clothing/suit/space/hardsuit/security/hos,
+/obj/item/clothing/mask/gas/vigilitas,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/tank/jetpack/oxygen/security,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"oo" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"os" = (
+/turf/closed/indestructible/reinforced,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ov" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"oy" = (
+/obj/item/reagent_containers/glass/bottle/romerol{
+	desc = "A small bottle with the words 'CONTAGIOUS SAMPLE' written on it. Probably not the best idea to drink it.";
+	name = "contagion bottle"
+	},
+/obj/structure/safe/floor,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"oF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/gun/energy/laser/wasp,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"oP" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/table{
+	dir = 8;
+	pixel_x = -1;
+	pixel_y = -11
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"oT" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"oU" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"pd" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"pf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Hallway"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"ph" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"pi" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"pn" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"po" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"ps" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"pt" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"pw" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"px" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"pA" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"pH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/security{
+	name = "Overwatch"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"pJ" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"pM" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"pN" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"pO" = (
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"pP" = (
+/obj/structure/catwalk/over,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"pQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/rifle/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"pR" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/light/small/directional/south,
+/obj/structure/chair/bench/red/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"pU" = (
+/obj/structure/crate_shelf,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"pZ" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"qa" = (
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/has_grav/deepstorage/cargo)
+"qj" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"qk" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"ql" = (
+/obj/item/clothing/under/nanotrasen/security/director,
+/obj/item/clothing/suit/armor/nanotrasen/sec_director,
+/obj/item/clothing/shoes/jackboots,
+/obj/structure/closet/secure_closet{
+	anchored = 1;
+	icon_state = "hos";
+	name = "Security Director's Locker"
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"qm" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"qo" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"qw" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"qB" = (
+/obj/structure/chair/bench/blue/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"qC" = (
+/obj/item/stack/tile/plasteel/tech/techmaint{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"qF" = (
+/obj/structure/table/chem,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/item/storage/firstaid/brute{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"qI" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"qJ" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"qQ" = (
+/obj/item/chair,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"qR" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/port_gen/pacman/mrs,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"qX" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod1"
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/shuttle1)
+"ra" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"rb" = (
+/obj/machinery/door/poddoor{
+	id = "vicargodoor"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "viholo"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"re" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"rf" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"rl" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"rp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"rt" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"ru" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"rw" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"rB" = (
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"rI" = (
+/obj/machinery/power/terminal,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"rJ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"rK" = (
+/obj/machinery/porta_turret/ruin/nt{
+	dir = 1;
+	faction = list("Deathsquad","turret")
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"rL" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"rS" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"rW" = (
+/obj/item/gun/energy/e_gun/e_old/hos{
+	pixel_y = 2;
+	pixel_x = 17;
+	spawn_no_ammo = 1
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"rX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"sf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod3"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/shuttle3)
+"si" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/orders{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"sk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"sl" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"su" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"sz" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"sC" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"sL" = (
+/turf/closed/mineral,
+/area/ruin/space/deepstorage)
+"sN" = (
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/obj/structure/closet/crate,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/machinery/light/small/directional/west,
+/obj/item/storage/backpack/satchel/sec,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"sP" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"sW" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"ta" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"tg" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"ty" = (
+/obj/structure/table/reinforced,
+/obj/item/table_bell,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"tE" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod1"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid/airless,
+/area/ruin/space/shuttle1)
+"tH" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"tI" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"tJ" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space{
+	burn_damage = 125
+	},
+/turf/open/space/basic,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"tK" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"tL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating/corner,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"tM" = (
+/obj/structure/rack,
+/obj/item/newspaper{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/newspaper{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/newspaper{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/newspaper{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"tO" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"tQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/table_frame,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"tW" = (
+/obj/structure/chair/bench/blue/directional/west,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"tY" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"ub" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"ud" = (
+/obj/structure/chair/bench/red/directional/west,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"ue" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"uh" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/hardsuit/engine,
+/obj/item/clothing/mask/gas/atmos,
+/obj/item/tank/internals/oxygen/yellow,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"uj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/item/stock_parts/cell/gun/empty,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ul" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"us" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"uu" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 8;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"ux" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"uy" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"uE" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"uF" = (
+/obj/structure/railing/thin{
+	dir = 10
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"uG" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"uH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"uK" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"uN" = (
+/obj/machinery/door/airlock/public{
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"uO" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "vigiturret1"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"uP" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"uQ" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"uR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"uT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"uU" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"uV" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 6
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"uW" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"uX" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"vb" = (
+/obj/structure/girder,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"vc" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"ve" = (
+/obj/machinery/door/airlock/security/glass{
+	dir = 4;
+	name = "Armory"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security)
+"vj" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"vk" = (
+/obj/structure/table/glass,
+/obj/item/storage/cans/sixbeer{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"vm" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"vp" = (
+/obj/item/chair,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"vr" = (
+/obj/item/ammo_casing/spent/slug,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/has_grav/deepstorage/hallway)
+"vu" = (
+/obj/structure/rack,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"vw" = (
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/has_grav/deepstorage/hallway)
+"vE" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"vL" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"vP" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"vR" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"vS" = (
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"vU" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"vV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"vY" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"wc" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"we" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"wf" = (
+/obj/effect/turf_decal/trimline/opaque/vired/corner,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"wi" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"wk" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"wl" = (
+/obj/item/stack/rods/ten,
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"wp" = (
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"wq" = (
+/obj/machinery/computer/helm{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -20;
+	id = "frontiepod1"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"wr" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"wx" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/shard/plastitanium{
+	pixel_x = -16;
+	pixel_y = 5
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"wy" = (
+/turf/closed/indestructible/reinforced,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"wC" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"wE" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"wG" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"wH" = (
+/obj/machinery/shower{
+	pixel_x = 0;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central1{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"wK" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/closet/crate/freezer{
+	anchored = 1
+	},
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"wM" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"wS" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"wX" = (
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"xc" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"xd" = (
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"xe" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"xf" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"xh" = (
+/obj/item/stack/tile/plasteel/dark,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"xj" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"xk" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"xn" = (
+/obj/effect/turf_decal/trimline/opaque/vired/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"xo" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"xp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"xB" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"xD" = (
+/obj/item/ammo_casing/spent/slug,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/has_grav/deepstorage/hallway)
+"xG" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"xH" = (
+/obj/structure/poddoor_assembly,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/has_grav/deepstorage/cargo)
+"xL" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"xN" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"xP" = (
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"xQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"xV" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"xW" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"xX" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"xZ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"yd" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"yi" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/power/rtg,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"yp" = (
+/obj/structure/chair/office,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"yv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"yz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"yB" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/transparent/white/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 7;
+	pixel_y = -20
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"yC" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"yE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"yF" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"yG" = (
+/obj/structure/sink/kitchen{
+	dir = 1
+	},
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"yI" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"yJ" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 6
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"yN" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"yP" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"yQ" = (
+/obj/structure/railing/thin{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"yS" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/trimline/opaque/ntblue/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"yV" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"yW" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"yY" = (
+/obj/machinery/door/airlock/public{
+	name = "Dormitory";
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"zb" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"zc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "frontiepod3"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/shuttle3)
+"zd" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/under/nanotrasen/security,
+/obj/item/clothing/under/nanotrasen/security,
+/obj/item/clothing/head/nanotrasen/cap/security,
+/obj/item/clothing/head/nanotrasen/cap/security,
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"zk" = (
+/obj/machinery/computer/helm,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -21;
+	pixel_y = 0;
+	id = "frontiepod2"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"zn" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"zu" = (
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"zw" = (
+/obj/machinery/porta_turret/ruin/nt{
+	dir = 4;
+	faction = list("Deathsquad","turret")
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"zx" = (
+/obj/structure/railing/thin,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"zC" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"zG" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/item/wallframe/airalarm{
+	pixel_x = 10;
+	pixel_y = -27
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = 13;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"zN" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"zW" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"zY" = (
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/obj/structure/closet/crate,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/machinery/light/small/directional/north,
+/obj/item/storage/backpack/satchel/sec,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"zZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer4{
+	dir = 10
+	},
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ag" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"An" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"As" = (
+/obj/machinery/light/directional/west,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"At" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"Av" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/security)
+"Aw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"AA" = (
+/turf/closed/wall,
+/area/ruin/space/shuttle3)
+"AC" = (
+/obj/structure/guncloset,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"AH" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"AI" = (
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"AJ" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/item/stack/rods{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"AN" = (
+/obj/machinery/porta_turret/ruin/nt/light{
+	dir = 8;
+	faction = list("Deathsquad","turret")
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"AP" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"AQ" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/shard/plastitanium,
+/obj/structure/grille/broken,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"AS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/foamtank,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"AT" = (
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/jetpack/oxygen,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"AZ" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Ba" = (
+/turf/closed/indestructible/reinforced,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"Bf" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/freezer/surplus_limbs/organs,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Bg" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Bj" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Bk" = (
+/obj/effect/turf_decal/trimline/transparent/white/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Bo" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Bq" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Bv" = (
+/obj/machinery/light/floor,
+/obj/structure/railing/thin,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Bx" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"By" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"BA" = (
+/obj/item/gun/energy/e_gun/e11/empty_cell,
+/turf/open/space/basic,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"BG" = (
+/obj/structure/table/reinforced,
+/obj/item/wallframe/intercom/table{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"BI" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"BM" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"BN" = (
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/effect/turf_decal/corner/transparent/ntblue/bordercorner{
+	layer = 2.040
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/space/neutered{
+	desc = "A horrifically jittery mass of plasteel and flesh. Its motions are jumpy, and faint giggling can be heard through it's faceless visor.";
+	retreat_distance = 0;
+	minimum_distance = 0;
+	health = 200;
+	maxHealth = 200;
+	dodge_prob = 55;
+	wander = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"BO" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"BT" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"BU" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"BX" = (
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"BY" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/shuttle2)
+"Ck" = (
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"Cn" = (
+/obj/structure/table/glass,
+/obj/item/toy/cards/deck/kotahi{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Cp" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Cv" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"Cw" = (
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Cy" = (
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"CB" = (
+/obj/item/stack/tile/plasteel/dark,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"CJ" = (
+/obj/structure/girder,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"CM" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"CP" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -29;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"CQ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"CT" = (
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"CW" = (
+/obj/structure/table/glass,
+/obj/item/toy/cards/deck{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/item/toy/cards/deck/kotahi{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Dg" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Dh" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Dn" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/item/shard{
+	pixel_x = -11;
+	pixel_y = 13
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 0;
+	pixel_y = 9
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Dp" = (
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"Dv" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/item/newspaper,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"DC" = (
+/obj/structure/lattice,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"DH" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -11;
+	pixel_y = 22
+	},
+/obj/structure/noticeboard{
+	pixel_x = 8;
+	pixel_y = 24
+	},
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/orders{
+	pixel_x = 9;
+	pixel_y = 21
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"DO" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw,
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"DQ" = (
+/obj/structure/table/chem,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/sink/chem,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"Ea" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Eh" = (
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"Ei" = (
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/obj/structure/closet/crate/freezer,
+/obj/effect/mob_spawn/human/corpse/damaged/whitesands,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"Em" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 9;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"En" = (
+/obj/structure/chair/office/dark,
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Eq" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Er" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Ex" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	pixel_x = 0;
+	pixel_y = 22;
+	id = "vicargodoor";
+	name = "cargo blasts"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_x = 11;
+	pixel_y = 20;
+	id = "viholo"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/stack/tile/plasteel{
+	pixel_x = -11;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Ez" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/rifle/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"EC" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"EF" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"EG" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"EH" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"EL" = (
+/obj/machinery/porta_turret/ruin/nt/light/sniper{
+	id = "fuelingpost";
+	faction = list("Deathsquad","turret")
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"EO" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 5;
+	layer = 2.040
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"EQ" = (
+/obj/machinery/vending/cola/blue,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"ES" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"EV" = (
+/obj/machinery/porta_turret/ruin/nt/light{
+	faction = list("Deathsquad","turret")
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"Fi" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 1;
+	piping_layer = 4
+	},
+/obj/effect/turf_decal/siding/yellow,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Fu" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Fw" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/bordercorner{
+	layer = 2.040;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Fx" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"FA" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"FB" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"FI" = (
+/obj/structure/grille/broken,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "vigiturret1"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"FK" = (
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"FO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"FP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"FQ" = (
+/turf/closed/wall,
+/area/ruin/space/shuttle1)
+"FZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/item/pen{
+	pixel_x = -16;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Gb" = (
+/obj/effect/turf_decal/trimline/transparent/white/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Gc" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 6;
+	layer = 2.040
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Gf" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/holopad/secure,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"Gh" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"Gi" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"Gq" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Gs" = (
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Gt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"Gu" = (
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Gv" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Gx" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Gy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"Gz" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/space,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"GA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 6;
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"GC" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/structure/chair/bench/red/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"GH" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/item/chair,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"GN" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"GO" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"GU" = (
+/obj/machinery/door/airlock/public{
+	name = "Canteen"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"Hf" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/shard/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Hg" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Hh" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Hi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Hn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"Ho" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Hq" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Hu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/freezer{
+	name = "Cold Storage"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Hw" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/machinery/smartfridge/bloodbank/preloaded,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"Hx" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Hy" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"HA" = (
+/obj/structure/chair/sofa/blue/corpo/right/directional/east,
+/obj/structure/sign/nanotrasen/vigilitas{
+	pixel_x = -30;
+	pixel_y = 0
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"HD" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"HF" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"HG" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"HH" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/food/drinks/waterbottle/large/empty,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"HK" = (
+/obj/item/reagent_containers/hypospray/medipen/atropine{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = -16;
+	pixel_y = -5
+	},
+/obj/item/gun/ballistic/automatic/smg/resolution/no_mag{
+	pixel_x = 3;
+	pixel_y = -15
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"HO" = (
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"HQ" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"HR" = (
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"HT" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"HW" = (
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 14;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"HX" = (
+/obj/machinery/door/airlock/public/glass{
+	dir = 4;
+	name = "Director's Office"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"HY" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Ia" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle/large{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"If" = (
+/obj/structure/grille,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Ih" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Il" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/command{
+	dir = 4;
+	name = "Director's Office"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Im" = (
+/obj/structure/chair/sofa/blue/corpo/left,
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Ir" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"Iz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"IE" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 8;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"IH" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/item/rack_parts{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"IL" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"IO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"IR" = (
+/obj/machinery/porta_turret/ruin/nt/light/sniper{
+	faction = list("Deathsquad","turret")
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"IU" = (
+/obj/item/stack/rods/ten,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"IW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"IY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ja" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Je" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Jh" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"Ji" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Jj" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Jl" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/med)
+"Jn" = (
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"JB" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = 26
+	},
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/orders{
+	pixel_x = 3;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"JJ" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/space,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"JK" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/bordercorner{
+	layer = 2.04;
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/smg,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"JL" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"JQ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"JR" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"JW" = (
+/obj/structure/sign/poster/contraband/eoehoma{
+	pixel_x = 31;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"JX" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/bordercorner{
+	layer = 2.040;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5"
+	},
+/obj/item/ammo_box/magazine/wt550m9{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"JZ" = (
+/obj/item/trash/chips{
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Kb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "vigiert1";
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/security)
+"Kd" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Kh" = (
+/obj/structure/closet/secure_closet/armorycage{
+	req_access = null
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 4
+	},
+/obj/item/storage/box/ammo/c46x30mm,
+/obj/item/stock_parts/cell/gun/sharplite/plus{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/obj/item/stock_parts/cell/gun/sharplite/plus{
+	pixel_y = 3;
+	pixel_x = 7
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_y = 10;
+	pixel_x = -8
+	},
+/obj/item/stock_parts/cell/gun{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"Kj" = (
+/obj/structure/table/wood,
+/obj/item/clothing/accessory/medal/bronze_heart{
+	pixel_y = 3;
+	pixel_x = 7
+	},
+/obj/item/clothing/accessory/medal/silver/security{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"Kk" = (
+/obj/machinery/suit_storage_unit/inherit,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"Kl" = (
+/obj/structure/sink/kitchen{
+	dir = 1
+	},
+/obj/structure/mirror{
+	pixel_x = 0;
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Km" = (
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/med)
+"Kn" = (
+/obj/item/food/burrito{
+	pixel_x = 13;
+	pixel_y = -13
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Kr" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Kt" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 5;
+	layer = 2.040
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/rifle/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Kz" = (
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"KB" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"KC" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"KF" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"KH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"KM" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"KN" = (
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "vigiturret2";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"KR" = (
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"KS" = (
+/obj/effect/turf_decal/trimline/opaque/vired/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"KT" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"KW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"KY" = (
+/obj/effect/turf_decal/atmos/air,
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Lb" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"Ld" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Office"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Le" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	piping_layer = 1
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Lh" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Lj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Lk" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 8;
+	layer = 2.040
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Ll" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 0;
+	pixel_y = -27
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen{
+	wander = 0
+	},
+/turf/open/floor/carpet/nanoweave,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Ln" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only/closed,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 1;
+	name = "Cargo"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Lo" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Lt" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Lu" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"Lw" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Lx" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Lz" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"LA" = (
+/obj/structure/window/plasma/reinforced/plastitanium/indestructible,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"LE" = (
+/obj/machinery/smartfridge/food,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"LG" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"LI" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"LK" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"LP" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 5
+	},
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"LU" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Mc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/chair/bench/blue/directional/north,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Mk" = (
+/obj/machinery/porta_turret/ruin/nt{
+	dir = 8;
+	faction = list("Deathsquad","turret")
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Mp" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Mq" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"Mv" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"MB" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"MC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"ME" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"MG" = (
+/obj/item/chair,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"MI" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"MJ" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle2)
+"ML" = (
+/obj/machinery/computer/helm{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -20;
+	id = "frontiepod3"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/shuttle3)
+"MN" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"MO" = (
+/obj/structure/table_frame,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/has_grav/deepstorage/med)
+"MV" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/servingdish,
+/obj/effect/turf_decal/corner/opaque/white/diagonal,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"MZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Nb" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Nc" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Nk" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/line{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/smg{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Nl" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Nm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser/space,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"Nn" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/shuttle1)
+"Np" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Nr" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ns" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Nx" = (
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Nz" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 10;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"NB" = (
+/obj/structure/flippedtable,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"NE" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"NF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"NH" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"NI" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"NJ" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"NM" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"NN" = (
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor5"
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"NO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/space,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"NR" = (
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"NW" = (
+/obj/machinery/camera/autoname,
+/turf/open/space/basic,
+/area/ruin/space)
+"NZ" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ol" = (
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Oq" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "trails_2"
+	},
+/obj/item/radio/intercom/wideband/table,
+/obj/item/wallframe/intercom/table{
+	pixel_x = 19;
+	pixel_y = 0
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"Os" = (
+/obj/machinery/photocopier,
+/obj/machinery/camera/autoname,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Ox" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy/closed,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Oy" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/shotgun/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"OF" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"OH" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"OI" = (
+/obj/structure/table,
+/obj/item/cigbutt{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/cigbutt{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/cigbutt{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"OK" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"OM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"OO" = (
+/obj/effect/turf_decal/trimline/opaque/vired/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"OP" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "vigiturret1"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"OW" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"Pe" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/engineering{
+	input_level = 25000
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Pk" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Pl" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Pq" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"Pu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"Pv" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/smg/space{
+	wander = 0
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"Pw" = (
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 0;
+	density = 0
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security)
+"PG" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"PN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/item/trash/chips{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"PO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"PV" = (
+/obj/item/ammo_casing/spent/slug,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"Qb" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 6
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"Qc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Qd" = (
+/obj/machinery/light/floor,
+/obj/structure/railing/thin{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Qf" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Ql" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"Qm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Qp" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/north{
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/filled/warning{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Qt" = (
+/obj/structure/chair/bench/blue/directional/west,
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/effect/turf_decal/corner/transparent/vired/bordercorner{
+	layer = 2.04
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Qu" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Qx" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"QA" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/item/reagent_containers/hypospray/medipen/rabbit,
+/obj/item/reagent_containers/hypospray/medipen/survival,
+/obj/item/reagent_containers/hypospray/medipen/survival,
+/obj/item/reagent_containers/hypospray/medipen/cureall,
+/obj/item/reagent_containers/hypospray/medipen/cureall,
+/obj/item/reagent_containers/hypospray/medipen/bonefixingjuice,
+/obj/item/reagent_containers/hypospray/medipen/bonefixingjuice,
+/obj/item/reagent_containers/hypospray/medipen/morphine,
+/obj/item/reagent_containers/hypospray/medipen/morphine,
+/obj/structure/closet/crate/freezer{
+	name = "Chemical Storage"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"QC" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"QF" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"QG" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"QI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/ntblue/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"QJ" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"QM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"QP" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"QQ" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"QR" = (
+/obj/machinery/door/airlock/public{
+	name = "Toilet";
+	dir = 4;
+	id_tag = "Vishitter"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"QS" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"QT" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"QW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"QX" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 8
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/deepstorage)
+"QY" = (
+/turf/closed/wall,
+/area/ruin/space/shuttle2)
+"Rb" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Rh" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/transparent/vired/bordercorner{
+	layer = 2.04;
+	dir = 8
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Rm" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ru" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/closed,
+/obj/machinery/door/firedoor/border_only/closed{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 1;
+	name = "Cargo"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Rw" = (
+/turf/template_noop,
+/area/template_noop)
+"RG" = (
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"RI" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"RM" = (
+/obj/structure/railing/thin,
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/space,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"RP" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"RR" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"RV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/turf_decal/trimline/transparent/white/filled/warning,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Sc" = (
+/obj/structure/catwalk/over,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Se" = (
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Sm" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"SB" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/deepstorage/security)
+"SC" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"SM" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/pug,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"SN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"SO" = (
+/obj/structure/chair/bench/blue/directional/north,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"SP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"SU" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"SY" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/warning{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"SZ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/closet/crate/large,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Ta" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/carpet/blue,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Tc" = (
+/turf/open/floor/engine/air,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Tf" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals_central1,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Tg" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/stack/rods,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Tm" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Tn" = (
+/obj/structure/catwalk/over,
+/obj/machinery/light/floor,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"To" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Tv" = (
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/trimline/opaque/ntblue/corner,
+/obj/item/chair,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Tw" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/vending/cola/black,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"TA" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax/ruin,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"TD" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"TJ" = (
+/obj/structure/chair/bench/blue/directional/north,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"TK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 6;
+	pixel_y = 12;
+	pixel_x = -7
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"TO" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"TP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/structure/noticeboard{
+	pixel_x = 0;
+	pixel_y = -24;
+	dir = 1
+	},
+/obj/item/paper/crumpled/fluff/ruin/space/deepstorage/orders{
+	pixel_x = 0;
+	pixel_y = -18
+	},
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"TR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"TS" = (
+/obj/machinery/camera/autoname,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"TU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security)
+"TW" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle1)
+"TY" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Ub" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Ue" = (
+/obj/structure/chair/bench/blue/directional/west,
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Ug" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/tech/techmaint/airless,
+/area/ruin/space/shuttle2)
+"Uj" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	id = "vigilockdown";
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Ul" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/fluff/paper/stack{
+	dir = 4;
+	pixel_y = -2;
+	pixel_x = -12
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby/med)
+"Un" = (
+/obj/structure/lattice,
+/obj/effect/gibspawner/human,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"Uq" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 1;
+	layer = 2.040
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/laser/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"Ur" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 1;
+	piping_layer = 4
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"UB" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/transparent/white/filled/warning,
+/obj/item/stack/ore/salvage/scrapmetal/ten{
+	pixel_x = -16;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"UH" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/stack/rods,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"UK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"UM" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"UR" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ve" = (
+/obj/machinery/suit_storage_unit/inherit,
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security)
+"Vf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/overwatch)
+"Vj" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Vk" = (
+/obj/structure/railing/thin{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Vy" = (
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"VA" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/security/bedroom)
+"VB" = (
+/obj/structure/chair/bench/blue/directional/east,
+/turf/open/floor/plasteel/mono/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"VI" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"VK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"VO" = (
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/effect/turf_decal/corner/transparent/ntblue/bordercorner{
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"VQ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gibbl2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/med)
+"VR" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"VT" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"VU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"VY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	dir = 4;
+	name = "Medical"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/med)
+"VZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"Wa" = (
+/turf/closed/wall,
+/area/ruin/space/deepstorage)
+"We" = (
+/obj/structure/chair/bench/blue/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Wj" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Wl" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"Wr" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/bathroom)
+"Wu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/light_switch{
+	pixel_x = -9;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"Wx" = (
+/obj/structure/dresser{
+	dir = 8;
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"WB" = (
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"WI" = (
+/obj/item/storage/backpack/duffelbag/syndie/c4,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"WO" = (
+/mob/living/simple_animal/bot/secbot/ed209/rockplanet{
+	faction = list("Deathsquad");
+	name = "\improper  ED-209 Robot"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/circuit/red,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"WS" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway)
+"WW" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/hypospray/medipen/mammoth,
+/obj/item/reagent_containers/hypospray/medipen/mammoth,
+/obj/item/reagent_containers/hypospray/medipen/mammoth,
+/obj/item/reagent_containers/hypospray/medipen/mammoth,
+/obj/structure/crate_shelf/built{
+	capacity = 2
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"WX" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security)
+"WY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
+/area/ruin/space/deepstorage)
+"WZ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Xa" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"Xf" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Xh" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/trash/chips{
+	pixel_x = -15;
+	pixel_y = -5
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Xi" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/shuttle3)
+"Xl" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Xn" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/deepstorage)
+"Xp" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	dir = 4;
+	layer = 2.040
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"Xq" = (
+/obj/structure/chair/bench/red/directional/south,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"Xr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden/layer4,
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Xs" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Xv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Xz" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/shuttle3)
+"XA" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"XB" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/shard/plastitanium{
+	pixel_x = 18;
+	pixel_y = 9
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"XE" = (
+/obj/structure/closet/crate/large,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/trimline/opaque/nsorange/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"XF" = (
+/obj/item/shard/plastitanium,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"XG" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 0;
+	pixel_y = 6;
+	on = 1
+	},
+/obj/structure/sign/poster/clip/lanchester{
+	pixel_x = -29;
+	pixel_y = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"XJ" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/item/chair,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"XL" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"XO" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/transparent/ntblue/border{
+	layer = 2.040;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/lobby)
+"XP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"XY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 4;
+	name = "Engineering"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Ya" = (
+/obj/effect/mob_spawn/human/corpse/vigilitas_private,
+/obj/structure/lattice,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/deepstorage)
+"Yf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"Yh" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/plasteel/mono,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Yk" = (
+/obj/structure/frame/machine,
+/turf/open/space/basic,
+/area/ruin/space/deepstorage)
+"Ym" = (
+/obj/effect/turf_decal/siding/thinplating/dark/end,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plasteel/tech/airless,
+/area/ruin/space/has_grav/deepstorage/cargo)
+"Yo" = (
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"Yp" = (
+/obj/effect/spawner/bunk_bed,
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 0;
+	pixel_y = 33
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Yt" = (
+/turf/closed/indestructible/titanium/nodiagnonal,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"Yu" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/moon,
+/area/ruin/space/deepstorage)
+"Yx" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"Yy" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"YD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"YE" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/machinery/light/directional/north,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"YF" = (
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 1
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"YL" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04;
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"YM" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/has_grav/deepstorage/canteen)
+"YN" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/opaque/vired/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/security/office)
+"YQ" = (
+/turf/closed/indestructible/reinforced,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"YX" = (
+/obj/effect/mob_spawn/human/corpse/frontier/space,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/obj/item/ammo_casing/spent/pistol_brass,
+/turf/open/floor/engine/hull/reinforced/interior,
+/area/ruin/space/has_grav/deepstorage/engineering)
+"Zb" = (
+/obj/effect/turf_decal/trimline/opaque/vired/line,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/security/lobby)
+"Zc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"Zm" = (
+/obj/effect/turf_decal/trimline/opaque/vired/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/hallway/east)
+"Zt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/deepstorage/med)
+"Zx" = (
+/obj/effect/turf_decal/borderfloorblack,
+/obj/effect/turf_decal/corner/transparent/vired/border{
+	layer = 2.04
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/space/has_grav/deepstorage/crewquarters)
+"ZE" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"ZF" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/space/has_grav/deepstorage/hallway/upper)
+"ZH" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"ZK" = (
+/obj/machinery/porta_turret/ruin/nt/light{
+	faction = list("Deathsquad","turret");
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/deepstorage)
+"ZM" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/deepstorage/med)
+"ZO" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/nanotrasen/ranged/trooper/shotgun/space{
+	wander = 0
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/space/has_grav/deepstorage/security/vault)
+"ZR" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/space/deepstorage)
+"ZZ" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/deepstorage/engineering)
+
+(1,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+Rw
+Rw
+"}
+(2,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+nn
+Rw
+nn
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+nn
+nn
+Rw
+Rw
+nn
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+"}
+(3,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(4,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(5,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+go
+go
+wl
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(6,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+go
+go
+go
+go
+go
+go
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(7,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+go
+go
+go
+go
+go
+go
+sL
+CJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(8,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+go
+go
+go
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(9,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+go
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+xh
+nn
+nn
+nn
+Rw
+Rw
+"}
+(10,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+tJ
+BA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(11,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+gk
+gk
+gk
+wy
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+iJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(12,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+wy
+iQ
+iQ
+iQ
+wy
+wy
+wy
+Ba
+Ba
+Ba
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+IU
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+iJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(13,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+wy
+LA
+LA
+LA
+wy
+wy
+wy
+Ba
+Ba
+Ba
+Ba
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+bL
+nn
+nn
+bL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(14,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+wy
+kA
+rW
+nT
+nX
+Ns
+re
+vm
+ME
+in
+Ba
+Ba
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+bL
+bC
+nn
+bL
+nn
+nn
+bL
+bC
+By
+bL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(15,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+wy
+wy
+Os
+fn
+BG
+zn
+xV
+re
+NI
+QT
+FA
+is
+Ba
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+bL
+Gi
+By
+bL
+bL
+bL
+bL
+Gi
+pA
+bL
+nn
+CJ
+CJ
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(16,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+gk
+iQ
+LA
+TA
+cG
+ll
+zn
+qI
+Hu
+fQ
+YD
+bk
+oy
+Ba
+su
+ZR
+ZR
+ZR
+ZR
+ZR
+ZR
+ZR
+ZR
+Qd
+AI
+AI
+ZR
+ZR
+ZR
+AI
+AI
+Qd
+ZR
+ZR
+Bv
+nn
+nn
+nn
+nn
+nn
+bL
+QX
+ku
+nn
+nn
+pA
+nn
+nn
+pA
+bL
+IU
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(17,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+gk
+iQ
+LA
+SM
+ps
+zn
+zn
+Lh
+re
+Wu
+ZO
+xQ
+ea
+os
+ei
+ei
+ei
+ei
+ei
+ei
+ei
+ei
+EH
+ZR
+EH
+ZR
+EH
+EH
+EH
+ZR
+EH
+ZR
+EH
+EH
+zx
+nn
+nn
+CJ
+nn
+nn
+bL
+nn
+rB
+FK
+EH
+Ya
+nn
+jP
+nn
+bL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(18,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+gk
+iQ
+LA
+Xq
+Lo
+Rb
+IW
+mM
+re
+vm
+WW
+Ei
+Ba
+os
+Hq
+fe
+Hq
+ei
+Hq
+fe
+Hq
+ei
+nn
+ZR
+nn
+ZR
+nn
+nn
+nn
+ZR
+nn
+ZR
+nn
+EH
+ZR
+nn
+nn
+nn
+nn
+nn
+bL
+nn
+nn
+ad
+nn
+pn
+Yk
+jP
+EH
+bL
+nn
+iJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(19,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+gk
+iQ
+LA
+Xq
+YL
+Qu
+vc
+tO
+re
+xB
+xB
+xB
+xB
+HG
+uO
+FI
+uO
+tI
+uO
+OP
+FI
+ei
+nn
+ZR
+nn
+qw
+gY
+gY
+gY
+qw
+nn
+ZR
+nn
+EH
+ZR
+nn
+nn
+iJ
+nn
+nn
+bL
+nn
+nn
+IU
+nn
+EH
+nn
+Un
+EH
+nn
+nn
+EH
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(20,1,1) = {"
+nn
+nn
+nn
+nn
+go
+go
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+wy
+wy
+wy
+YN
+xW
+ud
+gn
+xW
+we
+ac
+if
+cr
+pN
+Hy
+nw
+nw
+nw
+iu
+iN
+nw
+zN
+ei
+qw
+ZR
+nn
+qw
+cI
+cI
+cI
+qw
+nn
+ZR
+nn
+EH
+ZR
+nn
+nn
+nn
+nn
+nn
+bL
+bL
+wi
+pA
+Kz
+EH
+pA
+nn
+EH
+EH
+nn
+CT
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(21,1,1) = {"
+nn
+nn
+nn
+sL
+go
+go
+go
+sL
+sL
+Xn
+Xn
+Xn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+YQ
+YQ
+vU
+af
+vU
+vU
+Il
+ux
+ma
+Vy
+NM
+pN
+Em
+uu
+uu
+Lk
+uu
+uu
+uu
+uu
+ng
+qw
+qw
+qw
+qw
+To
+To
+To
+qw
+qw
+qw
+qw
+EH
+ZR
+nn
+nn
+nn
+nn
+nn
+nn
+bL
+nn
+Cv
+nn
+uQ
+nn
+iJ
+nn
+bX
+EH
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(22,1,1) = {"
+nn
+nn
+sL
+sL
+go
+go
+go
+go
+sL
+Dp
+Dp
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+XL
+sN
+XL
+vU
+KS
+oj
+vU
+Qf
+tY
+JK
+We
+Ho
+pN
+mD
+ch
+ch
+ch
+WB
+ch
+ch
+ch
+BT
+HT
+oT
+mB
+mB
+mB
+mB
+mB
+mB
+mB
+Gv
+qw
+ht
+zx
+nn
+nn
+nn
+cH
+nn
+nn
+bL
+pA
+nn
+pA
+EH
+nn
+nn
+wr
+NR
+Wa
+nn
+bL
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(23,1,1) = {"
+nn
+sL
+sL
+sL
+sL
+yi
+la
+uR
+KH
+KH
+EV
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+XG
+uE
+zd
+uE
+vU
+nc
+ql
+vU
+Kr
+Qm
+Vy
+Cn
+aB
+pN
+fK
+VB
+VB
+qB
+hH
+VB
+VB
+nz
+zb
+HT
+Sm
+pU
+wX
+pU
+wX
+li
+wX
+pU
+wG
+qw
+ZR
+Bv
+nn
+nn
+nn
+EH
+nn
+nn
+bL
+nn
+bL
+pA
+nn
+nn
+pA
+ad
+WY
+Wa
+EH
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(24,1,1) = {"
+nn
+sL
+sL
+sL
+sL
+sL
+jn
+go
+sL
+Dp
+Dp
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+XL
+uE
+bu
+vj
+vU
+zu
+ig
+vU
+vY
+Ih
+eY
+Qt
+ik
+pN
+Kt
+xN
+Fw
+uj
+oF
+nI
+UK
+bI
+AH
+HT
+Gx
+wX
+JJ
+AT
+wX
+wX
+ce
+wX
+TD
+qw
+nn
+nn
+nn
+nn
+nn
+EH
+EH
+nn
+iJ
+Wa
+nn
+nn
+nn
+Wa
+mZ
+mZ
+Wa
+Wa
+EH
+nn
+nn
+nn
+xh
+nn
+nn
+nn
+Rw
+"}
+(25,1,1) = {"
+nn
+nn
+sL
+sL
+Xn
+sL
+ev
+sL
+sL
+Xn
+Xn
+Xn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+zY
+zd
+Iz
+Wx
+vU
+VA
+Kj
+vU
+wc
+Eq
+xZ
+yJ
+QF
+pN
+Tw
+er
+jM
+VO
+jH
+jV
+ft
+XO
+Gc
+HT
+Sm
+li
+rt
+pU
+wX
+xX
+wX
+Bf
+wG
+qw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Wa
+pA
+pA
+nn
+Wa
+rL
+rL
+Wa
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(26,1,1) = {"
+nn
+nn
+nn
+sL
+Xn
+Dp
+ev
+Dp
+Xn
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+Yp
+xd
+yB
+Yt
+vU
+vU
+vU
+vU
+HX
+AP
+HX
+pN
+tI
+tI
+tI
+mi
+QG
+hu
+SO
+tI
+bf
+kI
+bf
+HT
+XE
+wX
+qC
+dg
+NF
+mS
+mS
+mS
+uV
+qw
+nn
+nn
+nn
+nn
+nn
+nn
+CJ
+nn
+nn
+Wa
+Lb
+CB
+nn
+Wa
+ZR
+ZR
+vb
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(27,1,1) = {"
+nn
+nn
+nn
+nn
+Xn
+Dp
+ZK
+Dp
+Xn
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+Yt
+Yt
+yY
+Yt
+ds
+HA
+jX
+fr
+OH
+Cp
+mu
+MI
+tI
+WO
+ck
+jW
+Uq
+hU
+Dv
+wC
+Wl
+Nl
+VI
+HT
+dX
+gm
+gm
+xL
+qw
+To
+To
+To
+qw
+qw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+vb
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+dP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(28,1,1) = {"
+nn
+nn
+nn
+nn
+Xn
+Xa
+Xa
+Xa
+Xn
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+UM
+Pk
+Gb
+zW
+lR
+CW
+Ll
+fr
+OH
+Cp
+mu
+KB
+tI
+tI
+tI
+jW
+oU
+eo
+TJ
+wC
+ed
+Nl
+VI
+HT
+Qp
+Se
+uX
+DO
+qw
+ZR
+ZR
+ZR
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+IU
+nn
+nn
+nn
+Wa
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Ck
+nn
+nn
+nn
+Rw
+Rw
+Rw
+"}
+(29,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+Ia
+Zx
+Mp
+mQ
+Im
+vk
+lf
+fr
+ta
+nf
+Zb
+OI
+tI
+WO
+ck
+jW
+bJ
+ld
+Dv
+wC
+VT
+IL
+MC
+Ru
+QI
+uT
+qJ
+RV
+rb
+ZR
+ZR
+ZR
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+cH
+nn
+nn
+IU
+nn
+nn
+nn
+nn
+CJ
+nn
+nn
+nn
+nn
+Rw
+Rw
+nn
+Rw
+"}
+(30,1,1) = {"
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+YF
+Rh
+ey
+mO
+hM
+jx
+TP
+fr
+TS
+Cp
+mu
+EQ
+tI
+tI
+tI
+Uj
+fF
+Uj
+tI
+wC
+ed
+Je
+jZ
+Ox
+Ym
+AJ
+rt
+iH
+xH
+iV
+ZR
+ZR
+RM
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Ck
+nn
+nn
+nn
+nn
+iD
+nn
+nn
+Ck
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(31,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+hB
+JW
+Ue
+HH
+HY
+Bk
+wK
+fr
+HX
+jC
+HX
+pN
+Fu
+aV
+Ta
+IE
+hR
+Nz
+ax
+wC
+ru
+WS
+mJ
+Ln
+hL
+hG
+CM
+UB
+qa
+Ol
+ZR
+ZR
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+CJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(32,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Nc
+Nc
+fr
+fr
+fr
+fr
+fr
+yY
+fr
+fr
+iY
+lu
+wS
+VR
+qj
+ka
+yp
+FZ
+Ul
+RP
+dQ
+wC
+Bo
+ic
+VI
+HT
+Ex
+rt
+Se
+hk
+cS
+ZR
+ZR
+ZR
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+dP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(33,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+kF
+kF
+ny
+vR
+fE
+MG
+mb
+Gu
+Nk
+NH
+iY
+Ql
+XA
+uN
+Lx
+yz
+GA
+pQ
+TK
+tg
+Mc
+wC
+VT
+SC
+VI
+HT
+TO
+by
+SZ
+IH
+qw
+ZR
+pP
+Tn
+pP
+pP
+pP
+pP
+pP
+Tn
+pP
+pP
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(34,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+kF
+kF
+kF
+FP
+ul
+aK
+pO
+ES
+jL
+kG
+NB
+qQ
+Zc
+Yx
+VR
+Bg
+Jn
+Cw
+wp
+HR
+gO
+FO
+wC
+fh
+Ub
+VI
+nG
+nG
+nG
+nG
+gV
+gV
+nn
+nn
+ZR
+nn
+nn
+nn
+nn
+nn
+ZR
+nn
+nn
+pP
+nn
+nn
+nn
+Ck
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(35,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EC
+kL
+OK
+Hg
+pO
+pO
+HW
+vp
+Yf
+an
+vS
+iY
+no
+fd
+GU
+bF
+xe
+ub
+tK
+nx
+gN
+tW
+wC
+Tm
+rJ
+RR
+nG
+KF
+ov
+KF
+gV
+gV
+NW
+nn
+ZR
+nn
+nn
+nn
+nn
+nn
+ZR
+nn
+nn
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+CJ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+nn
+"}
+(36,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EC
+kL
+OK
+Hg
+Xh
+pO
+Kn
+PN
+cY
+dR
+ep
+rS
+ih
+QJ
+VR
+Jl
+Jl
+Jl
+VY
+Jl
+Jl
+Jl
+wC
+fU
+ic
+VI
+nG
+Tf
+nG
+wH
+gV
+gV
+EH
+EH
+ZR
+FQ
+qX
+qX
+qX
+tE
+FQ
+EH
+EH
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(37,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EC
+kL
+OK
+Hg
+sW
+JZ
+Tv
+ph
+ix
+dI
+NH
+iY
+KM
+sl
+VR
+po
+rl
+hc
+xp
+vu
+PV
+MO
+vr
+WI
+AZ
+hn
+nG
+KF
+vP
+KF
+gV
+gV
+nn
+nn
+ZR
+FQ
+yV
+At
+nK
+MN
+FQ
+nn
+nn
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(38,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EC
+kL
+OK
+gI
+bv
+ul
+yS
+xj
+jG
+MV
+YM
+hP
+XJ
+RI
+VR
+EO
+JX
+HK
+TR
+Zt
+BN
+jU
+vw
+xD
+Nl
+VI
+kK
+pJ
+Wr
+yG
+gV
+nn
+nn
+nn
+ZR
+FQ
+TW
+ao
+Gz
+wq
+FQ
+nn
+nn
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(39,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+kF
+kF
+kF
+CQ
+bv
+pO
+yS
+lv
+uy
+lv
+YM
+iY
+ZF
+Yx
+VR
+VQ
+fm
+BO
+BI
+Xp
+xG
+zG
+gX
+wM
+Bj
+Lt
+cP
+OM
+Lj
+SP
+gV
+ZR
+ZR
+ZR
+ZR
+FQ
+yV
+tH
+hy
+zC
+FQ
+ZR
+ZR
+Tn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(40,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+kF
+kF
+id
+lz
+GH
+iE
+LE
+ap
+mX
+YM
+iY
+ZF
+wS
+VR
+QA
+DQ
+it
+it
+eN
+qF
+Hw
+wC
+ed
+AZ
+VI
+nG
+Hh
+Dg
+Kl
+gV
+nn
+EH
+nn
+ZR
+FQ
+FQ
+GO
+GO
+FQ
+FQ
+nn
+EH
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(41,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+SB
+bc
+bc
+bc
+bc
+bc
+YM
+YM
+uP
+Yo
+uP
+VR
+Jl
+kj
+Km
+bi
+ZM
+dO
+Jl
+wC
+pf
+nN
+pf
+nG
+nG
+QR
+nG
+gV
+nn
+EH
+nn
+ZR
+nn
+FQ
+Nn
+Nn
+FQ
+ZR
+nn
+EH
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(42,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+Kk
+bz
+ju
+il
+bc
+au
+au
+Ez
+IO
+Bq
+yN
+au
+au
+au
+au
+au
+au
+au
+NJ
+TY
+IO
+vL
+nG
+CP
+Nx
+tM
+gV
+nn
+EH
+nn
+ZR
+nn
+FQ
+co
+co
+FQ
+ZR
+nn
+EH
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+Xn
+Xa
+Xa
+Xa
+Xn
+nn
+nn
+nn
+"}
+(43,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+AC
+HF
+dh
+MB
+bc
+qk
+fC
+ek
+IO
+OO
+QP
+Xf
+Xf
+Ji
+Xf
+Dh
+BX
+xc
+EF
+Zm
+IO
+iL
+nG
+Ea
+nR
+gV
+gV
+ZR
+ZR
+ZR
+ZR
+ZR
+FQ
+fY
+fY
+FQ
+ZR
+ZR
+ZR
+Tn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+Xn
+Dp
+AN
+Dp
+Xn
+sL
+nn
+nn
+"}
+(44,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+io
+SY
+Nm
+GN
+bc
+IR
+fC
+ek
+Qc
+eC
+PO
+Xs
+LG
+eV
+LK
+eV
+PO
+eC
+eV
+eV
+XP
+Er
+gV
+gV
+gV
+gV
+nn
+EH
+nn
+nn
+ZR
+nn
+nn
+nn
+nn
+nn
+ZR
+nn
+nn
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+Xn
+sL
+ev
+sL
+Xn
+sL
+sL
+nn
+"}
+(45,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+AC
+xP
+EG
+ij
+bc
+qk
+fC
+Np
+JL
+QW
+Gq
+xn
+wE
+wf
+rX
+dS
+dS
+bT
+cn
+QW
+SN
+iv
+gV
+gV
+gV
+EH
+EH
+EH
+EH
+EH
+ZR
+EH
+EH
+EH
+EH
+EH
+ZR
+EH
+EH
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+Xn
+sL
+jn
+sL
+Xn
+go
+sL
+go
+"}
+(46,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+bc
+bc
+eK
+Kb
+bc
+bc
+bc
+ve
+Av
+ve
+au
+An
+Ja
+iL
+au
+KN
+KN
+KN
+au
+au
+iv
+iv
+nn
+nn
+nn
+nn
+nn
+EH
+nn
+nn
+ZR
+nn
+nn
+nn
+nn
+nn
+ZR
+nn
+nn
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+jn
+go
+go
+go
+go
+go
+"}
+(47,1,1) = {"
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+Ve
+OW
+WX
+pw
+Mv
+sP
+sk
+jw
+Lu
+au
+eB
+Ja
+iL
+au
+qk
+hC
+qk
+au
+iv
+iv
+iv
+Vk
+Vk
+Vk
+Vk
+Vk
+pP
+pP
+pP
+Tn
+pP
+pP
+pP
+pP
+pP
+Tn
+pP
+pP
+pP
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+QQ
+go
+go
+sL
+sL
+sL
+"}
+(48,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+Ve
+fX
+Gt
+Aw
+Aw
+jr
+cE
+Oy
+pR
+au
+be
+OF
+BM
+sC
+sC
+sC
+sC
+sC
+Ir
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+nn
+nn
+"}
+(49,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+us
+Hn
+KW
+oP
+Gy
+ty
+yC
+TU
+lS
+au
+cB
+aQ
+iL
+sC
+KR
+yd
+jd
+Ir
+Ir
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(50,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+JB
+nY
+vE
+Pv
+si
+sk
+kd
+GC
+au
+sz
+Xl
+dq
+pH
+qm
+Gf
+jv
+Ir
+AI
+fl
+AI
+AI
+fl
+AI
+AI
+uF
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(51,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Mk
+nn
+nn
+nn
+nn
+nn
+SB
+SB
+gz
+Kh
+iB
+Pw
+JR
+ra
+fH
+Gh
+au
+Xv
+wE
+gu
+sC
+DH
+NN
+Oq
+Ir
+nn
+ZR
+nn
+nn
+ZR
+nn
+nn
+ZR
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(52,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+hf
+EH
+pP
+EH
+EH
+hf
+nn
+nn
+SB
+SB
+bc
+bc
+bc
+bc
+bc
+Ve
+Ve
+Ve
+au
+oo
+wE
+yv
+sC
+ee
+iR
+Vf
+Ir
+nn
+ZR
+nn
+nn
+ZR
+nn
+nn
+ZR
+ZR
+QY
+QY
+QY
+QY
+QY
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(53,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+VZ
+Sc
+rw
+Sc
+Sc
+Sc
+Sc
+xo
+pP
+bx
+bx
+bx
+rI
+Pe
+As
+Pe
+QS
+QS
+QS
+QS
+QS
+XY
+pd
+XY
+sC
+sC
+sC
+sC
+Ir
+Xn
+Xn
+NW
+nn
+ZR
+nn
+nn
+nn
+ZR
+gT
+cl
+zk
+Pq
+QY
+QY
+QY
+QY
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(54,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EH
+nn
+EH
+nn
+nn
+lD
+nn
+KT
+LU
+xf
+yW
+SU
+pZ
+Jj
+qR
+QS
+Qx
+qo
+Nr
+rp
+Rm
+Bx
+HQ
+Vj
+Tc
+KY
+bx
+Dp
+If
+EH
+EH
+ZR
+EH
+EH
+EH
+ZR
+ls
+KC
+Eh
+JQ
+dm
+ue
+pM
+BY
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(55,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+rK
+ZR
+ZR
+DC
+nn
+hA
+Sc
+Sc
+Lz
+ZH
+Lw
+fs
+bt
+uG
+PG
+xk
+QM
+NE
+QS
+AS
+px
+Ur
+Fi
+Xr
+kX
+dd
+QC
+Hi
+Tc
+bx
+EL
+If
+nn
+nn
+ZR
+nn
+nn
+nn
+ZR
+ls
+MJ
+Eh
+lU
+dm
+ue
+pM
+BY
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(56,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+EH
+nn
+EH
+nn
+nn
+lD
+nn
+KT
+LU
+xf
+as
+gP
+NO
+ZZ
+QS
+QS
+YE
+ha
+zZ
+lm
+cM
+UR
+Nb
+Ag
+Le
+KY
+bx
+Dp
+If
+nn
+nn
+ZR
+nn
+nn
+dP
+ZR
+ls
+Pu
+Ug
+Pu
+QY
+QY
+cO
+cO
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(57,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+VZ
+Sc
+wk
+Sc
+Sc
+Sc
+Sc
+uK
+pP
+bx
+bx
+bx
+En
+yP
+hb
+tL
+Ld
+uH
+ef
+VK
+Pl
+UH
+pt
+uU
+VU
+bx
+bx
+bx
+bx
+Xn
+Xn
+EH
+EH
+Hx
+EH
+EH
+EH
+ZR
+QY
+QY
+QY
+QY
+QY
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(58,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+pi
+EH
+pP
+EH
+EH
+pi
+nn
+nn
+nn
+bx
+le
+Gs
+FB
+hz
+QS
+Yh
+yI
+kc
+tQ
+IY
+Dn
+HD
+MZ
+NZ
+vV
+mo
+Fx
+bx
+ZR
+nn
+nn
+ZR
+nn
+nn
+nn
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+nn
+go
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(59,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+zw
+nn
+nn
+nn
+nn
+nn
+nn
+bx
+bx
+bx
+bx
+bx
+bx
+xf
+xf
+Tg
+AQ
+bx
+uh
+Yy
+MZ
+WZ
+vV
+iM
+Fx
+Wj
+ZR
+nn
+nn
+ZR
+nn
+nn
+nn
+zx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+go
+go
+go
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(60,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+bx
+bx
+bx
+bx
+XF
+XB
+YX
+HO
+bx
+bx
+bx
+bx
+bx
+bx
+bx
+bx
+bx
+gl
+Vk
+ZR
+RG
+Vk
+Vk
+Vk
+yQ
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+go
+go
+go
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(61,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+bx
+Kd
+dv
+wx
+Hf
+bx
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+go
+go
+Xn
+Xn
+Xn
+Xn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+"}
+(62,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Ck
+nn
+nn
+AA
+dl
+jh
+zc
+sf
+AA
+nn
+nn
+nn
+nn
+nn
+Ck
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+ZE
+Yu
+go
+sL
+sL
+Dp
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(63,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+BU
+LP
+Qb
+yE
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+go
+Mq
+KH
+KH
+EV
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(64,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+lW
+Cy
+iI
+ML
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+go
+go
+sL
+sL
+Dp
+Xa
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(65,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+Jh
+uW
+yF
+LI
+AA
+nn
+Ck
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+go
+go
+go
+go
+Xn
+Xn
+Xn
+Xn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(66,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Ck
+AA
+AA
+rf
+rf
+AA
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+go
+go
+go
+sL
+sL
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(67,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+cd
+cd
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+Ck
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+go
+go
+go
+sL
+sL
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(68,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+Xz
+Xz
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+go
+go
+go
+sL
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(69,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+AA
+Xi
+Xi
+AA
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+nn
+"}
+(70,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(71,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+sL
+sL
+go
+go
+go
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(72,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+sL
+sL
+go
+go
+go
+go
+go
+go
+go
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(73,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(74,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+go
+sL
+sL
+sL
+go
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(75,1,1) = {"
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+sL
+sL
+sL
+sL
+sL
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+"}
+(76,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+"}
+(77,1,1) = {"
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+"}
+(78,1,1) = {"
+Rw
+Rw
+nn
+nn
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+nn
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+nn
+nn
+nn
+nn
+Rw
+Rw
+nn
+nn
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+"}
+(79,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+Rw
+Rw
+Rw
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+Rw
+Rw
+nn
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+nn
+Rw
+Rw
+nn
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+"}
+(80,1,1) = {"
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+Rw
+Rw
+Rw
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+nn
+nn
+nn
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+Rw
+"}

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -725,6 +725,20 @@
 	name = "Ramzi Scrapping Station"
 	description = "A Syndicate FOB dating back to the ICW, now home to the Ramzi Clique and their latest haul."
 
+/datum/map_template/ruin/space/onehalftwo
+	name = "Nanotrasen Refueling Station"
+	id = "onehald_two"
+	description = "An abandoned Nanotrasen refueling post evacuated after an attempted ACLF plasmaflood. Since then, hivebots and a small Ramzi Clique salvage team have attempted to claim the station."
+	suffix = "onehalftwo.dmm"
+	cost = 3
+
+/datum/map_template/ruin/space/videepstorage
+	name = "Vigilitas Deepstorage"
+	id = "vi_deepstorage"
+	description = "A Vigilitas blacksite for holding important and suspicious cargo."
+	suffix = "vi_deepstorage.dmm"
+	cost = 3
+
 //							///
 //		MARK: WastePlanet
 //							///


### PR DESCRIPTION
## Описание / Что этот PR делает
Перенос оффовских руин для космоса
## Причина создания ПР / Почему это хорошо для игры
Расширение пула, крутые руины да, новый опыт да.
## Демонстрация изменений / Тестирование
<img width="1888" height="1504" alt="image" src="https://github.com/user-attachments/assets/e0a939ed-6a37-473b-be16-cdb8000fc6f7" />
<img width="2560" height="2560" alt="image" src="https://github.com/user-attachments/assets/88447ed8-89af-4e9e-94c7-c9f4e3e1ec4e" />

## Список изменений

```yml
🆑
map: новые руинки Nanotrasen Refuelling Station, Vigilitas Deepstorage.
/🆑
```
