### PR TITLE
FIX: Спрайты обычных и random кошельков более не исчезают в пустом состоянии

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -202,4 +202,4 @@
 
 /obj/item/storage/wallet/random/PopulateContents()
 	new /obj/effect/spawner/random/entertainment/wallet_storage(src)
-	icon_state = "wallet"
+	icon_state = "wallet_closed"

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -115,6 +115,8 @@ Weebstick (Красная катана) теперь нельзя сломать
 
 - EDIT: `code\modules\hydroponics\grown\replicapod.dm` - Исправление отобрежения ДНК на сканере
 
+- EDIT `code\game\objects\items\storage\wallets.dm` -> Чиним работу random кошельков
+
 MECH_WEAPON
 ### Исправление бага перезарядки мех-оружия (SOB-3, BRM-6, SGL-6)
 **Проблема:** Оружие с `disabledreload = TRUE` (SOB-3 Clusterbang, BRM-6 Missile Rack, SGL-6 Flashbang) не могло быть перезаряжено из-за отсутствия переменной `projectiles`, что приводило к `projectiles_max = 0` и неправильной работе логики `ammo_resupply()`.

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -112,6 +112,7 @@ CELADON_QOL_LOADOUT
 - EDIT `code\modules\mob\mob_helpers.dm`: `/proc/stutter`
 
 - EDIT `code\_onclick\ai.dm` -> Чиним для ИИ возможность узнавать экипаж
+- EDIT `code\game\objects\items\storage\wallets.dm` -> Чиним работу random кошельков
 
 Радио для лежачих персонажей
 - EDIT `code/game/objects/items/devices/radio/radio.dm`: `/obj/item/radio/AltClick(mob/user)` - добавлен параметр `floor_okay = TRUE` в `canUseTopic`

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -112,7 +112,6 @@ CELADON_QOL_LOADOUT
 - EDIT `code\modules\mob\mob_helpers.dm`: `/proc/stutter`
 
 - EDIT `code\_onclick\ai.dm` -> Чиним для ИИ возможность узнавать экипаж
-- EDIT `code\game\objects\items\storage\wallets.dm` -> Чиним работу random кошельков
 
 Радио для лежачих персонажей
 - EDIT `code/game/objects/items/devices/radio/radio.dm`: `/obj/item/radio/AltClick(mob/user)` - добавлен параметр `floor_okay = TRUE` в `canUseTopic`

--- a/mod_celadon/resprite/code/wallet.dm
+++ b/mod_celadon/resprite/code/wallet.dm
@@ -1,4 +1,5 @@
 /obj/item/storage/wallet
+	icon_state = "wallet_closed"
 	icon = 'mod_celadon/_storage_icons/icons/resprite/wallet.dmi'
 
 /obj/item/storage/wallet/proc/get_wallet_overlay_state()


### PR DESCRIPTION
## Описание / Что этот PR делает
Issue fix #2728
## Причина создания ПР / Почему это хорошо для игры
Устраняем забавные баги со спрайтами.
## Демонстрация изменений / Тестирование
Изменения на другие кошельки не повлияли, а ниже скриншот работающего обычного и random кошелька в игре.
<img width="886" height="400" alt="image" src="https://github.com/user-attachments/assets/b0bfb868-8655-4710-ad98-6188d4a2e5d1" />

## Список изменений

```yml
🆑Azzy.Dreemurr
fix: Спрайты обычных и random кошельков более не исчезают в пустом состоянии
/🆑
```
