### PR TITLE
FIX: Runtimes Validator - ship_trails (list -> alist - 516)

### DIFF
--- a/code/modules/overmap/ships/ship_datum.dm
+++ b/code/modules/overmap/ships/ship_datum.dm
@@ -134,10 +134,10 @@
 	var/rotation_velocity = 0
 
 	var/skiptickfortrail = 0
-	// [CELADON-EDIT] - Убираем предупреждение валидатора
-	var/list/obj/shiptrail/trails = list(1 = null,
-							2 = null,
-							3 = null)
+	// [CELADON-EDIT] - Убираем предупреждение валидатора; [CELADON-EDIT] - Добавлены ковычки для запуска на 516
+	var/list/obj/shiptrail/trails = list("1" = null,
+							"2" = null,
+							"3" = null)
 	// [/CELADON-EDIT]
 
 /datum/overmap/ship/proc/check_proximity()

--- a/code/modules/overmap/ships/ship_datum.dm
+++ b/code/modules/overmap/ships/ship_datum.dm
@@ -135,9 +135,15 @@
 
 	var/skiptickfortrail = 0
 	// [CELADON-EDIT] - Убираем предупреждение валидатора; [CELADON-EDIT] - Добавлены ковычки для запуска на 516
-	var/list/obj/shiptrail/trails = list("1" = null,
-							"2" = null,
-							"3" = null)
+#if DM_VERSION >= 516
+	var/list/obj/shiptrail/trails = alist(1 = null,
+							2 = null,
+							3 = null)
+#else
+	var/list/obj/shiptrail/trails = list(1 = null,
+							2 = null,
+							3 = null)
+#endif
 	// [/CELADON-EDIT]
 
 /datum/overmap/ship/proc/check_proximity()

--- a/code/modules/overmap/ships/ship_datum.dm
+++ b/code/modules/overmap/ships/ship_datum.dm
@@ -134,10 +134,10 @@
 	var/rotation_velocity = 0
 
 	var/skiptickfortrail = 0
-	// [CELADON-EDIT] - Убираем предупреждение валидатора; [CELADON-EDIT] - Добавлены ковычки для запуска на 516
-	var/list/obj/shiptrail/trails = list("1" = null,
-							"2" = null,
-							"3" = null)
+	// [CELADON-EDIT] - Убираем предупреждение валидатора
+	var/list/obj/shiptrail/trails = list(1 = null,
+							2 = null,
+							3 = null)
 	// [/CELADON-EDIT]
 
 /datum/overmap/ship/proc/check_proximity()

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -170,7 +170,6 @@ DONT_ALTCLICK_WALLET - Убирает вытаскивание карты на �
 
 DEBUG_QUALITY
 - DEL `code/game/objects/items/storage/boxes.dm` -> `mod_celadon/qol/code/BluespaceTechnician.dm`
-- EDIT `code/modules/overmap/ships/ship_datum.dm` - Добавлены ковычки для запуска на 516
 
 CELADON_QOL_LOADOUT
 - ADD, EDIT: `code/modules/client/preferences.dm`

--- a/mod_celadon/qol/README.md
+++ b/mod_celadon/qol/README.md
@@ -170,6 +170,7 @@ DONT_ALTCLICK_WALLET - Убирает вытаскивание карты на �
 
 DEBUG_QUALITY
 - DEL `code/game/objects/items/storage/boxes.dm` -> `mod_celadon/qol/code/BluespaceTechnician.dm`
+- EDIT `code/modules/overmap/ships/ship_datum.dm` - Добавлены ковычки для запуска на 516
 
 CELADON_QOL_LOADOUT
 - ADD, EDIT: `code/modules/client/preferences.dm`


### PR DESCRIPTION
## Описание / Что этот PR делает
Пока будет в черновике. Ждет ответ от Евангеля о спаме логов рантайма во время полетов корабликов на локалке и возможно на сервере.
Reverts CeladonSS13/Shiptest#2689

## Причина создания ПР / Почему это хорошо для игры
<img width="1157" height="461" alt="image" src="https://github.com/user-attachments/assets/0b9ed530-c7ff-4981-927b-1c5b9c9517d2" />

## Демонстрация изменений / Тестирование
> Комментарий Космонавта:
> После добавление ассоциативного списка, и добавления условия пред-компиляции, более не выдает рантаймов.

## Список изменений

```yml
🆑Azzy.Dreemurr
tweak: Откат изменения: Позволяем билду запуститься на 516 без ошибок на локалке
/🆑
```

