### PR TITLE
MAP: Jungle Ruins

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_cavecrew.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_cavecrew.dmm
@@ -1,261 +1,454 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/turf_decal/industrial/traffic,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/cargo)
 "ad" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "5-8"
+	icon_state = "2-10"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 0;
+	pixel_y = -8
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -14;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash/large{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
 "ae" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/syndie/c4{
-	pixel_y = 5;
-	pixel_x = 2
+/obj/machinery/portable_atmospherics/canister/toxins{
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	name = "shitty plasma canister";
+	max_integrity = 60;
+	desc = "A shoddily constructed container of Plasma gas. Highly toxic."
 	},
-/obj/item/crowbar/power{
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/industrial/fire{
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"ag" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 5
 	},
-/obj/item/ammo_casing/caseless/rocket{
-	pixel_x = -6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"af" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 2;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"ag" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"ah" = (
+/obj/structure/chair/bench/grey/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	req_access = null;
-	anchored = 1
+/obj/item/trash/candy,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"am" = (
+/obj/structure/cable{
+	icon_state = "2-9"
 	},
 /obj/structure/railing{
 	dir = 4;
 	layer = 4.1
 	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"ah" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"aq" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"ar" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"aw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"am" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5;
-	color = "#808080"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"aw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark{
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/effect/turf_decal/corner/opaque/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ax" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/road/slow{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-9"
+/obj/effect/turf_decal/corner/opaque/tan/half{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"aI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/jungle/cavecrew/cargo)
-"aK" = (
-/obj/structure/table/wood,
-/obj/item/trash/syndi_cakes{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"aL" = (
-/obj/machinery/door/airlock/grunge{
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"aC" = (
+/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"aM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner{
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/overmap_encounter/planetoid/cave/explored)
+"aD" = (
+/obj/machinery/button/door{
+	pixel_x = -1;
+	pixel_y = -22;
+	dir = 1;
+	id = "cavecheckpointnorth"
+	},
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"aF" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree2"
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aI" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-6"
+/obj/structure/table/wood/poker,
+/obj/item/spacecash/bundle/c10,
+/obj/item/spacecash/bundle/c10{
+	pixel_x = 9;
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"aO" = (
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_x = -11;
-	pixel_y = 19
+/obj/item/spacecash/bundle/c1{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
+/obj/item/spacecash/bundle/c20{
+	pixel_x = 9;
+	pixel_y = -5
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"aL" = (
+/obj/structure/table/wood/reinforced{
+	color = "#55391A"
+	},
+/turf/closed/mineral/random/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
-"aQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
+"aO" = (
+/obj/structure/falsewall/plastitanium,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew)
+"aR" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aY" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"aY" = (
-/obj/structure/falsewall/plastitanium,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"aZ" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"bb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"bg" = (
+/obj/structure/hazard/electrical/electrified_water,
+/obj/structure/cable{
+	icon_state = "0-1"
 	},
-/area/ruin/powered)
-"bh" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 8
+/turf/open/water/jungle,
+/area/ruin/jungle/cavecrew)
+"bj" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/spacecash/bundle/c1000{
+	pixel_x = 6;
+	pixel_y = 11
 	},
-/obj/effect/turf_decal/techfloor{
+/obj/item/melee/energy/sword/saber/pirate{
+	pixel_y = 7;
+	pixel_x = 7
+	},
+/obj/item/spacecash/bundle/c1000{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/lighter{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/obj/item/camera_bug{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
+/turf/open/floor/carpet/green/jungleplanet,
 /area/ruin/jungle/cavecrew/bridge)
+"bm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
 "bp" = (
-/turf/closed/wall/r_wall/yesdiag,
-/area/ruin/powered)
-"bG" = (
-/obj/structure/spacevine,
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/cave/explored)
-"bH" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/obj/structure/curtain/cloth/grey,
-/obj/effect/decal/cleanable/shreds,
-/turf/open/floor/carpet/nanoweave/beige,
+/obj/structure/flora/rock/jungle{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/hallway)
+"bs" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"bt" = (
+/obj/machinery/portable_atmospherics/canister/oxygen{
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	name = "poorly-maintained o2 canister";
+	max_integrity = 60;
+	desc = "A poorly-constructed canister of Oxygen. Necessary for human life, but with this level of rust and pressure, more of a hazard."
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"bu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/plastic,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/structure/cable{
+	icon_state = "1-9"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/jungle/cavecrew/ship)
+"bx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/carpet/green/jungleplanet,
 /area/ruin/jungle/cavecrew/dormitories)
+"bB" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"bF" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/caution{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"bG" = (
+/obj/structure/fermenting_barrel,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/cargo)
+"bH" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 4.1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
 "bJ" = (
+/obj/structure/spacevine,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"bK" = (
 /obj/structure/flora/grass/jungle{
 	pixel_x = -13;
 	pixel_y = -14
 	},
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"bK" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -4;
-	pixel_y = -6
-	},
-/turf/open/water/jungle/lit,
 /area/overmap_encounter/planetoid/jungle/explored)
+"bT" = (
+/obj/structure/hazard/electrical/electrified_water,
+/turf/open/water/jungle,
+/area/ruin/jungle/cavecrew)
 "bU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/statuebust,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
+/obj/structure/cable{
+	icon_state = "5-10"
 	},
-/turf/open/floor/pod/light,
-/area/ruin/jungle/cavecrew/hallway)
-"ck" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"bX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8;
+	layer = 2.01
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"bY" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"cb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"ce" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/wood/jungleplanet{
+	dir = 4
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"cf" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 3.1
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/clothing/mask/whistle/trench{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/megaphone{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"ch" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/gun/ballistic/automatic/pistol/ringneck,
+/obj/item/melee/knife/combat,
+/turf/open/floor/pod,
+/area/ruin/jungle/cavecrew/ship)
+"ci" = (
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/sheet/metal/ten,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/stack/sheet/metal/ten,
+/obj/item/stack/rods/ten,
+/obj/item/stack/rods/ten,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"cj" = (
+/obj/machinery/door/poddoor,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"ck" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"cl" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 9;
+	pixel_y = 10
+	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/reagent_containers/food/drinks/soda_cans/vimukti{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/mead,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"cn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"cx" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"cs" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"cx" = (
+/obj/effect/turf_decal/industrial/warning/dust{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"cK" = (
-/obj/item/stack/rods/ten{
-	pixel_x = -3
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-9"
 	},
-/obj/item/stack/ore/salvage/scraptitanium/five{
-	pixel_x = 11;
-	pixel_y = -10
-	},
-/obj/item/stack/ore/salvage/scrapsilver/five{
-	pixel_y = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"cU" = (
-/obj/machinery/power/port_gen/pacman/super,
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/button/door{
-	id = "gut_engines";
-	name = "Engine Shutters";
-	pixel_y = -22;
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
-"cV" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = -11;
-	pixel_y = 13
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 5;
-	pixel_x = 10
-	},
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"cX" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"cD" = (
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/dust/corner,
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"cM" = (
 /obj/structure/flora/junglebush/large{
 	pixel_x = -7;
 	pixel_y = 8
@@ -264,2993 +457,324 @@
 	pixel_x = 10;
 	pixel_y = 9
 	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"cZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/security)
-"dd" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"dm" = (
-/obj/machinery/power/smes/engineering,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/industrial/radiation{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"ds" = (
-/obj/effect/turf_decal/techfloor/corner{
-	dir = 1
-	},
-/obj/structure/chair/plastic{
-	dir = 4;
-	pixel_y = 9;
-	pixel_x = -7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"dA" = (
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"dH" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"dI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"dO" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/bottle/moonshine{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"dQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/hallway)
-"dT" = (
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/cargo)
-"ed" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/cargo)
-"ef" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"ei" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"es" = (
-/turf/template_noop,
-/area/template_noop)
-"eu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1
-	},
-/turf/open/water/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"eD" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "gut_launchdoor"
-	},
-/turf/open/floor/engine/hull/reinforced/interior,
-/area/ship/storage)
-"eG" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -8;
-	pixel_x = -31
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"eQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/plasma,
-/obj/effect/decal/cleanable/glass{
-	pixel_x = 11;
-	pixel_y = -11
-	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"eW" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/item/chair/plastic{
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 7
-	},
-/obj/item/storage/wallet/random{
-	pixel_y = -6
-	},
-/obj/item/stack/telecrystal/five,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"fg" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"fs" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"fv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/wall/red/directional/south{
-	name = "Bartender's locker"
-	},
-/obj/item/clothing/under/suit/waiter/syndicate,
-/obj/item/clothing/suit/apron/purple_bartender,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/item/storage/pill_bottle/happy{
-	pixel_y = -9;
-	pixel_x = -8
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"fy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"fA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"fG" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"fI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = 19;
-	pixel_y = 9
-	},
-/obj/machinery/light/small/broken/directional/south,
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"fN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"fO" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/storage)
-"fS" = (
-/turf/closed/mineral/random/jungle,
-/area/ruin/powered)
-"gd" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"gk" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/south,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"gm" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 1
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/hallway)
-"gv" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -31;
-	pixel_x = -1
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"gF" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/under/frontiersmen/officer,
-/obj/item/clothing/suit/armor/frontier,
-/obj/item/clothing/head/beret/sec/frontier/officer,
-/turf/open/floor/carpet/red_gold,
-/area/ruin/jungle/cavecrew/dormitories)
-"gM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi';
-	dir = 8
-	},
-/area/ruin/jungle/cavecrew/engineering)
-"gU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/structure/cable{
-	icon_state = "4-10"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"hf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/railing{
-	dir = 2;
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi';
-	dir = 8
-	},
-/area/ruin/powered)
-"hh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"hn" = (
-/turf/open/floor/engine/hull/reinforced/interior,
-/area/ship/storage)
-"ho" = (
-/obj/machinery/door/poddoor{
-	id = "gut_launchdoor"
-	},
-/turf/open/floor/engine/hull/reinforced/interior,
-/area/ship/storage)
-"ht" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"hz" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"ih" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"ij" = (
-/mob/living/simple_animal/hostile/venus_human_trap,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"iq" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/chair/office{
-	dir = 4;
-	name = "tactical swivel chair"
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/officer/neutured,
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"iE" = (
-/obj/structure/chair/comfy/grey/directional/east,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"iN" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"iT" = (
-/obj/structure/flora/rock{
-	pixel_x = 9
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"iV" = (
-/turf/closed/wall/rust,
-/area/ruin/powered)
-"iW" = (
-/turf/open/floor/plating/asteroid/dirt,
-/area/overmap_encounter/planetoid/jungle/explored)
-"iZ" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/industrial/loading{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"ja" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"jd" = (
-/obj/structure/spacevine/dense,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"jg" = (
-/obj/structure/spacevine/dense,
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"jh" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/dogbed/cayenne,
-/mob/living/simple_animal/pet/dog/corgi/puppy{
-	name = "Kiwi";
-	faction = list("neutral","frontiersman")
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"jj" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/powered)
-"jm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/engineering)
-"jr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"ju" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8;
-	name = "tactical chair"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#808080"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"jy" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/machinery/computer/crew,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/storage)
-"jA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "5-10"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"jC" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"jF" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/security)
-"jO" = (
-/obj/structure/flora/junglebush/large{
-	pixel_y = -4
-	},
-/obj/item/flashlight/lantern{
-	pixel_x = 14;
-	pixel_y = -3
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
-"jZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"kb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"ke" = (
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/fluff/drake_statue{
-	pixel_x = -25
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"kj" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -31;
-	pixel_x = 6
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"ks" = (
-/obj/effect/turf_decal/industrial/traffic,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"ku" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -5;
-	pixel_y = 18
-	},
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 14;
-	pixel_y = 1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"kA" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/obj/structure/flora/grass/jungle{
-	pixel_x = -11;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"kB" = (
-/obj/structure/cable{
-	icon_state = "1-9"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"kH" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"kL" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -5;
-	pixel_y = 18
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"kO" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/hole{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"kR" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"kV" = (
-/obj/effect/turf_decal/siding/wood/end{
-	dir = 4
-	},
-/obj/structure/bookcase/random/fiction,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/toy/figure/curator{
-	pixel_y = 19;
-	pixel_x = -11
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"la" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/button/massdriver{
-	id = "gut_launchdoor";
-	name = "Cannon Button";
-	pixel_x = 21;
-	pixel_y = 8;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"lm" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/bridge)
-"lo" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"lu" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/engineering)
-"lz" = (
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/jungle/cavecrew/cargo)
-"lD" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"lG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/powered)
-"lI" = (
-/obj/structure/flora/tree/jungle/small{
-	icon_state = "tree2"
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"lR" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 10;
-	pixel_y = 5
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"lS" = (
-/obj/structure/railing/corner,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"lT" = (
-/obj/effect/turf_decal/industrial/warning/dust/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/garbage{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"lV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/garbage{
-	pixel_x = -5
-	},
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/freezer/wall/directional/west,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/effect/spawner/random/food_or_drink/ration,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"lY" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"mb" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"mj" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/loot,
-/obj/item/storage/pill_bottle/iron{
-	pixel_x = -6
-	},
-/obj/item/storage/pill_bottle/lsd{
-	pixel_y = -3;
-	pixel_x = -2
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"mt" = (
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/security)
-"mu" = (
-/turf/open/floor/plating,
-/area/ruin/powered)
-"mw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/wrapping{
-	pixel_x = -13;
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"mz" = (
-/obj/structure/chair/stool/bar{
-	pixel_x = -6
-	},
-/obj/effect/decal/cleanable/vomit/old{
-	pixel_x = -14;
-	pixel_y = 18
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"mC" = (
-/obj/structure/cable{
-	icon_state = "2-6"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"mD" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "gut_holo"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "gut_cargo";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/turf/open/floor/engine/hull/interior,
-/area/ship/storage)
-"mI" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red_gold,
-/area/ruin/jungle/cavecrew/dormitories)
-"mK" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"na" = (
-/obj/structure/flora/grass/jungle/b{
-	pixel_x = 10;
-	pixel_y = -19
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"ng" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"nh" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"np" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 9;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"nq" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 17;
-	pixel_x = 3
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 5;
-	pixel_x = -9
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"nt" = (
-/obj/effect/turf_decal/industrial/loading{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"nu" = (
-/obj/machinery/computer/card/minor/cmo,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"nv" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"nR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"nV" = (
-/obj/structure/railing{
-	dir = 9;
-	layer = 4.1
-	},
-/obj/structure/reagent_dispensers/beerkeg{
-	pixel_x = 8
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"og" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "4-9"
-	},
-/obj/structure/cable{
-	icon_state = "5-10"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/item/stack/cable_coil/red{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"oq" = (
-/turf/closed/mineral/random/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"ov" = (
-/obj/structure/flora/grass/jungle/b{
-	pixel_y = -4
-	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/overmap_encounter/planetoid/jungle/explored)
-"ow" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"oD" = (
-/obj/structure/spacevine/dense,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"oH" = (
-/obj/effect/turf_decal/industrial/loading{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"oQ" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"oR" = (
-/obj/structure/fermenting_barrel{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/structure/fermenting_barrel{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/powered)
-"oU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/computer,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"oW" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 2
-	},
-/area/ruin/jungle/cavecrew/cargo)
-"pn" = (
-/obj/effect/turf_decal/industrial/radiation{
-	dir = 4
-	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"pt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/cargo)
-"px" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/internals/neutered,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"pB" = (
-/obj/effect/turf_decal/industrial/traffic,
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"pL" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"qx" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"qz" = (
-/obj/structure/guncloset,
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/turf_decal/industrial/warning{
-	dir = 10
-	},
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_y = 5
-	},
-/obj/item/gun/ballistic/revolver/ashhand{
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"qO" = (
-/turf/closed/wall/rust,
-/area/ruin/jungle/cavecrew/cargo)
-"qU" = (
 /obj/structure/spacevine,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"rn" = (
-/obj/structure/flora/grass/jungle/b{
-	pixel_x = 13;
-	pixel_y = -12
-	},
-/obj/structure/flora/grass/jungle/b{
-	pixel_x = 10;
-	pixel_y = 9
-	},
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_x = -11
-	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
-"rr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/jungle/cavecrew/cargo)
-"rt" = (
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"rx" = (
-/obj/structure/flora/rock/jungle{
-	pixel_y = 12
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"rA" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"rK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-6"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"rN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/neutered,
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"rQ" = (
-/obj/structure/railing{
-	dir = 2;
-	layer = 4.1
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"rT" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"sj" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-6"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"sm" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/wrapping,
+"cO" = (
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/obj/machinery/power/terminal,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/warning,
-/obj/item/storage/toolbox/syndicate{
-	pixel_y = 5;
-	pixel_x = 11
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"sH" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/reagent_containers/glass/bottle/cyanide{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/glass/bottle/histamine{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/chlorine{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/glass/mortar{
-	pixel_x = 5
-	},
-/obj/item/pestle{
-	pixel_x = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/poster/official/moth/meth{
-	pixel_y = 32
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"sJ" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/item/clothing/head/crown{
-	pixel_x = 6;
-	pixel_y = 9;
-	name = "magnificent crown"
-	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"sM" = (
-/obj/structure/spacevine,
-/obj/structure/spacevine/dense,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"ta" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"cV" = (
+/turf/closed/mineral/random/jungle,
+/area/ruin/jungle/cavecrew/cargo)
+"cX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"cZ" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken3"
+	},
 /area/ruin/jungle/cavecrew/dormitories)
-"tj" = (
-/obj/effect/decal/cleanable/dirt/dust,
+"dd" = (
+/obj/machinery/portable_atmospherics/canister/oxygen{
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	name = "poorly-maintained o2 canister";
+	max_integrity = 60;
+	desc = "A poorly-constructed canister of Oxygen. Necessary for human life, but with this level of rust and pressure, more of a hazard."
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"de" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -18;
+	pixel_y = 4
+	},
+/obj/structure/mirror{
+	pixel_y = 29;
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"df" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"to" = (
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"dh" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Bathroom"
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"dj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"tu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/reagent_dispensers/water_cooler{
-	pixel_x = 8;
-	pixel_y = 15;
-	density = 0
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
 	},
-/obj/structure/sign/poster/contraband/punch_shit{
-	pixel_x = 32
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-25";
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/greenglow{
-	color = "#808080";
-	pixel_x = -11;
-	pixel_y = 3
-	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/hallway)
-"tL" = (
-/obj/structure/cable{
-	icon_state = "1-9"
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"tO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-6"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"tQ" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"tY" = (
-/obj/structure/spacevine,
-/obj/structure/spacevine,
-/turf/open/water/jungle,
+/turf/open/floor/concrete/slab_1/jungleplanet,
 /area/overmap_encounter/planetoid/cave/explored)
-"ua" = (
-/obj/effect/turf_decal/siding/wood{
+"dk" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/machinery/conveyor_switch/oneway{
+	pixel_y = 8;
+	layer = 3.09;
+	id = "outpost2"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"dl" = (
+/obj/effect/turf_decal/industrial/caution/white{
+	color = "#d2d53d";
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"dm" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/corner/opaque/red/half{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"dp" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ds" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken5"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"dt" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-9"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/industrial/warning,
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/jungle/cavecrew/ship)
+"du" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "danger";
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"dz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"dA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Prep Room";
+	dir = 4
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"dB" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Command Post"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/jungle/cavecrew/bridge)
+"dH" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dK" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"dP" = (
+/obj/structure/railing{
+	layer = 3.1
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/hallway)
+"dQ" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/autolathe/hacked,
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"dR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew)
+"dS" = (
+/obj/machinery/light/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/clothing/under/frontiersmen/deckhand,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"dT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"dU" = (
+/obj/item/shovel,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew)
+"dZ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/corner_steel_grid/diagonal,
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"ea" = (
 /obj/structure/chair{
 	pixel_x = -9;
 	pixel_y = 12;
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"ue" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
-/area/ship/storage)
-"uf" = (
-/obj/effect/turf_decal/techfloor/hole{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/techfloor/hole/right{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/door/airlock/highsecurity,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/security)
-"un" = (
-/obj/structure/falsewall/plastitanium,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"uo" = (
-/obj/structure/chair/stool/bar{
-	pixel_x = -5;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"uq" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 7;
-	pixel_y = 27
-	},
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -5;
-	pixel_y = 15
-	},
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"uu" = (
-/obj/structure/closet/cabinet,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/item/clothing/under/frontiersmen,
-/obj/item/clothing/head/beret/sec/frontier,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"uC" = (
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"uK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"uX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"va" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/powered)
-"vk" = (
-/obj/machinery/power/shieldwallgen/atmos/roundstart{
-	id = "gut_holo";
-	dir = 1
-	},
-/obj/machinery/button/shieldwallgen{
-	dir = 1;
-	id = "gut_holo";
-	pixel_x = 8;
-	pixel_y = -21
-	},
-/obj/machinery/button/door{
-	id = "gut_cargo";
-	name = "Cargo Door Control";
-	pixel_y = -22;
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "gut_cargo";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/turf/open/floor/engine/hull/interior,
-/area/ship/storage)
-"vl" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-5"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"vo" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet{
-	icon_state = "sec";
-	name = "Ammo Locker";
-	req_access_txt = "1"
-	},
-/obj/item/storage/box/lethalshot{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/storage/box/lethalshot{
-	pixel_x = -3;
-	pixel_y = -5
-	},
-/obj/item/ammo_casing/a4570,
-/obj/item/ammo_box/magazine/skm_762_40,
-/obj/item/ammo_box/magazine/skm_762_40,
-/obj/item/ammo_box/magazine/skm_762_40,
-/obj/item/ammo_box/magazine/illestren_a850r,
-/obj/item/ammo_box/magazine/illestren_a850r,
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"vr" = (
-/obj/machinery/computer/cargo,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"vM" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13;
-	pixel_x = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 4;
-	pixel_x = -4
-	},
-/obj/item/clipboard{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/phone{
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/storage/fancy/cigarettes/cigars/havana{
-	pixel_y = -8;
-	pixel_x = 4
-	},
-/obj/item/lighter{
-	pixel_y = -16;
-	pixel_x = 13
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"we" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"wg" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/bed{
-	icon_state = "dirty_mattress"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/security)
-"wr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-8"
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/f3/sentry,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"eb" = (
+/obj/structure/platform/wood{
+	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"wt" = (
-/turf/closed/mineral/random/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"wu" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/neutured,
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/ship/storage)
-"wG" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"wH" = (
-/obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"wN" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/security)
-"wZ" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"xi" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high{
-	pixel_y = -5;
-	pixel_x = -3
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"xj" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8;
-	name = "tactical chair"
-	},
-/obj/effect/turf_decal/techfloor{
+/area/overmap_encounter/planetoid/cave/explored)
+"ec" = (
+/obj/effect/turf_decal/trimline/opaque/green/filled/shrink_cw{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/vomit/old{
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"ef" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/corner/opaque/yellow,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"eg" = (
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/cave/explored)
+"ei" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"en" = (
+/obj/structure/flora/driftlog,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eo" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "shotgun";
+	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "shotgun";
+	pixel_x = 4;
+	pixel_y = -6
 	},
-/obj/machinery/light/directional/east,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"xn" = (
-/obj/structure/table/wood,
-/obj/item/trash/tray,
-/obj/item/trash/waffles,
-/obj/item/trash/energybar,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/hallway)
-"xr" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 1
-	},
-/obj/effect/turf_decal/industrial/traffic,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/internals,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"xv" = (
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"xx" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"xG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/trash/can/food{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/trash/candy{
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"xI" = (
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/security)
-"xR" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/plastic,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/industrial/warning,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"xT" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"yj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/structure/bed{
-	icon_state = "dirty_mattress"
-	},
-/obj/effect/decal/cleanable/vomit/old,
-/obj/structure/grille/broken,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"yk" = (
-/obj/effect/turf_decal/borderfloor,
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"yv" = (
-/obj/effect/turf_decal/industrial/warning,
-/obj/effect/decal/cleanable/oil{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ship/storage)
-"yx" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/asteroid/dirt,
-/area/overmap_encounter/planetoid/jungle/explored)
-"yA" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/jungle/cavecrew/cargo)
-"yC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/fluff/hedge,
-/obj/structure/curtain/bounty,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"yD" = (
-/obj/structure/cable{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/jungle/cavecrew/cargo)
-"yJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/jungle/cavecrew/cargo)
-"yV" = (
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"yW" = (
-/obj/structure/closet/crate/goldcrate,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"yZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"zj" = (
-/obj/structure/cable{
-	icon_state = "0-6"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"zG" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = -13;
-	pixel_y = -14
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"zJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/secure_closet/freezer/kitchen/wall{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/item/circuitboard/machine/microwave{
-	pixel_y = -5;
-	pixel_x = -5
-	},
-/obj/item/circuitboard/machine/reagentgrinder,
-/obj/item/circuitboard/machine/processor{
-	pixel_y = -4;
-	pixel_x = 1
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/hallway)
-"zN" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating/catwalk_floor,
-/area/ruin/jungle/cavecrew/hallway)
-"zV" = (
-/obj/structure/table/wood/reinforced,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/obj/item/toy/figure/vanguard{
-	pixel_y = 2;
-	pixel_x = -8
-	},
-/obj/item/toy/figure/warden{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/food/candyheart{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"zX" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 3.1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Af" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor/hole/right,
-/obj/structure/cable{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"Ag" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/item/desk_flag{
-	pixel_x = -6;
-	pixel_y = 17
-	},
-/obj/item/megaphone/sec{
-	name = "syndicate megaphone";
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/camera_bug{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"Ap" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -17;
-	pixel_x = -11
-	},
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"At" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -17;
-	pixel_x = -11
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"AK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/hallway)
-"AR" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 3.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
-	dir = 8
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"AV" = (
 /obj/structure/cable{
 	icon_state = "1-6"
 	},
-/turf/open/floor/plasteel/stairs/left,
-/area/ruin/jungle/cavecrew/bridge)
-"Be" = (
-/obj/structure/bed,
-/obj/effect/spawner/random/bedsheet,
-/obj/structure/curtain/cloth/grey,
-/turf/open/floor/carpet/red_gold,
-/area/ruin/jungle/cavecrew/dormitories)
-"Bp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/turf_decal/techfloor,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"Bt" = (
-/obj/effect/turf_decal/industrial/warning/corner{
-	color = "#808080";
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"Bv" = (
-/turf/open/floor/plasteel/stairs/right,
-/area/ruin/jungle/cavecrew/bridge)
-"Bz" = (
-/obj/machinery/vending/donksofttoyvendor,
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/hallway)
-"BI" = (
-/obj/machinery/porta_turret/ruin/ramzi{
-	faction = list("Frontiersmen")
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ship/storage)
-"BO" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/gear,
-/obj/item/gun/ballistic/automatic/smg/skm_carbine{
-	pixel_y = -6
-	},
-/obj/item/gun/ballistic/automatic/zip_pistol,
-/obj/item/gun/ballistic/automatic/zip_pistol,
-/obj/item/gun/ballistic/automatic/zip_pistol,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"BR" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = -1;
-	pixel_y = 17
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"BT" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = -2;
-	pixel_x = -4
-	},
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"BU" = (
-/obj/structure/closet/crate/silvercrate,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"Cc" = (
-/obj/item/stack/ore/salvage/scrapmetal/ten{
-	pixel_x = 2;
-	pixel_y = -4
-	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/jungle/cavecrew/cargo)
-"Cq" = (
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/powered)
-"Cr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/item/book/manual/wiki/engineering{
-	pixel_x = 5;
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"CC" = (
-/obj/effect/turf_decal/industrial/warning/dust/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"CF" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"CJ" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 3.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"CN" = (
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/human/frontier,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"CT" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"CU" = (
-/obj/effect/turf_decal/industrial/warning/corner,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"CZ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"Df" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/rock/pile/largejungle,
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Dg" = (
-/obj/structure/table/wood/reinforced,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/trash/can/food{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/item/storage/crayons{
-	pixel_y = -8;
-	pixel_x = 5
-	},
-/obj/item/melee/energy/sword/saber/pirate/red,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"Dh" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Dq" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"Dt" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"DJ" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 5;
-	pixel_x = 10
-	},
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"DP" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 6;
-	color = "#808080"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"DV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Eb" = (
-/obj/structure/bed{
-	icon_state = "dirty_mattress"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood,
-/obj/item/food/grown/berries/poison{
-	pixel_x = -9;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/security)
-"Ec" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine,
-/obj/structure/closet/crate/secure/weapon,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"Ej" = (
-/obj/structure/railing{
-	dir = 10;
-	layer = 3.1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Em" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/techfloor/hole,
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"Ep" = (
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"Es" = (
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"EG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"EI" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -1;
-	pixel_y = -37
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"EO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/powered)
-"EP" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/closed/mineral/random/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"EZ" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/engine/hull/reinforced/interior,
-/area/ship/storage)
-"Fs" = (
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Fw" = (
-/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"Fy" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/chair/comfy/orange/directional/east{
-	buildstackamount = 0;
-	color = "#c45c57"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"FB" = (
-/obj/structure/cable{
-	icon_state = "2-9"
-	},
-/obj/item/stack/rods/ten{
-	pixel_x = 7
-	},
-/obj/machinery/light/directional/east{
-	pixel_x = 24
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/jungle/cavecrew/cargo)
-"FY" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 13;
-	pixel_y = 7
-	},
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 5;
-	pixel_y = 11
-	},
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -2;
-	pixel_y = 1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Ge" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 1
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/hallway)
-"Gh" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Gk" = (
-/obj/machinery/door/window/southleft{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/hallway)
-"Gm" = (
-/obj/structure/railing{
-	dir = 9;
-	layer = 4.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"Go" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/machinery/light/directional/west,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Gy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
-/obj/structure/cable{
-	icon_state = "2-10"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"GL" = (
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"GN" = (
-/obj/machinery/porta_turret/ruin/ramzi{
-	faction = list("Frontiersmen")
-	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/dormitories)
-"GR" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 3;
-	pixel_y = 9
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Hk" = (
-/obj/structure/flora/tree/jungle/small{
-	icon_state = "tree2"
-	},
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Hx" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"HD" = (
-/obj/item/chair/greyscale{
-	dir = 8;
-	pixel_y = -7;
-	pixel_x = -3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/robot_debris,
-/obj/effect/decal/cleanable/oil,
-/obj/item/stack/cable_coil/cut/yellow,
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/dormitories)
-"HI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/jungle/cavecrew/cargo)
-"HL" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"HQ" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"HW" = (
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_x = -11;
-	pixel_y = 19
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Ie" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 10
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"Ir" = (
-/obj/structure/spacevine,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Is" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table/wood/reinforced,
-/obj/item/paicard{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/flashlight/lamp{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_carp{
-	pixel_y = 1;
-	pixel_x = -5
-	},
-/obj/item/lighter/greyscale{
-	pixel_x = -1;
-	pixel_y = -6
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"Iu" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 9
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Iv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"Ix" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/powered)
-"Iz" = (
-/obj/structure/girder,
-/obj/structure/flora/grass/jungle/b,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"IA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
-/turf/open/water/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"II" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/item/book/manual/wiki/hacking{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/book/manual/wiki/cooking{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/garbage{
-	pixel_x = 10;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"IJ" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"IN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-10"
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"IZ" = (
-/obj/item/reagent_containers/syringe/contraband/morphine{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe/contraband/methamphetamine,
-/obj/item/reagent_containers/food/drinks/mead{
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/closet/wall/directional/west,
-/obj/item/restraints/handcuffs/cable/white,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/chem_pile,
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/plastic,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/wood{
-	icon_state = "wood-broken2"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"Jg" = (
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/cave/explored)
-"Jh" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old{
-	pixel_y = -5;
-	pixel_x = 3
-	},
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Jm" = (
-/obj/structure/flora/rock{
-	icon_state = "basalt2";
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Jt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/pod/light,
-/area/ruin/jungle/cavecrew/hallway)
-"Jz" = (
-/turf/closed/wall/rust,
-/area/overmap_encounter/planetoid/cave/explored)
-"JB" = (
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/jungle/cavecrew/cargo)
-"JJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -21;
-	pixel_y = 11
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/dormitories)
-"JK" = (
-/obj/item/soap{
-	pixel_x = 13;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/glass/bucket/wooden{
-	pixel_x = -9
-	},
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/wrapping,
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/security)
-"JO" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "6-8"
-	},
-/obj/structure/closet/crate/science,
-/obj/item/storage/box/stockparts/t2{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/obj/item/storage/backpack/duffelbag{
-	pixel_y = -5
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"JQ" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"JY" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Ka" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"Kb" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 1;
-	name = "tactical chair"
-	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/storage)
-"Kh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/hatch{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/jungle/cavecrew/hallway)
-"Kw" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/closed/mineral/random/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Kx" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"Kz" = (
-/obj/structure/cable{
-	icon_state = "1-9"
-	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"KA" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/ruin/powered)
-"KF" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "gut_engines";
-	name = "Thruster Blast Door"
-	},
-/turf/open/floor/plating,
-/area/ship/storage)
-"KH" = (
-/obj/structure/window/reinforced/spawner/east,
-/obj/effect/turf_decal/techfloor{
-	dir = 5
-	},
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/grenade/chem_grenade/metalfoam{
-	pixel_x = 2
-	},
-/obj/item/grenade/chem_grenade/metalfoam{
-	pixel_x = 6
-	},
-/obj/item/grenade/empgrenade{
-	pixel_x = -4
-	},
-/obj/item/grenade/frag,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"KK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/powered)
-"KM" = (
-/obj/structure/cable{
-	icon_state = "2-6"
-	},
-/obj/structure/cable{
-	icon_state = "0-6"
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"KW" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/table_bell{
-	pixel_x = 9;
-	pixel_y = -1
-	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/dice/d2,
-/obj/item/spacecash/bundle/c1000{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/spacecash/bundle/c1000{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"Lb" = (
-/obj/structure/bed,
-/obj/structure/curtain/cloth/grey,
-/obj/item/bedsheet/hos,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red_gold,
-/area/ruin/jungle/cavecrew/dormitories)
-"Ll" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = 14;
-	pixel_y = 1
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Lm" = (
-/obj/structure/girder/displaced,
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Lo" = (
-/obj/structure/table/reinforced{
-	color = "#c1b6a5"
-	},
-/obj/machinery/fax/ruin,
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"Ls" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 8
-	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Lv" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Lw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"Ly" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"LB" = (
-/obj/effect/turf_decal/industrial/warning/dust{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"LD" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 5;
-	color = "#808080"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/jungle/cavecrew/security)
-"LV" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"Ma" = (
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Mg" = (
-/obj/effect/turf_decal/industrial/warning/dust/corner,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Mm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Mn" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/ruin/jungle/cavecrew/cargo)
-"Ms" = (
-/obj/structure/railing{
-	dir = 2;
-	layer = 4.1
-	},
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi';
-	dir = 8
-	},
-/area/ruin/powered)
-"Mv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"MC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/cargo)
-"MR" = (
-/mob/living/simple_animal/hostile/carp,
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"MT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-5"
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/rifle/neutered,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"MW" = (
-/mob/living/simple_animal/crab/evil,
-/turf/open/floor/plating/asteroid/dirt,
-/area/overmap_encounter/planetoid/jungle/explored)
-"MY" = (
-/obj/machinery/suit_storage_unit/inherit/industrial,
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/security)
-"Nc" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/secure/loot,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"Nf" = (
-/obj/structure/spacevine,
-/turf/closed/mineral/random/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Nj" = (
-/obj/structure/flora/ausbushes/sunnybush{
-	pixel_x = 12;
-	pixel_y = 2
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/jungle/cavecrew/cargo)
-"Nl" = (
-/obj/structure/closet/cabinet,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/clothing/under/frontiersmen,
-/obj/item/clothing/head/beret/sec/frontier,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/machinery/light/small/broken/directional/north,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/jungle/cavecrew/dormitories)
-"Nn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"No" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"Np" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"Nr" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/hallway)
-"Ns" = (
-/obj/structure/flora/rock/jungle{
-	pixel_x = 3;
-	pixel_y = 9
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Nu" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/cargo)
-"NH" = (
-/obj/machinery/door/window/brigdoor/southright{
-	dir = 4
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"NK" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"NN" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/machinery/door/poddoor{
-	id = "gut_engines";
-	name = "Thruster Blast Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/storage)
-"NR" = (
-/turf/open/floor/plating/asteroid/dirt/jungle/dark,
-/area/overmap_encounter/planetoid/jungle/explored)
-"NW" = (
-/obj/structure/destructible/tribal_torch/lit{
-	pixel_x = 16;
-	pixel_y = 15
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Oa" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/patterned/cargo_one,
-/area/ruin/jungle/cavecrew/cargo)
-"Oe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Oi" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/security)
-"OJ" = (
-/obj/effect/turf_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"OU" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/beret/sec/frontier{
-	pixel_y = 10;
-	pixel_x = -4
-	},
-/obj/item/storage/toolbox/ammo{
-	pixel_y = 2
-	},
-/obj/item/storage/toolbox/ammo{
-	pixel_y = -6;
-	pixel_x = -5
-	},
-/obj/item/grenade/frag{
-	pixel_x = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"OZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Pg" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/structure/cable{
-	icon_state = "5-8"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Pj" = (
-/obj/effect/turf_decal/techfloor,
-/obj/structure/closet/crate,
-/obj/item/clothing/suit/space/nasavoid/old,
-/obj/item/clothing/head/helmet/space/nasavoid/old,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Pv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/ruin/powered)
-"Pz" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/engineering)
-"PB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"PG" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"PR" = (
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ship/storage)
-"PS" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"PU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"Qh" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8;
-	name = "tactical chair"
-	},
-/obj/effect/turf_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#808080"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Ql" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"ep" = (
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 14;
 	pixel_x = 2
@@ -3261,37 +785,1742 @@
 	},
 /turf/open/water/jungle/lit,
 /area/overmap_encounter/planetoid/jungle/explored)
-"Qr" = (
+"er" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/turf/open/floor/concrete/slab_3{
+	dir = 8
+	},
+/area/ruin/jungle/cavecrew/cargo)
+"es" = (
+/turf/template_noop,
+/area/template_noop)
+"et" = (
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"eE" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"eF" = (
+/obj/structure/platform/wood{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -11;
+	pixel_y = 12
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 4;
+	pixel_y = 14
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"eG" = (
+/obj/structure/cable{
+	icon_state = "2-6"
+	},
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"eN" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/ruin/jungle/cavecrew/hallway)
+"eO" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/gun_maint_kit,
+/obj/item/gun_maint_kit,
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"eQ" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/oil{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/atmospherics/components/unary/shuttle/fire_heater{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/jungle/cavecrew/ship)
+"eU" = (
+/obj/machinery/atmospherics/components/binary/valve/on,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"eY" = (
+/obj/structure/spacevine,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"fb" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"fg" = (
+/turf/open/floor/plating/asteroid/dirt,
+/area/overmap_encounter/planetoid/cave/explored)
+"fr" = (
+/obj/effect/turf_decal/corner_steel_grid/diagonal,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"fu" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fv" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"fy" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 6
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"fz" = (
+/obj/structure/girder,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"fD" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"fG" = (
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"fI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"fN" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"fS" = (
+/obj/structure/girder,
+/turf/open/floor/plating/asteroid/dirt,
+/area/overmap_encounter/planetoid/cave/explored)
+"fT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"fX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"fY" = (
+/obj/structure/spacevine,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ge" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gh" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"gk" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/wrapping,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/industrial/warning,
+/obj/item/storage/toolbox/syndicate{
+	pixel_y = 5;
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/jungle/cavecrew/ship)
+"gm" = (
+/obj/machinery/portable_atmospherics/canister/chlorine{
+	name = "shoddily constructed chlorine canister";
+	desc = "This canister of chlorine seems really week. Best hope it doesn't end up in your line of fire!";
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50)
+	},
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"go" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken7"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"gq" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"gs" = (
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"gu" = (
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"gv" = (
+/obj/machinery/porta_turret/ruin/frontiersmen,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/jungle/cavecrew/ship)
+"gw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"gA" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"gC" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"gD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"gF" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"gG" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"gM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Armory"
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"gP" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -4;
+	pixel_y = -6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gR" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"gS" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"gU" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"ha" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"hg" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"hh" = (
+/obj/machinery/light/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/industrial/warning/dust/corner{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/ruin/powered)
-"Qx" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"hi" = (
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"hm" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"hp" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"hs" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"ht" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"hz" = (
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = -7;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew)
+"hB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"hE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"hM" = (
+/obj/structure/chair/office{
+	dir = 1;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1;
+	layer = 2.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/wasp,
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"hQ" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hU" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/structure/table,
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ib" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/machinery/camera/autoname,
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = 9;
+	pixel_y = -8
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/corner/opaque/red/three_quarters{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ih" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 17;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ij" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"ik" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iv" = (
+/obj/structure/spacevine,
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ix" = (
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"iz" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"iA" = (
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"iD" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iM" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/obj/item/reagent_containers/glass/concrete_bag,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"iT" = (
+/obj/structure/railing{
+	layer = 3.1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"iV" = (
+/turf/closed/wall/concrete,
+/area/ruin/jungle/cavecrew)
+"iW" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ja" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"jb" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/tan/half,
+/obj/effect/turf_decal/road/slow,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"jd" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"jf" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"jg" = (
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"jh" = (
+/obj/structure/flora/tree/jungle,
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"Qy" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
+"ji" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/ruin/jungle/cavecrew/hallway)
-"Qz" = (
-/obj/structure/flora/tree/jungle/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"jm" = (
+/obj/item/storage/box/stockparts/t2{
+	pixel_x = 4;
+	pixel_y = 3;
+	name = "FIX THE GODDAMN OREMACHINE"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"jn" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"jv" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/structure/spacevine,
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"QE" = (
+"jz" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jA" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/mineral/processing_unit_console{
+	pixel_y = 20;
+	machinedir = 2;
+	output_dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/spitter,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"jF" = (
+/obj/structure/flora/grass/jungle,
 /obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"jM" = (
+/obj/structure/spacevine,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jO" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"jR" = (
+/obj/effect/turf_decal/atmos/plasma,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/industrial/warning/dust,
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"jS" = (
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 4;
+	layer = 2.01
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"jU" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 5
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"jW" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ka" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"kc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"kd" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ki" = (
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/obj/structure/guncloset,
+/obj/effect/turf_decal/industrial/warning{
+	dir = 6
+	},
+/obj/item/gun/ballistic/automatic/smg/skm_carbine,
+/obj/item/gun/ballistic/shotgun/automatic/slammer{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"kj" = (
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ks" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"kt" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 3.1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/table,
+/obj/item/binoculars,
+/obj/item/flashlight{
+	pixel_x = -1;
+	pixel_y = 11
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"kv" = (
+/obj/structure/sign/poster/rilena/ri{
+	pixel_x = 0;
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"kw" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kA" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 17;
+	pixel_x = 3
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"kB" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"kE" = (
+/obj/item/trash/can,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"kH" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"kL" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"kO" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew/ship)
+"kQ" = (
+/obj/item/storage/box/ammo/a12g_beanbag,
+/obj/item/gun/ballistic/shotgun/doublebarrel/empty,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"kR" = (
+/obj/structure/chair/bench/grey/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"kS" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"kV" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kW" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lb" = (
+/obj/structure/flora/driftlog,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ld" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"ll" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lm" = (
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"lo" = (
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"lu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/three_quarters,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"ly" = (
+/obj/structure/sign/poster/contraband/backdoor_xeno_babes_6,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/dormitories)
+"lz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"lA" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"lD" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lF" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"lH" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"lI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken4"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"lM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"lR" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"lS" = (
+/obj/machinery/conveyor{
+	id = "sbase";
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"lV" = (
+/turf/closed/wall/concrete,
+/area/ruin/jungle/cavecrew/bridge)
+"lY" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/overmap_encounter/planetoid/cave/explored)
+"mb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"mc" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"mm" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"mt" = (
+/obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/spacevine,
 /turf/open/water/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"QG" = (
-/obj/effect/turf_decal/industrial/warning,
-/turf/open/floor/plasteel/patterned,
+"mv" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"mx" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -6;
+	pixel_y = -20
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -11;
+	pixel_y = -14
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"my" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/turf_decal/techfloor,
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder,
+/turf/open/floor/plasteel/patterned/jungleplanet,
 /area/ruin/jungle/cavecrew/cargo)
-"QH" = (
+"mz" = (
+/obj/effect/turf_decal/corner_steel_grid/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/grenade/firecracker{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/item/assembly/timer{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/item/stack/sheet/metal{
+	pixel_x = -15;
+	pixel_y = 0
+	},
+/obj/item/stack/sheet/metal{
+	pixel_x = -13;
+	pixel_y = 3
+	},
+/obj/item/screwdriver{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"mC" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine/hull,
+/area/ruin/jungle/cavecrew/ship)
+"mG" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/trash/candy,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"mI" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/item/trash/raisins,
+/obj/item/trash/raisins,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/effect/spawner/random/trash/crushed_can,
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"mJ" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"mK" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"mL" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 0
+	},
 /obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"mM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/bait_can/worm,
+/obj/item/fishing_line,
+/obj/item/fishing_rod,
+/obj/item/fishing_hook,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"mO" = (
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew/cargo)
+"mY" = (
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"na" = (
+/obj/structure/flora/grass/jungle/b{
+	pixel_x = 10;
+	pixel_y = -19
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew)
+"ne" = (
+/turf/closed/indestructible/rock/jungle,
+/area/ruin/jungle/cavecrew/bridge)
+"ni" = (
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"np" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nq" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"nr" = (
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/obj/structure/chair/sofa/olive/old/left,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/surgeon{
+	environment_smash = 0
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"nu" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"nv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"nC" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/corner/opaque/red/half,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"nI" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nJ" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/hand_labeler,
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"nO" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 3.1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/jungleplanet/lit,
+/area/overmap_encounter/planetoid/cave/explored)
+"nQ" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nT" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"nV" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cavecheckpointnorth";
+	name = "Checkpoint North"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"od" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"oe" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"of" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"oh" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 7;
+	pixel_y = 27
+	},
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ol" = (
+/obj/structure/chair/office{
+	dir = 1;
+	pixel_x = -7
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 4;
+	layer = 2.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"om" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oq" = (
+/obj/structure/dresser,
+/obj/item/reagent_containers/food/drinks/soda_cans/vimukti{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/vimukti{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/vimukti{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"ov" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ow" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/heavy/neutered{
+	name = "The Cook"
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ox" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"oD" = (
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg3"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"oJ" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew/ship)
+"oM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"oP" = (
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"oR" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/turf_decal/corner/opaque/blue/half{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"oS" = (
+/obj/structure/flora/junglebush/large{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oV" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew)
+"oW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/hazard/electrical/electrified_water,
+/turf/open/water/jungle,
+/area/ruin/jungle/cavecrew)
+"oZ" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"pa" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/salvageable/computer,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 6
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"pc" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"pg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"pj" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/machinery/computer/helm{
+	icon_state = "computer-left"
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"pk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"pl" = (
+/obj/structure/sign/poster/contraband/hacking_guide,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/engineering)
+"pn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"pq" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pv" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/salvage/scrapuranium/five,
+/obj/item/stack/ore/salvage/scrapplasma/five,
+/obj/item/stack/ore/salvage/scrapplasma/five,
+/obj/item/stack/ore/salvage/scrapplasma/five,
+/obj/item/stack/ore/salvage/scrapsilver/five,
+/obj/item/stack/ore/salvage/scraptitanium/five,
+/obj/item/stack/ore/salvage/scraptitanium/five,
+/obj/item/stack/ore/salvage/scrapmetal/twenty,
+/obj/item/stack/ore/salvage/scrapmetal/ten,
+/obj/effect/turf_decal/road/slow{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/tan/half{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"pC" = (
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = 8;
+	pixel_y = 15;
+	density = 0
+	},
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"pG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/obj/structure/marker_beacon,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"pK" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"pY" = (
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden,
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"qb" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	pixel_x = -5;
+	pixel_y = 24;
+	id = "bunker-control"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"qj" = (
+/obj/effect/turf_decal/atmos/plasma,
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"qr" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"qu" = (
+/obj/effect/spawner/bunk_bed,
+/obj/item/toy/plush/lizardplushie{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"qx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"qL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"qM" = (
+/obj/structure/chair{
+	pixel_x = -9;
+	pixel_y = 3;
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/internals/neutered/sentry{
+	desc = "A member of the brutal Frontiersman terrorist fleet! This one waits patiently, their finger on the trigger, as the glint of their scope in the sun catches your eye. A pin on their lapel reads 'proudly vegan!'."
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"qO" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/suit_storage_unit,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"qU" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qZ" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "8-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"rg" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"rh" = (
+/obj/effect/spawner/bunk_bed,
+/obj/item/toy/plush/snakeplushie{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/ruin/jungle/cavecrew/dormitories)
+"rm" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"rn" = (
+/turf/closed/indestructible/rock/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"rr" = (
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"rA" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/ship)
+"rK" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rN" = (
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rU" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"rY" = (
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/obj/structure/flora/ausbushes/sunnybush{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/hallway)
+"sa" = (
+/obj/effect/turf_decal/trimline/opaque/green/filled/shrink_ccw{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"sh" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"sj" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken2"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"sl" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"sn" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/machinery/door/airlock/grunge,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"sr" = (
+/obj/structure/marker_beacon,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"st" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Checkpoint"
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"sv" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/chair/sofa/olive/old/right/directional,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"sx" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"sI" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"sJ" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -3307,169 +2536,2928 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
 /area/ruin/jungle/cavecrew/engineering)
-"QI" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"QN" = (
-/obj/effect/decal/cleanable/dirt,
+"sL" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sM" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 5
+	},
 /obj/structure/cable{
-	icon_state = "4-10"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"QX" = (
-/obj/structure/table/wood/reinforced,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/turf/open/floor/pod,
+/area/ruin/jungle/cavecrew/ship)
+"sP" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can{
+	pixel_x = 12;
+	pixel_y = 15
 	},
-/obj/item/flashlight/lamp/green{
-	pixel_y = 13;
-	pixel_x = -7
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"sR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"sV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 8
 	},
-/obj/item/pen{
-	pixel_y = 8;
-	pixel_x = 5
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"sZ" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/item/pen/charcoal{
-	pixel_y = 1;
-	pixel_x = 5
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ta" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cavecheckpointsouth";
+	name = "Checkpoint South"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"to" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"tp" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"ts" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"tu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner_steel_grid/diagonal,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"tw" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.01
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Armory";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"tx" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"tA" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1;
+	name = "tactical chair"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/wasp,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/jungle/cavecrew/ship)
+"tB" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken4"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"tC" = (
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11;
+	pixel_y = -28
+	},
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/item/toy/plush/moth/punished,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"tK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/door{
+	pixel_x = 22;
+	pixel_y = 9;
+	dir = 8;
+	id = "cavecheckpointnorth"
+	},
+/obj/effect/turf_decal/trimline/opaque/tan/filled/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"tQ" = (
+/turf/closed/wall/concrete,
+/area/ruin/jungle/cavecrew/engineering)
+"tX" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/structure/curtain/cloth{
+	open = 0;
+	icon_state = "bathroom-closed"
+	},
+/turf/open/floor/plasteel/stairs/jungleplanet,
 /area/ruin/jungle/cavecrew/dormitories)
-"Rd" = (
+"tY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"tZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"ua" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/bridge)
+"uf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.01
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Power Control"
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"uk" = (
+/obj/structure/girder,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"un" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"uq" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/flame/neuter{
+	wander = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"uu" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered/sentry,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"uz" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/wall/directional/west{
+	name = "Slop Closet"
+	},
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium{
+	pixel_x = -6;
+	pixel_y = -2;
+	name = "Secret Ingredient"
+	},
+/obj/item/food/grown/peas,
+/obj/item/food/grown/peas,
+/obj/item/food/deadmouse,
+/obj/item/food/deadmouse,
+/obj/item/food/deadmouse,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"uB" = (
+/obj/structure/railing/corner,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"uC" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 3.1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"uJ" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"uN" = (
+/obj/machinery/button/door{
+	pixel_x = 22;
+	pixel_y = -9;
+	dir = 8;
+	id = "cavecheckpointsouth"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/tan/filled/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"uR" = (
+/obj/machinery/mineral/unloading_machine{
+	input_dir = 2;
+	output_dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"uX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/railing{
 	dir = 4;
 	layer = 4.1
 	},
-/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/industrial/caution/white{
+	color = "#d2d53d";
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"uY" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"vb" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	layer = 4.1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/pounder/space{
+	environment_smash = 0
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"vd" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper{
+	environment_smash = 0
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ve" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"vg" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew/ship)
+"vh" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"vi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"vk" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg3"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"vr" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree2"
+	},
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vt" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"vJ" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vM" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/meat,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"vO" = (
+/obj/structure/flora/driftlog,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vY" = (
+/turf/closed/wall/concrete,
+/area/ruin/jungle/cavecrew/hallway)
+"we" = (
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"wf" = (
+/obj/structure/flora/junglebush/large{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wg" = (
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wk" = (
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"wq" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wr" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew)
+"ws" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wt" = (
+/obj/machinery/light/directional/west,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/pill_bottle/tramal{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/revolver/ashhand{
+	pixel_y = 8;
+	pixel_x = -3
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/blackmarket_uplink{
+	pixel_x = 10;
+	pixel_y = -5
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -3;
+	pixel_y = -10
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"ww" = (
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wz" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular,
+/obj/item/roller,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"wB" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wE" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew)
+"wF" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"wG" = (
+/obj/item/clothing/suit/armor/vest/frontier,
+/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
+/obj/item/clothing/mask/gas/frontiersmen,
+/obj/structure/closet,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"wN" = (
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"wP" = (
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"wQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"xh" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"xi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Mess Hall"
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"xr" = (
+/obj/structure/spacevine,
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xu" = (
+/obj/structure/falsewall/plastitanium,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"xv" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"xI" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"xJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"xL" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"xS" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"yj" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yk" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"yr" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"yx" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"yA" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"yC" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"yJ" = (
+/obj/structure/flora/ausbushes/sunnybush{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/fermenting_barrel{
+	pixel_x = -14;
+	pixel_y = -8
+	},
+/obj/structure/fermenting_barrel{
+	pixel_x = -28;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/cargo)
+"yK" = (
+/obj/machinery/porta_turret/ruin/frontiersmen{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew)
+"yU" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"yW" = (
+/obj/structure/fluff/fokoff_sign,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yZ" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"zf" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing/corner,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"zl" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/item/clothing/head/hardhat{
+	pixel_x = -11;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/jungleplanet/lit,
+/area/ruin/jungle/cavecrew)
+"zr" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"zt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"zu" = (
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"zG" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "getout";
+	pixel_y = -13;
+	pixel_x = -28
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"zI" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/storage/box/ammo/a762_40,
+/obj/item/storage/box/ammo/a762_40,
+/obj/item/ammo_box/magazine/skm_762_40/extended/empty,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"zJ" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"zL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2
+	},
+/obj/structure/closet/cabinet,
+/obj/item/clothing/head/frontier/peaked,
+/obj/item/clothing/under/frontiersmen/officer,
+/obj/item/clothing/suit/armor/frontier,
+/obj/item/clothing/shoes/combat,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"zM" = (
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1;
+	layer = 2.01
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"zN" = (
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"zW" = (
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"zX" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/suit_storage_unit/inherit,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"Af" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Aj" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Al" = (
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"As" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet/lit,
+/area/ruin/jungle/cavecrew/bridge)
+"At" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/punji_sticks,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"AE" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"AH" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"AR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"AV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull,
+/area/ruin/jungle/cavecrew/ship)
+"AW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ba" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/storage/fancy/cigarettes/cigars/havana{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/phone{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 13;
+	pixel_x = 8
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Bd" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8;
+	name = "tactical chair"
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/turf/open/floor/engine/hull,
+/area/ruin/jungle/cavecrew/ship)
+"Be" = (
+/obj/machinery/button/shieldwallgen{
+	dir = 1;
+	id = "gut_holo";
+	pixel_x = -2;
+	pixel_y = -21
+	},
+/obj/machinery/button/door{
+	id = "gut_cargo";
+	name = "Cargo Door Control";
+	pixel_y = -22;
+	dir = 1;
+	pixel_x = -11
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "gut_cargo";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "gut_holo";
+	dir = 1
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ruin/jungle/cavecrew/ship)
+"Bo" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bp" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "getout";
+	pixel_y = -3;
+	pixel_x = -5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/bigplant,
+/turf/open/floor/plating/jungleplanet/lit,
+/area/ruin/jungle/cavecrew/bridge)
+"Bs" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = -2;
+	pixel_x = -4
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bt" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/reagent_containers/glass/rag,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Bv" = (
+/obj/structure/table,
+/obj/item/reagent_containers/pill/finobranc,
+/obj/item/reagent_containers/pill/finobranc{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/pill/finobranc{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/structure/large_mortar,
+/obj/item/pestle,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Bx" = (
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"By" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Bz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty{
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"BF" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"BH" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/attachment/bayonet,
+/obj/item/attachment/bayonet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"BJ" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/transparent/green/filled/warning,
+/turf/open/floor/plasteel/patterned/brushed,
+/area/ruin/jungle/cavecrew/ship)
+"BN" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/modular_computer/laptop/preset/civilian/rilena{
+	pixel_x = -3;
+	pixel_y = 12
+	},
+/obj/machinery/jukebox/boombox{
+	pixel_x = 6;
+	pixel_y = -14
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew)
+"BP" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"BS" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"BT" = (
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"BV" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg1"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Cc" = (
+/obj/structure/curtain/cloth{
+	open = 0;
+	icon_state = "bathroom-closed"
+	},
+/turf/open/floor/plasteel/stairs/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Cd" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/closet/body_bag{
+	name = "body bag - Mark #2"
+	},
+/obj/effect/mob_spawn/human/corpse/damaged,
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6;
+	layer = 2.01
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Cg" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Cl" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 14;
+	pixel_y = 1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Co" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Cq" = (
+/obj/structure/spacevine,
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Cr" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Cv" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/chair/bench/grey/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Cy" = (
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg2"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"CB" = (
+/obj/structure/flora/driftwood,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CC" = (
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"CD" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"CF" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"CH" = (
+/obj/structure/spacevine,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"CJ" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"CN" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"CO" = (
+/obj/structure/flora/tree/jungle/small{
+	icon_state = "tree2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CP" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CR" = (
+/obj/machinery/porta_turret/ruin/frontiersmen{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/jungle/cavecrew/ship)
+"CY" = (
+/obj/structure/flora/rock/jungle{
+	pixel_y = 13
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"CZ" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"Da" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/spacevine,
+/obj/structure/flora/ausbushes/sunnybush{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Dh" = (
+/obj/machinery/fax/ruin,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 9
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Do" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null;
+	anchored = 1
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Dx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/glass,
+/obj/item/toy/cards/deck{
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/item/toy/cards/deck/tarot{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/book/fish_catalog{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"DB" = (
+/obj/effect/turf_decal/techfloor,
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"DC" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"DH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = -15;
+	pixel_y = 2
+	},
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"DJ" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"DK" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DP" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"DS" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew/cargo)
+"DW" = (
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/obj/structure/rack,
+/obj/effect/turf_decal/industrial/traffic{
+	dir = 10
+	},
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/glasses/welding{
+	pixel_y = 5
+	},
+/obj/item/multitool{
+	pixel_x = 9
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"DX" = (
+/obj/structure/spacevine,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DY" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"DZ" = (
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Em" = (
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Es" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ew" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ey" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = -11;
+	pixel_y = 13
+	},
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"EA" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"EH" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"EI" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"EK" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew/engineering)
+"EM" = (
+/obj/effect/turf_decal/trimline/opaque/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"EN" = (
+/mob/living/simple_animal/hostile/human/frontier/civilian{
+	r_hand = null
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"EP" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"EU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 1
+	},
+/area/ruin/jungle/cavecrew)
+"Fa" = (
+/obj/structure/chair/comfy/grey/directional/east,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Fe" = (
+/obj/structure/cable{
+	icon_state = "0-10"
+	},
+/obj/item/stack/cable_coil/random/five,
+/obj/item/wirecutters,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Fm" = (
+/obj/machinery/porta_turret/ruin/frontiersmen{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/ruin/jungle/cavecrew/ship)
+"Fp" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5";
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/machinery/button/door{
+	pixel_x = -8;
+	pixel_y = 11;
+	dir = 8;
+	id = "cavecheckpointnorth"
+	},
+/obj/item/reagent_containers/food/drinks/rilenacup{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/toy/plush/rilena{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/machinery/button/door{
+	pixel_x = -8;
+	pixel_y = 0;
+	dir = 8;
+	id = "cavecheckpointsouth"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew)
+"Fq" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fw" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Fy" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"FK" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"FN" = (
+/obj/structure/platform/wood{
+	dir = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Gd" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Gf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Gg" = (
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Gh" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/turf/open/floor/engine/hull/reinforced,
+/area/ruin/jungle/cavecrew/ship)
+"Gm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high{
+	pixel_y = -5;
+	pixel_x = -3
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Gn" = (
+/obj/machinery/computer/crew/syndie{
+	dir = 8;
+	icon_state = "computer-right"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Go" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Gq" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Gr" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "gut_cargo";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	id = "gut_holo"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ruin/jungle/cavecrew/ship)
+"Gy" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/card/minor/cmo{
+	dir = 8;
+	icon_state = "computer-left"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"GF" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"GJ" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"GK" = (
+/obj/effect/turf_decal/atmos/oxygen,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"GN" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/turf_decal/techfloor{
+	dir = 8
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"GT" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg2"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"GU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"GV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"GW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/structure/sign/poster/contraband/missing_gloves{
+	pixel_x = 0;
+	pixel_y = 30
+	},
+/obj/structure/railing{
+	dir = 8;
+	layer = 4.1
+	},
 /obj/effect/turf_decal/industrial/warning,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"GZ" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Hb" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hc" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Hd" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 8;
+	pixel_y = -11
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Hj" = (
+/obj/machinery/light/directional/east,
+/obj/item/kirbyplants{
+	icon_state = "plant-12";
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/corner/opaque/red/three_quarters{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Hp" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/neutered{
+	environment_smash = 0
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Hw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Hx" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"HD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "cavecheckpointnorth";
+	name = "Checkpoint North"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"HG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"HI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins{
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	name = "shitty plasma canister";
+	max_integrity = 60;
+	desc = "A shoddily constructed container of Plasma gas. Highly toxic."
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"HL" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "gut_cargo";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/engine/hull/interior,
+/area/ruin/jungle/cavecrew/ship)
+"HN" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 4.1
+	},
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"HO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew)
+"HV" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/structure/spacevine,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HW" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ie" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Ip" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/portable_atmospherics/canister/chlorine{
+	name = "shoddily constructed super-high-capacity chlorine canister";
+	desc = "Oh Huntsman, this is a bad idea.";
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	maximum_pressure = 14119.25;
+	max_integrity = 60
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/cavecrew/ship)
+"Ir" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Is" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Iu" = (
+/obj/effect/spawner/bunk_bed,
+/turf/open/floor/wood,
+/area/ruin/jungle/cavecrew/dormitories)
+"Iv" = (
+/obj/item/storage/box/zipties{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/grenade/frag{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/box/syndie_kit/emp,
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Iw" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Iz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"IA" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"ID" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"II" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"IO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"IP" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"IS" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IX" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"IZ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Jg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Jh" = (
+/obj/structure/flora/grass/jungle/b{
+	pixel_x = 10;
+	pixel_y = 25
+	},
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"Ji" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Jl" = (
+/obj/machinery/button/door{
+	pixel_x = 22;
+	pixel_y = 9;
+	dir = 8;
+	id = "cavecheckpointsouth"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 1
+	},
+/area/ruin/jungle/cavecrew)
+"Jm" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 5
 	},
 /obj/machinery/light_switch{
 	pixel_y = 21;
 	pixel_x = -10
 	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"Rh" = (
+/obj/machinery/computer/crew{
+	icon_state = "computer-right"
+	},
+/obj/machinery/button/door{
+	id = "gut_cargo";
+	name = "Cargo Door Control";
+	pixel_y = 22;
+	pixel_x = -1
+	},
+/obj/item/melee/boarding_axe,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Jo" = (
+/obj/structure/flora/junglebush/large{
+	pixel_x = -7;
+	pixel_y = 8
+	},
 /obj/structure/spacevine,
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Ri" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/jungle/cavecrew/dormitories)
-"RL" = (
-/obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"RM" = (
-/turf/open/water/jungle/lit,
-/area/overmap_encounter/planetoid/jungle/explored)
-"RT" = (
-/obj/machinery/computer/crew/syndie{
+/area/overmap_encounter/planetoid/cave/explored)
+"Jt" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Jz" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"JB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/human/frontier/ranged/neutered,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"JC" = (
+/obj/structure/platform/wood,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"JI" = (
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/stairs/jungleplanet{
 	dir = 4
 	},
-/obj/effect/turf_decal/techfloor{
-	dir = 8
+/area/overmap_encounter/planetoid/cave/explored)
+"JJ" = (
+/obj/structure/cable{
+	icon_state = "8-10"
 	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"Sc" = (
-/obj/effect/turf_decal/industrial/warning/dust{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"JQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/glass/concrete_bag{
+	pixel_x = -10;
+	pixel_y = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"JS" = (
+/obj/effect/turf_decal/industrial/warning/dust,
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"JX" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Kd" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
 	},
-/area/ruin/powered)
-"Sj" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/button/massdriver{
+	id = "gut_launchdoor";
+	name = "Cannon Button";
+	pixel_x = 21;
+	pixel_y = 8;
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5;
+	layer = 2.01
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Ke" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Kg" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg3"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Kh" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/obj/machinery/light/directional/east,
+/obj/item/stack/cable_coil/random/five,
+/obj/effect/turf_decal/techfloor{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Kw" = (
+/obj/structure/sign/poster/contraband/punch_shit{
+	pixel_x = 32
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/dormitories)
+"Kz" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KA" = (
+/obj/machinery/power/shuttle/engine/fire{
+	dir = 1
+	},
+/obj/machinery/door/poddoor{
+	id = "gut_engines";
+	name = "Thruster Blast Door"
+	},
 /turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/bridge)
-"SI" = (
+/area/ruin/jungle/cavecrew/ship)
+"KC" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KF" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/frag,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/turf/open/floor/pod,
+/area/ruin/jungle/cavecrew/ship)
+"KK" = (
+/obj/structure/railing/corner,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KM" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet{
+	icon_state = "sec";
+	name = "Ammo Locker";
+	req_access_txt = "1"
+	},
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/skm_46_30,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/ammo_box/magazine/illestren_a850r,
+/obj/item/storage/box/ammo/a4570,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/item/ammo_box/magazine/m12g_slammer,
+/obj/item/ammo_box/magazine/m12g_slammer,
+/obj/machinery/light/directional/east,
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"KN" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KQ" = (
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KR" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"KW" = (
+/turf/open/floor/plasteel/stairs,
+/area/ruin/jungle/cavecrew/ship)
+"KZ" = (
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Lb" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/atmospherics/components/unary/shuttle/fire_heater{
+	dir = 1
+	},
 /turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"SN" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/area/ruin/jungle/cavecrew/ship)
+"Lc" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ld" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Li" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/ruin/powered)
-"ST" = (
+/obj/structure/chair/plastic{
+	pixel_x = -1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/corner/opaque/red/half{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Lm" = (
+/turf/closed/wall/concrete,
+/area/ruin/jungle/cavecrew/cargo)
+"Ln" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
-	dir = 1
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Lp" = (
+/obj/structure/cable{
+	icon_state = "1-9"
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Lq" = (
+/obj/item/shovel,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Lv" = (
+/obj/item/storage/backpack/duffelbag/syndie/c4{
+	pixel_y = 5;
+	pixel_x = 2
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"SY" = (
-/obj/structure/railing{
-	dir = 4;
-	layer = 3.1
+/obj/effect/turf_decal/industrial/fire{
+	dir = 5
 	},
-/obj/effect/turf_decal/spline/fancy/opaque/black{
+/obj/item/crowbar/power{
+	pixel_y = -4
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/light/directional/south,
+/obj/item/grenade/spawnergrenade/manhacks{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Lw" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"LA" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/dormitories)
+"LD" = (
+/obj/structure/sign/barsign{
+	pixel_y = 32
+	},
+/obj/machinery/vending/cola/shamblers,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"LM" = (
+/obj/structure/spacevine,
+/obj/structure/punji_sticks,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"LN" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/spacevine,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"LT" = (
+/obj/effect/turf_decal/spline/fancy/opaque/lightgrey{
+	dir = 8
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"LW" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"LY" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Ma" = (
+/obj/effect/turf_decal/industrial/loading,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"Mb" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"Mf" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 14;
+	pixel_y = 1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mg" = (
+/obj/item/shovel,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mk" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/steeldecal/steel_decals10,
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"Mm" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/corner/opaque/red/three_quarters{
+	dir = 1
+	},
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Mo" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mp" = (
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Tc" = (
-/obj/item/stack/ore/salvage/scrapmetal/five{
-	pixel_x = -5;
-	pixel_y = -12
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken4"
 	},
-/turf/open/floor/plating/asteroid/dirt,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mr" = (
+/obj/machinery/atmospherics/components/trinary/mixer,
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/open/floor/plasteel/tech,
 /area/ruin/jungle/cavecrew/cargo)
-"Th" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 9
+"Ms" = (
+/obj/structure/railing{
+	dir = 6;
+	layer = 3.1
 	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"MA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"MG" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"MN" = (
+/obj/structure/spacevine,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"MR" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/decal/cleanable/crayon,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"MT" = (
+/obj/effect/turf_decal/techfloor,
+/obj/effect/turf_decal/industrial/loading{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"MU" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"Ti" = (
+/obj/effect/decal/cleanable/food/egg_smudge,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Tt" = (
-/obj/effect/turf_decal/industrial/loading{
-	dir = 4
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken3"
+	},
+/area/ruin/jungle/cavecrew/dormitories)
+"MW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing{
+	layer = 4.1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/patterned/cargo_one,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 8
+	},
+/area/ruin/jungle/cavecrew/hallway)
+"MY" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"MZ" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Na" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner,
+/turf/open/floor/plating/jungleplanet,
 /area/ruin/jungle/cavecrew/cargo)
-"Ty" = (
-/turf/open/water/jungle,
+"Nc" = (
+/obj/structure/spacevine,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Nf" = (
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/item/circuitboard/machine/autolathe,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/circuit/machine/common,
+/obj/item/circuitboard/machine/chem_heater,
+/obj/item/circuitboard/machine/suit_storage_unit/industrial,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"Ng" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Nj" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Nk" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Nl" = (
+/obj/structure/grille,
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bunker-control"
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Nn" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Np" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
 /area/overmap_encounter/planetoid/cave/explored)
-"TD" = (
+"Nq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken2"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Nr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/turf_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Ns" = (
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_x = -1;
+	pixel_y = -37
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ny" = (
+/obj/structure/flora/ausbushes/sunnybush{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew/hallway)
+"NC" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"NG" = (
+/obj/structure/cable{
+	icon_state = "2-6"
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"NK" = (
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/jungle/cavecrew)
+"NL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random/entertainment/cigarette,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"NM" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"NN" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"NP" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"NR" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NT" = (
+/obj/structure/bed/double{
+	dir = 1
+	},
+/obj/item/bedsheet/double/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"NW" = (
+/obj/machinery/porta_turret/ruin/frontiersmen{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/ship)
+"Oc" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"Oe" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Oi" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	layer = 4.1
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Os" = (
+/obj/structure/platform/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ou" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Ov" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"Oy" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"OA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"OF" = (
+/obj/effect/turf_decal/corner_techfloor_grid{
+	dir = 9
+	},
+/obj/item/stack/sheet/metal/twenty,
+/obj/effect/turf_decal/box,
+/turf/open/floor/concrete/slab_1,
+/area/ruin/jungle/cavecrew/engineering)
+"OG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/concrete/slab_3{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"OI" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"OP" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/effect/turf_decal/techfloor,
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/jukebox/boombox,
+/turf/open/floor/plasteel/patterned/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"OR" = (
+/obj/structure/ore_box,
+/obj/machinery/light/directional/east,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"OU" = (
+/obj/machinery/mineral/processing_unit{
+	output_dir = 4;
+	input_dir = 2
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"OV" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OZ" = (
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Pc" = (
+/turf/open/floor/plasteel/stairs/jungleplanet{
+	dir = 4
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Pf" = (
+/obj/effect/turf_decal/corner_techfloor_gray/diagonal,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/bridge)
+"Pg" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/yellow/half,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Pq" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Pt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 21;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Px" = (
+/obj/effect/turf_decal/corner/opaque/tan/half,
+/obj/effect/turf_decal/road/slow,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"PB" = (
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 4
+	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"PC" = (
 /obj/structure/flora/ausbushes/stalkybush{
 	pixel_x = 1;
 	pixel_y = 16
@@ -3484,483 +5472,780 @@
 	},
 /turf/open/water/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
-"TJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/ruin/jungle/cavecrew/dormitories)
-"TY" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/steeldecal/steel_decals10{
+"PF" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/blue/half{
 	dir = 1
 	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/jungle/cavecrew/bridge)
-"Ua" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/chair/comfy/orange/directional/east{
-	color = "#66b266"
-	},
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = 10;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/wood,
-/area/ruin/jungle/cavecrew/dormitories)
-"Ud" = (
-/obj/machinery/light/directional/west,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Ul" = (
-/obj/effect/turf_decal/industrial/hatch/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/rust,
-/area/ruin/jungle/cavecrew/cargo)
-"Ur" = (
-/obj/effect/turf_decal/industrial/stand_clear{
-	dir = 8;
-	pixel_x = 8
-	},
-/turf/open/floor/plating/rust,
-/area/ruin/powered)
-"Us" = (
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 10
-	},
-/obj/effect/turf_decal/steeldecal/steel_decals10{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/stack/sheet/mineral/plasma/twenty{
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/engineering)
-"Uy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/concrete/slab_1/jungleplanet,
 /area/ruin/jungle/cavecrew/hallway)
-"UC" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 6
-	},
-/obj/machinery/vending/tool,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"UI" = (
-/obj/effect/turf_decal/techfloor,
-/obj/effect/turf_decal/techfloor/hole,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"UJ" = (
-/obj/structure/table/wood/reinforced,
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/bridge)
-"UP" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"UV" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"UY" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -1;
-	pixel_y = -37
-	},
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_y = -11;
-	pixel_x = -1
-	},
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"Vd" = (
-/obj/structure/flora/tree/jungle,
-/obj/structure/flora/grass/jungle{
-	pixel_x = -11;
-	pixel_y = 10
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Vu" = (
-/obj/effect/turf_decal/techfloor/hole{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/techfloor/hole/right{
-	dir = 4;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/borderfloor{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/grunge{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Vy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plasteel/tech/techmaint,
-/area/ruin/jungle/cavecrew/engineering)
-"VO" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "armory";
-	name = "armor locker";
-	req_access_txt = "1"
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/clothing/under/frontiersmen,
-/obj/item/clothing/under/frontiersmen,
-/obj/item/clothing/under/frontiersmen,
-/obj/item/clothing/suit/armor/vest/frontier,
-/obj/item/clothing/suit/armor/vest/frontier,
-/obj/item/clothing/suit/armor/vest/frontier,
-/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
-/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
-/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"VU" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/techfloor{
-	dir = 9
-	},
-/obj/effect/turf_decal/techfloor/corner,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"VV" = (
-/obj/machinery/light/directional/east,
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"VX" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "gut_cargo";
-	name = "Blast Shutters";
-	dir = 4
-	},
-/turf/open/floor/engine/hull/interior,
-/area/ship/storage)
-"VY" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/effect/turf_decal/industrial/radiation{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/tech/grid,
-/area/ship/storage)
-"VZ" = (
-/turf/closed/wall/r_wall/yesdiag,
-/area/ruin/jungle/cavecrew/cargo)
-"Wh" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 20
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = -13;
-	pixel_y = 10
-	},
+"PN" = (
 /obj/structure/railing{
-	dir = 6;
+	dir = 4;
 	layer = 3.1
 	},
 /turf/open/water/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
-"Wk" = (
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Wq" = (
-/obj/effect/turf_decal/techfloor{
+"PS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"PY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/cavecrew)
+"PZ" = (
+/obj/structure/closet,
+/obj/item/clothing/mask/gas/frontiersmen,
+/obj/item/clothing/head/helmet/bulletproof/x11/frontier,
+/obj/item/clothing/suit/armor/vest/frontier,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Qb" = (
+/obj/item/documents/frontier,
+/obj/item/desk_flag{
+	pixel_x = -11;
+	pixel_y = 14
+	},
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Ql" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/secure/gear,
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
+/obj/item/clothing/neck/dogtag/ramzi,
+/obj/item/clothing/neck/dogtag/ramzi,
+/obj/item/clothing/suit/armor/ramzi,
+/obj/item/clothing/head/helmet/m10/ramzi,
+/obj/item/clothing/glasses/hud/security/sunglasses/ramzi,
+/obj/item/clothing/glasses/hud/security/sunglasses/ramzi,
+/turf/open/floor/pod,
+/area/ruin/jungle/cavecrew/ship)
+"Qx" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Qy" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "outpost2"
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Qz" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/storage)
-"Wu" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/zipties{
-	pixel_y = 7;
-	pixel_x = 4
+/obj/effect/turf_decal/industrial/warning,
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/atmospherics/components/unary/shuttle/fire_heater{
+	dir = 1
 	},
-/obj/item/storage/box/syndie_kit/emp{
-	pixel_x = -3
+/turf/open/floor/plasteel/tech/techmaint,
+/area/ruin/jungle/cavecrew/ship)
+"QB" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/tech,
-/area/ruin/jungle/cavecrew/security)
-"Wy" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/ruin/powered)
-"WD" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/structure/sink{
-	pixel_y = 22;
-	pixel_x = 6
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/jungle/cavecrew/hallway)
-"WE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"WN" = (
-/obj/structure/flora/rock/jungle{
-	pixel_y = 13
-	},
-/turf/open/water/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"WQ" = (
-/obj/effect/turf_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/secure/loot,
-/obj/item/storage/box/maid{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/patterned/cargo_one,
+/turf/open/floor/concrete/slab_1/jungleplanet,
 /area/ruin/jungle/cavecrew/cargo)
-"Xb" = (
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/ruin/powered)
-"Xx" = (
-/mob/living/simple_animal/hostile/human/frontier/ranged/mosin/neutered,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"XM" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = 6;
-	pixel_y = -22
-	},
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/cave/explored)
-"XU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/powered)
-"XV" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/ship/storage)
-"Ya" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/floor/plating/asteroid/dirt/jungle,
-/area/overmap_encounter/planetoid/jungle/explored)
-"Yf" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/jukebox,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"Yq" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/syndicate{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/toy/figure{
-	pixel_x = -3;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/ruin/jungle/cavecrew/hallway)
-"Yw" = (
-/turf/open/floor/plasteel/stairs{
-	icon = 'icons/obj/stairs.dmi';
-	dir = 1
-	},
-/area/ship/storage)
-"YE" = (
-/obj/effect/turf_decal/techfloor{
+"QE" = (
+/obj/structure/platform/wood{
 	dir = 9
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/nugget_box,
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = -2;
+	pixel_y = -3
 	},
-/turf/open/floor/plasteel/patterned/brushed,
-/area/ruin/jungle/cavecrew/security)
-"YL" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 7;
+	pixel_y = -8
+	},
+/obj/effect/decal/cleanable/ash/large{
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"QH" = (
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/caution,
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"QJ" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QK" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"QP" = (
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "Command Post"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/jungle/cavecrew/bridge)
+"QQ" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QR" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QT" = (
+/obj/structure/platform/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"QU" = (
+/obj/structure/cable{
+	icon_state = "2-10"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"QX" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/engineering)
+"Rc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/asteroid/dirt,
-/area/ruin/powered)
-"YN" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 1
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Rd" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "bunker-control"
 	},
-/obj/effect/turf_decal/steeldecal/steel_decals1,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/jungleplanet,
 /area/ruin/jungle/cavecrew/bridge)
-"YR" = (
-/obj/structure/fluff/fokoff_sign,
+"Rh" = (
+/mob/living/simple_animal/hostile/carp,
 /turf/open/water/jungle/lit,
 /area/overmap_encounter/planetoid/jungle/explored)
-"YS" = (
+"Ri" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Rj" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Rr" = (
+/obj/structure/chair/bench/grey/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/ruin/jungle/cavecrew/hallway)
-"Za" = (
-/obj/structure/railing/corner{
-	dir = 1
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"RD" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"RG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-5"
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"RI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"Zd" = (
+/obj/structure/closet,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/under/frontiersmen,
+/obj/item/clothing/head/soft/frontiersmen,
+/obj/item/clothing/head/soft/frontiersmen,
+/obj/item/clothing/head/soft/frontiersmen,
+/obj/item/clothing/head/soft/frontiersmen,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/head/soft/frontiersmen,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"RJ" = (
+/obj/effect/spawner/bunk_bed,
+/obj/machinery/light/directional/north,
+/obj/item/toy/plush/carpplushie/dehy_carp{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"RL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	dir = 8
+	},
+/area/ruin/jungle/cavecrew/cargo)
+"RM" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"RT" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet{
+	icon_state = "wood-broken5"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"RV" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Sj" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"SD" = (
+/obj/item/storage/secure/safe,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/engineering)
+"SI" = (
+/obj/item/pen{
+	pixel_y = 4;
+	pixel_x = -4
+	},
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_x = 17;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/item/clipboard{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/table/wood/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"SK" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/hardsuit/security/independent/frontier,
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"SM" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 9;
+	layer = 4.1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"SR" = (
 /obj/structure/flora/grass/jungle{
 	pixel_x = -13;
 	pixel_y = -14
 	},
-/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/spacevine/dense,
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"Zi" = (
+"ST" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"SW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.01
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Armory";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"SX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/glass/concrete_bag,
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"SY" = (
+/obj/structure/cable{
+	icon_state = "2-6"
+	},
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/internals/neutered,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Tc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"Te" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/effect/turf_decal/industrial/hatch/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/button/door{
+	id = "gut_engines";
+	name = "Engine Shutters";
+	pixel_y = -22;
+	dir = 1
+	},
+/turf/open/floor/pod,
+/area/ruin/jungle/cavecrew/ship)
+"Tf" = (
+/obj/effect/turf_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Th" = (
+/obj/structure/cable{
+	icon_state = "1-9"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/floor/concrete/slab_3{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Ti" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "danger";
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Tj" = (
+/obj/structure/platform/wood{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ts" = (
+/obj/structure/railing{
+	layer = 3.1
+	},
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = -13;
+	pixel_y = -2
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Tu" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/canister/toxins{
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 50, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 50);
+	name = "shitty plasma canister";
+	max_integrity = 60;
+	desc = "A shoddily constructed container of Plasma gas. Highly toxic."
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/jungle/cavecrew/cargo)
+"Tv" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-1"
+	},
+/obj/item/clothing/head/soft/frontiersmen,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Tw" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 5;
+	pixel_x = 10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Tx" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Ty" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"TC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/door/airlock/grunge{
+	dir = 4;
+	name = "UNDER CONSTRUCTION!"
+	},
+/turf/open/floor/plasteel/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"TD" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/corner_steel_grid/diagonal,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"TE" = (
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TJ" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TO" = (
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"TP" = (
+/obj/structure/girder,
+/obj/structure/hazard/electrical/electrified_water,
+/turf/open/water/jungle,
+/area/ruin/jungle/cavecrew)
+"TY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Ud" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"Ue" = (
+/obj/machinery/conveyor{
+	id = "outpost3";
+	dir = 1
+	},
+/turf/open/floor/plasteel/tech/grid/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Ug" = (
+/obj/structure/spacevine,
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Uh" = (
+/obj/structure/flora/ausbushes/sunnybush{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Us" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_2/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"Uy" = (
+/obj/effect/turf_decal/industrial/outline/yellow,
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"UC" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5"
+	},
+/obj/item/storage/toolbox/ammo{
+	pixel_y = 2
+	},
+/obj/item/storage/toolbox/ammo{
+	pixel_y = -6;
+	pixel_x = -5
+	},
+/turf/open/floor/pod/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"UI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/crayon,
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/industrial/warning/dust/corner,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"UJ" = (
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/effect/decal/cleanable/food/flour,
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 2;
+	pixel_x = 0
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"UN" = (
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/obj/effect/turf_decal/industrial/caution/white{
+	color = "#d2d53d";
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"UV" = (
+/obj/structure/flora/rock{
+	pixel_x = 9
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"UY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vb" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vd" = (
+/obj/structure/spacevine,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vg" = (
+/obj/structure/cable{
+	icon_state = "4-5"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vh" = (
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vi" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/opaque/yellow,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Vk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
 /obj/item/kirbyplants{
-	icon_state = "plant-03";
-	pixel_x = 6
+	icon_state = "plant-25";
+	pixel_x = 2;
+	pixel_y = 8
 	},
-/obj/machinery/light_switch{
-	pixel_y = 21;
-	pixel_x = -10
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/green/jungleplanet,
 /area/ruin/jungle/cavecrew/dormitories)
-"Zr" = (
+"Vm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/north,
-/turf/open/floor/plasteel/patterned,
-/area/ruin/jungle/cavecrew/cargo)
-"Zx" = (
-/obj/effect/turf_decal/industrial/traffic{
-	dir = 10
-	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/belt/utility/full/engi,
-/obj/item/clothing/glasses/welding{
-	pixel_y = 5
-	},
-/obj/item/multitool{
-	pixel_x = 9
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-6"
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plasteel/tech/grid,
-/area/ruin/jungle/cavecrew/engineering)
-"Zy" = (
-/obj/effect/mob_spawn/human/corpse/pirate,
-/turf/open/water/jungle/lit,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vu" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vx" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Vy" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 14;
+	pixel_y = 1
+	},
+/obj/structure/spacevine,
+/turf/open/water/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"Zz" = (
+"VB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"VD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"VH" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"VO" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"VU" = (
+/obj/structure/destructible/tribal_torch/lit,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"VV" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"VZ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8;
 	name = "tactical chair"
@@ -3968,47 +6253,638 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 4
 	},
-/obj/effect/turf_decal/industrial/warning{
-	dir = 8;
-	color = "#808080"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/plasteel/tech,
-/area/ship/storage)
-"ZC" = (
-/obj/effect/turf_decal/techfloor{
-	dir = 9
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/hull,
+/area/ruin/jungle/cavecrew/ship)
+"Wc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/computer/helm,
-/turf/open/floor/plasteel/telecomms_floor,
-/area/ship/storage)
-"ZG" = (
-/obj/structure/flora/ausbushes/stalkybush{
-	pixel_x = -8;
-	pixel_y = 3
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"We" = (
+/obj/structure/railing{
+	layer = 4.1
 	},
-/turf/open/water/jungle/lit,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Wg" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle,
 /area/overmap_encounter/planetoid/jungle/explored)
-"ZQ" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -20;
-	pixel_y = -31
+"Wh" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wj" = (
+/obj/structure/sign/poster/radio/icf,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew)
+"Wk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"Wl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Wn" = (
+/obj/effect/turf_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Wq" = (
+/obj/effect/turf_decal/industrial/warning/fulltile,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/cavecrew)
+"Wr" = (
+/mob/living/simple_animal/hostile/human/frontier,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Wu" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Wv" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/hallway)
+"Wz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/opaque/tan/filled/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"WA" = (
+/mob/living/simple_animal/hostile/human/frontier/ranged/officer/neutured{
+	name = "Officer Seth";
+	environment_smash = 0
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/random/entertainment/cigarette{
+	pixel_x = 14;
+	pixel_y = -6
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"WD" = (
+/obj/effect/turf_decal/techfloor{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned/brushed/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"WE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs,
+/area/ruin/jungle/cavecrew/ship)
+"WK" = (
+/obj/structure/railing/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/stairs/wood/jungleplanet{
+	dir = 4
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"WN" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"WP" = (
+/obj/structure/spacevine,
+/obj/structure/punji_sticks,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"WS" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_4/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"WY" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 8
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xb" = (
+/obj/structure/platform/wood,
+/turf/open/floor/plasteel/stairs/wood/jungleplanet{
+	dir = 8
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Xd" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"Xf" = (
+/obj/effect/turf_decal/spline/fancy/opaque/black/corner{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/human/frontier/ranged/trooper/skm/neutured,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"Xi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/ruin/jungle/cavecrew)
+"Xj" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/servingdish,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/spoon/plastic,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Xo" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Xq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/opaque/tan/filled/warning,
+/turf/open/floor/concrete/reinforced/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Xs" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"Xt" = (
+/obj/item/stack/rods/ten,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"Xu" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xy" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/cave/explored)
+"XC" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/structure/flora/tree/jungle{
+	icon_state = "tree9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"XH" = (
+/obj/structure/sign/poster/contraband/radiofreefrontier,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/jungle/cavecrew/hallway)
+"XK" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating/asteroid/dirt/jungle,
 /area/overmap_encounter/planetoid/cave/explored)
-"ZT" = (
+"XM" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/mob_spawn/human/corpse/ramzi,
+/obj/structure/closet/body_bag{
+	name = "body bag - Mark #1"
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4;
+	layer = 2.01
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"XN" = (
+/obj/machinery/light/directional/north,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"XT" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"XU" = (
+/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/reagentgrinder{
+	name = "Slop-O-Matic";
+	desc = "Insert meat, vegetables, and rum and press blend. Food for the whole cell!";
+	pixel_x = 7;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bowl{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"XW" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/platform/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yc" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/punji_sticks,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yf" = (
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 13;
+	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = 5;
+	pixel_y = 11
+	},
+/obj/structure/flora/ausbushes/stalkybush{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yi" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Yj" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/engineering)
+"Yn" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing{
+	dir = 8;
+	layer = 3.1
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yo" = (
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"Yp" = (
+/obj/structure/flora/driftwood,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Yq" = (
+/obj/structure/flora/grass/jungle{
+	pixel_x = -13;
+	pixel_y = -14
+	},
+/obj/structure/spacevine,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Yv" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/food/pizza/vegetable,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"YA" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/corner/opaque/yellow/half{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/hallway)
+"YE" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_3{
+	dir = 8
+	},
+/area/ruin/jungle/cavecrew/cargo)
+"YG" = (
+/obj/structure/railing{
+	dir = 1;
+	layer = 2.89
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"YK" = (
+/obj/structure/grille/broken,
+/obj/structure/hazard/electrical/electrified_water,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/water/jungle,
+/area/ruin/jungle/cavecrew)
+"YL" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"YN" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs,
+/area/ruin/jungle/cavecrew/ship)
+"YR" = (
+/turf/closed/wall/concrete,
+/area/overmap_encounter/planetoid/cave/explored)
+"YS" = (
+/turf/open/floor/plating/asteroid/dirt,
+/area/ruin/jungle/cavecrew)
+"YV" = (
+/obj/machinery/porta_turret/ruin/frontiersmen{
 	dir = 6
 	},
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/newspaper{
-	pixel_x = -4;
-	pixel_y = 8
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/jungle/cavecrew/ship)
+"YX" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Za" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/turf_decal/borderfloorblack{
+	layer = 2.030;
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew/ship)
+"Zd" = (
+/obj/structure/falsewall/plastitanium{
+	name = "slightly ajar wall"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/bridge)
+"Zh" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/structure/flora/grass/jungle{
+	pixel_x = -11;
+	pixel_y = 10
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Zi" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/structure/spacevine/dense,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zk" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zm" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Zx" = (
+/obj/effect/turf_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew/cargo)
+"ZA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
+"ZB" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 2
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/carpet/green/jungleplanet,
 /area/ruin/jungle/cavecrew/dormitories)
+"ZD" = (
+/turf/closed/mineral/random/jungle,
+/area/ruin/jungle/cavecrew)
+"ZL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ZM" = (
+/obj/effect/decal/cleanable/crayon{
+	color = "#FF3333";
+	icon_state = "danger";
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "panelscorched"
+	},
+/area/ruin/jungle/cavecrew)
+"ZP" = (
+/obj/machinery/light/directional/west,
+/turf/open/water/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ZQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/glass/concrete_bag,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/jungle/cavecrew)
+"ZR" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 9;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ZS" = (
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/jungle/cavecrew/dormitories)
+"ZT" = (
+/obj/structure/table/reinforced{
+	color = "#c1b6a5";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/paper_bin{
+	pixel_x = -11;
+	pixel_y = 13
+	},
+/obj/item/pen{
+	pixel_y = 13;
+	pixel_x = -15
+	},
+/obj/item/trash/popcorn{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/item/radio/intercom/table{
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/cavecrew)
+"ZV" = (
+/obj/structure/railing{
+	layer = 4.1
+	},
+/obj/effect/turf_decal/industrial/stand_clear,
+/turf/open/floor/plating/jungleplanet,
+/area/overmap_encounter/planetoid/cave/explored)
 
 (1,1,1) = {"
 es
@@ -4047,15 +6923,22 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
 es
 es
 es
@@ -4111,26 +6994,33 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
 es
-Ma
-Ma
-NR
-Ma
-Ma
-Ma
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
 es
 es
 es
@@ -4173,31 +7063,38 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Pz
-Pz
-Pz
-Pz
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Ma
-EI
-Ma
-Qz
-Ma
-Ma
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
 es
 es
 es
@@ -4236,34 +7133,41 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Pz
-dm
-pn
-Pz
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Ma
-Ma
-NR
-Ma
-Ns
-Ma
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+es
+es
+es
+es
+es
+rN
+BF
+HW
+rN
+rN
+rN
+ww
+rN
+rN
+es
+es
+es
+es
 es
 es
 es
@@ -4285,13 +7189,6 @@ es
 es
 es
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
 es
 es
 es
@@ -4300,35 +7197,49 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Pz
-VU
-QH
-Pz
-Pz
-Pz
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-jO
-Qx
-NR
-lI
-Ma
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+es
+rN
+rN
+np
+wq
+rN
+rN
+rN
+rN
+ov
+rN
+BF
+ov
+om
+rN
+es
+es
 es
 es
 es
@@ -4339,61 +7250,68 @@ es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
 es
 es
 es
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Pz
-Bp
-gM
-xi
-SI
-Pz
-wN
-wN
-wN
-wN
-wN
-wt
-wt
-wt
-rx
-Ma
-ij
-wt
-Ma
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+QX
+QX
+QX
+QX
+QX
+QX
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+Ns
+rN
+BF
+Fq
+rN
+rN
+rN
+om
+dH
+HW
+np
+wg
+es
 es
 es
 es
@@ -4403,62 +7321,69 @@ es
 (7,1,1) = {"
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
 es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Nr
-Nr
-Nr
-Nr
-Nr
-Pz
-mb
-CN
-CZ
-Vy
-Pz
-wN
-VO
-OU
-Wu
-wN
-wt
-wt
-Kw
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+QX
+mm
+PB
+Gm
+dQ
+QX
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+rN
+np
+rN
+Oe
 ov
-Jh
-Lm
-wt
-wt
+rN
+rN
+ov
+np
+kW
+wg
+wg
 es
 es
 es
@@ -4468,63 +7393,70 @@ es
 (8,1,1) = {"
 es
 es
-wt
-wt
-wt
-iW
-iW
-wt
-wt
-wt
-wt
-RM
-MR
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Nr
-Nr
-lV
-zJ
-gm
-Pz
-Rd
-Us
-kR
-ag
-Pz
-mt
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+fY
+TE
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+QX
+GN
+sJ
+Go
+sP
+QX
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
 np
 dH
-gk
-wN
-wN
-wt
-Kw
-iW
-Kw
-wt
-wt
-wt
-wt
+np
+ov
+rN
+Cr
+rN
+np
+np
+np
+wg
+wg
+np
 es
 es
 es
@@ -4533,64 +7465,71 @@ es
 (9,1,1) = {"
 es
 es
-wt
-wt
-MW
-RM
-NR
-NR
-wt
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+es
+es
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+TE
+TE
+TE
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+LA
+LA
+LA
+LA
+LA
+LA
+QX
+GW
 Nr
-Nr
-Yq
-dQ
-Qy
-Ge
-Pz
-Zx
+tx
+Do
+QX
 wr
-ja
-kH
-Pz
-MY
-am
-Bt
-af
-ae
-wN
-wt
-wt
-yx
-Jz
-wt
-wt
-wt
-wt
-wt
+wr
+Wj
+wr
+wr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+ov
+IS
+Is
+GJ
+wg
+vO
+Es
+DK
+rN
 es
 es
 es
@@ -4598,1884 +7537,2087 @@ es
 (10,1,1) = {"
 es
 es
-wt
-wt
-Rh
-Rh
-RM
-RM
-Rh
-wt
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-MR
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Nr
+es
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+fY
+TE
+TE
+fY
+fY
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+Kw
+ah
+kR
+MU
+gR
+uz
+QX
+ld
 Bz
-aK
-dO
-Gk
-xn
-Pz
+fr
+dZ
+QX
+wr
+ki
 UC
 Iv
-Pz
-lu
-jm
-wN
-qz
-LD
-DP
-vo
-wN
-Ri
-Ri
-aY
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
+wr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+YX
+wg
+wg
+Ld
+np
+np
+om
+rN
+es
 es
 es
 "}
 (11,1,1) = {"
 es
 es
-wt
-wt
-wt
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
 Rh
-Rh
-wt
-jg
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Nr
-jr
-uo
+TE
+TE
+fY
+fY
+fY
+Pq
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+LA
+Xj
+cl
+oM
+XU
+kQ
+SD
+DW
+Wc
+fr
 mz
-fv
-Nr
-Nr
-Nr
-Nr
-Nr
-ah
-Ti
-wN
-wN
-Th
-nv
-wN
-wN
-Ri
-BU
-we
-Ri
-Ri
-wt
-wt
-wt
-wt
-wt
+pl
+SK
+gS
+EP
+kd
+wr
+wr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+wg
+jb
+Oe
+wB
+kW
+rN
+rN
+HW
+rN
 es
 es
 "}
 (12,1,1) = {"
 es
 es
-wt
-wt
-wt
-wt
-wt
-wt
-bK
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-lm
-lm
-lm
-lm
-lm
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+fY
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+LA
+LA
+LA
+LA
+LA
+Cv
+Rr
+VD
+Yv
+sl
+QX
+pa
+mG
 tu
-AK
-Yf
-Nr
+TD
+QX
+Uy
 WD
 zN
-Nr
-Nr
-Uy
+DB
+Lv
+wr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+FK
+Is
 Oe
-wN
-YE
-ds
-UI
-jF
-JK
-Ri
-sJ
+om
+rN
+rN
 TJ
-yW
-Ri
-wt
-wt
-wt
-wt
-wt
-es
+rN
 es
 "}
 (13,1,1) = {"
 es
 es
-es
-wt
-wt
-wt
-RM
-RM
-RM
-RM
-RM
-RM
-uq
-RM
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+TE
+TE
+fY
+fY
+Pq
 fG
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-mj
-pB
-wt
-wt
-wt
-lm
-lm
-RT
-Ag
-TY
-lm
-Nr
-aL
-Nr
-Nr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+wP
+fG
+fG
+ly
+qu
+Xs
+rh
+LA
+LD
+wl
+VD
+GU
+kE
+QX
+QX
+QX
+QX
+uf
+QX
+wr
 Kh
-Nr
-Nr
+ow
+LY
 KM
-ad
-ck
-Oi
-hz
-px
-xv
-xI
-cZ
-Ri
-Ri
-un
-Ri
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
+wr
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+np
+rN
+Is
+qU
+rN
+rN
+HW
+rN
 es
 "}
 (14,1,1) = {"
 es
 es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-Ma
-ZG
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-WQ
-aZ
-aa
-ed
-eW
-wt
-lm
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+Nn
+Sj
+fY
+fY
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+LA
+RJ
+Ng
+Iu
+LA
+eE
+Wl
+cZ
 UJ
-iE
-sj
-Ie
-lm
-Jt
+Wv
+Wv
+eN
+eN
+Wv
 ST
-Nn
-MT
-rK
-Nn
-WE
-jA
-fy
-YS
-wN
-wG
-kO
-Np
-wg
-Eb
-Ri
-xG
-mw
-Ri
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
+Ke
+wr
+wr
+ib
+Mm
+wr
+wr
+ZD
+ZD
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+rN
+rN
+TJ
+Is
+rN
+np
+rN
 es
 "}
 (15,1,1) = {"
 es
 es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-Ma
-ht
-Es
-Qx
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-qO
-Dq
-qx
-pB
-qx
-LV
-wt
-lm
+TE
+TE
+TE
+TE
+TE
+TE
+gP
+lb
+TE
+TE
+LN
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+YR
+fG
+fG
+fG
+LA
+oq
+tZ
+RI
+LA
+LA
+pC
+Nk
 vM
-KW
-wZ
+Wv
+de
 Af
-AV
-CJ
-uX
+Wv
+Wv
+Pt
 gU
-DV
-DV
-aw
-Mm
+wr
 NK
+aw
+nC
 YS
-Nr
-wN
-wN
-uf
-wN
-wN
-wN
-Ri
-ua
-jC
-mI
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+gu
+ZD
+ZD
+ZD
+TP
+iV
+iV
+iV
+iV
+fG
+fG
+fG
+rN
+rN
+HW
+HW
+OV
+dH
+rN
+es
 "}
 (16,1,1) = {"
 es
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-Df
-Ma
-Qx
-Ya
-wt
-wt
-wt
-wt
-wt
-wt
-rt
-QG
-oq
-JO
-Ul
-ks
-Nc
-Oa
-Jz
-lm
-lm
-nu
-YN
-Em
-Bv
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+MG
+fG
+oh
+fG
+gF
+fG
+fG
+fG
+fG
+fG
+fG
+fz
+dd
+HI
+Tu
+pc
+fG
+fG
+fG
+LA
+Vk
+Tx
+bx
+ZS
+LA
+LA
+xi
+LA
+Wv
+dh
+Wv
+Wv
 SY
-aM
+yU
 Pg
-Nr
-Nr
-Nr
-Nr
-Nr
-Nr
-Nr
-fS
-va
-Ms
-IJ
-fS
-fS
-Ri
-uu
-hh
-Be
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+gM
+Li
+gA
+Ti
+wE
+gu
+Oc
+ZD
+ZD
+YK
+lH
+dU
+Xt
+iV
+iV
+fG
+fG
+fG
+rN
+rK
+om
+rN
+OV
+HW
+es
 "}
 (17,1,1) = {"
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RL
-RL
-RL
-Qz
-wt
-wt
-wt
-wt
-wt
-wt
-vr
-uK
-pL
-oq
-nt
-oH
-xr
-nt
-Tt
-wt
-lm
-Sj
-Lo
-iq
-gd
-lm
+TE
+TE
+TE
+TE
+TE
+rK
+rN
+yj
+TE
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+nT
+ae
+Na
+Lm
+EI
+GK
+qj
+jR
+Ov
+fG
+fG
+fG
+LA
+sv
+Dx
+ZB
+NM
+LA
+Ny
+DY
+kc
+sh
+jO
+kc
+lA
 bU
 ef
-Wk
-Nr
-fS
-fS
-fS
+lu
+wr
+Hj
+dm
+mL
+Wq
+bg
+bT
+ZD
+ZD
+ZD
+sx
+ZM
+lz
+ci
 iV
-fS
-fS
-fS
-ih
-rT
-dI
-Ep
-fS
-Ri
-Ri
-cx
-Ri
-Ri
-Ri
-Ri
-Ri
-Ri
-Ri
-wt
-wt
+fG
+fG
+fG
+fG
+rN
+TJ
+rN
+TJ
+OV
+es
 "}
 (18,1,1) = {"
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-Ma
-ke
-Es
-wt
-wt
-wt
-wt
-wt
-qO
-Zr
-Mv
-pL
-oW
-JB
+TE
+TE
+TE
+rN
+rN
+Zm
+lD
+dH
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+YR
+ae
+zu
+JS
+Wk
+Zy
+od
+Mr
+fy
+eU
+er
+fS
+fG
+LA
+nr
 aI
 JB
-JB
-Cc
-cK
-oR
-Sj
-Sj
-ei
-bh
-lm
-Nr
-Vu
-Nr
-Nr
-fS
-fS
-lT
-Sc
-Qr
-mu
-mu
-mu
-kb
-kb
-Ep
-mu
-PS
-dA
-dA
-zj
-Iz
-Ri
-sH
-IZ
-fI
-Ri
-wt
-wt
+Tf
+tX
+PF
+Xf
+Vi
+NC
+NC
+cX
+YA
+NC
+lu
+Wv
+wr
+wr
+SW
+tw
+wr
+wr
+TP
+ZD
+ZD
+CJ
+ja
+oW
+Bx
+hz
+wr
+fG
+fG
+fG
+kj
+rN
+rN
+rN
+np
+rN
+es
 "}
 (19,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-Ya
-wH
-wt
-wt
-wt
-wt
-wt
-wt
-oU
-CU
-xx
-Gm
-yJ
-HI
+es
+TE
+TE
+rN
+pq
+rN
+dH
+ei
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+bt
+nJ
+sV
+OP
+BT
+Zy
+vh
+Zy
+BT
+YE
+ag
+YR
+LA
+LA
+dS
 rr
-HI
-Tc
-dA
-Ix
-JQ
-Sj
-Sj
-Sj
-lm
-mK
-hf
-Fw
-Nr
-fS
-mC
-EG
-PU
-to
-PU
-PU
-XU
-Mg
-LB
+ZS
+Cc
+oR
+AE
+MY
+Wv
+Wv
+XH
+Wv
+Wv
+Wv
+Wv
+fG
+fG
+DR
+jf
+fG
+fG
+ZD
+ZD
+ZD
+oV
+iV
 CC
+dR
 YL
-YL
-YL
-YL
-YL
-Kz
-yk
-eQ
-JJ
-yj
-Ri
-wt
-wt
+wr
+fG
+fG
+fG
+fG
+CP
+rN
+Cr
+rN
+es
+es
 "}
 (20,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
+es
+TE
+TE
+qU
+qU
+qU
+BF
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+ht
+my
+BT
 Ma
-Ma
-Es
-Kw
-wt
-wt
-wt
-wt
-wt
-wt
-xx
-nV
-yA
-yJ
-yV
-yD
-MC
-Mn
-bb
-dI
-No
-kb
-bb
-Pv
-tj
-Wy
-jj
-bb
-fN
-fA
-tO
-kB
-Ep
-wt
-wt
-wt
-wt
-wt
-Jz
-wt
-EP
-zX
-Ej
-na
-CF
-KA
-Ri
-Nl
-HD
-Ri
-Ri
-wt
-wt
+iz
+zI
+Us
+Zy
+ks
+fS
+fG
+LA
+LA
+LA
+LA
+LA
+rY
+rm
+Ke
+Wv
+fG
+fG
+fG
+YR
+fG
+fG
+fG
+EH
+dz
+DZ
+fG
+fG
+ZD
+ZD
+ZD
+ZD
+iV
+zl
+QH
+du
+wr
+fG
+fG
+fG
+fG
+qU
+HW
+ov
+rN
+es
+es
 "}
 (21,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-YR
-NW
-Qx
-wt
-Nf
-wt
-wt
-wt
-wt
-wt
-wt
-Nj
-yV
-dT
-lz
-FB
-pt
-aQ
-aQ
-lG
-SN
-yZ
-to
-EG
-ng
-KK
-EG
-OZ
-EO
-yZ
-tL
-wt
-Jz
-wt
-fg
-cX
-wt
-wt
-wt
-wt
-Ty
-rA
-Ej
-CF
+es
+TE
+TE
+ww
 rN
-Ri
-Ri
-Ri
-Ri
-wt
-wt
-wt
+dH
+lD
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+YR
+cD
+cf
+Ov
+Ma
+wz
+eO
+RL
+qx
+ks
+fg
+fG
+fG
+fG
+fG
+fG
+Wv
+Wv
+fX
+Wv
+Wv
+fG
+fG
+WS
+Vx
+By
+xE
+gC
+Hx
+eo
+jf
+Co
+Vm
+Oc
+IA
+HO
+ZD
+wr
+wr
+IZ
+XT
+wr
+fG
+fG
+fG
+fG
+kj
+rN
+kw
+en
+es
+es
 "}
 (22,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-cV
-RM
-RM
-RM
-qU
-qU
+TE
+TE
+TE
+TE
+rN
+ei
+TJ
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+JS
+VB
+Zy
+Ma
 Nf
-wt
-Jz
-wt
-wt
-eu
-eu
-IA
-eu
-VZ
-Nu
-Ur
-rQ
+BH
+yC
+BT
+QB
+qr
+qr
+fG
+fG
+fG
+fG
+vY
+dP
+MW
 bp
+vY
+fG
+NG
+sR
+Rj
+gs
+AW
 AR
-AR
-AR
-AR
-AR
-AR
-AR
-AR
-AR
-AR
-AR
-Ty
-Ud
-Ty
-Ty
+ZA
+gG
+cx
+Zx
+ZA
+GF
+mb
 lR
-wt
-Jz
-wt
-WN
-Ty
-Ty
-lD
-Cq
-CF
-Ri
-Ua
-Is
-Ri
-wt
-wt
-wt
+ZD
+ZD
+wr
+wr
+TC
+wr
+wr
+fG
+fG
+fG
+fG
+NR
+cs
+dp
+es
+es
 "}
 (23,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-uC
-qU
-tY
-jd
-Go
-Ll
-Ty
-nq
-Ty
-Ty
-Ty
-BI
-mD
-VX
-vk
-fO
-Ty
-Ty
-BI
-ue
-ue
-ue
-fO
-fO
-fO
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-bG
-Ud
-FY
-Ty
-lY
-Ty
+TE
+TE
+TE
+TE
+rN
+rN
 lD
-Lw
-CF
-yk
-Cr
-ZT
-Ri
-wt
-wt
-wt
+fb
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+cV
+fz
+gw
+DS
+DS
+BT
+cO
+qx
+nq
+MR
+lF
+jn
+ZA
+ZA
+jf
+JX
+ZA
+OI
+mY
+et
+we
+eG
+Lp
+fT
+fG
+fG
+fG
+fG
+fG
+YR
+fG
+fG
+mv
+oe
+na
+GF
+Ud
+st
+IO
+qL
+Gq
+wr
+fG
+fG
+fG
+NR
+NR
+nQ
+vJ
+wf
+es
 "}
 (24,1,1) = {"
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-uC
-QE
+TE
+TE
+TE
+TE
+TE
+yW
+rN
+dH
+fG
+nQ
+WP
+Cq
+fG
+lY
+jF
+lY
+fG
+lY
+fG
+Lm
+cV
+cV
+yJ
+bG
+mO
+uB
+bs
+PS
+UI
+Iz
 tY
-jd
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-fO
-Gh
-nR
-Pj
-fO
-fO
-fO
-fO
-ZC
-Kb
-Yw
-Dt
-VY
-fO
-fO
-Ty
-Ty
-Ty
-Jg
-Ty
-Ty
-Ir
-Ir
-TD
-Ty
-Ty
-Ty
-lD
-Lw
-UP
-Ri
-II
-bH
-Ri
-wt
-wt
-wt
+MA
+GV
+uX
+pG
+UN
+am
+uX
+dj
+ha
+ha
+Th
+fG
+YR
+fG
+Qx
+cM
+fG
+fG
+fG
+YR
+XN
+Ew
+oe
+YS
+Tc
+wr
+kv
+EN
+Jz
+wr
+fG
+fG
+nQ
+NR
+NR
+Nc
+Yi
+rN
+es
 "}
 (25,1,1) = {"
+TE
+TE
+TE
+TE
+TE
+Ey
+TE
+rN
+BF
+nQ
+LW
+Xu
+zr
+jW
+Yc
+Uh
+KN
+oP
+qM
 RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Zy
-uC
-qU
-Ir
-Ty
-Ll
-Dh
-Lv
-Ty
-Jg
-Ty
-Ty
-fO
-JY
-nR
-iZ
-Kx
-BO
-Ec
-fO
-jy
-Wq
-Yw
-GL
-sm
-xT
-NN
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ir
-bG
-wt
-Ty
-Ty
-lS
-Wh
-CF
-HL
-Ri
-kV
-Ri
-Ri
-wt
-wt
-wt
+Gg
+Gg
+wN
+mJ
+dK
+yZ
+KQ
+KQ
+lY
+YG
+oD
+kS
+aC
+LT
+LT
+LT
+LT
+LT
+LT
+LT
+LT
+LT
+KQ
+ZP
+KQ
+KQ
+iW
+fG
+YR
+fG
+CY
+KQ
+KQ
+iT
+Oc
+SX
+wr
+Fp
+BN
+ZT
+wr
+fG
+YR
+nQ
+nQ
+nQ
+nQ
+OV
+ov
+es
 "}
 (26,1,1) = {"
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+WN
+NR
+nQ
+aR
+Yq
+eY
+KQ
+KQ
+Lc
+kt
 uC
-qU
-Ir
-jd
-Ty
-Ll
-kL
-Ty
-Ty
-Ty
-Ty
-fO
-iN
-Xx
-QI
-Ka
-fs
-PR
-wu
-Hx
-Ls
-vl
-Za
-og
-yv
-KF
-Ty
-Ty
-Ty
-Ty
-Ty
-Jg
-Ir
-wt
-wt
-wt
-VV
-lD
-Xb
-dA
-GN
-Ri
-Ri
-Ri
-wt
-wt
-wt
-wt
+uC
+uC
+uC
+nO
+Kg
+hs
+KQ
+KQ
+KQ
+ka
+WY
+Oi
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Xu
+mc
+ea
+ZR
+KQ
+KQ
+KQ
+iT
+hE
+Xi
+wr
+mK
+mK
+mK
+wr
+iV
+lm
+jz
+nQ
+iv
+aR
+rN
+rK
+es
 "}
 (27,1,1) = {"
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-uC
-qU
+wg
+wg
+wg
+wg
+wg
+CB
+wg
+wg
+wg
+Vd
+Vd
+eY
+eY
+Em
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
 jd
-Ir
-Dh
-Jg
-Ty
-Ty
-Ty
-Ty
-Ty
-fO
-KH
-CT
-NH
-la
-nh
-PG
-XV
-nR
-QN
-IN
-Gy
-xR
-ow
-KF
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-wt
-wt
-Ri
-Ri
-Ri
-Ri
-OJ
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+ZV
+KQ
+KQ
+KQ
+BS
+vk
+vb
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+IX
+Bv
+KQ
+KQ
+KQ
+KQ
+iT
+Yo
+TY
+nV
+Wz
+Ie
+Xq
+ta
+EU
+kl
+Aj
+rN
+iD
+MZ
+VO
+MZ
+es
 "}
 (28,1,1) = {"
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-uC
-qU
-Ir
-Ir
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+Vd
+Vd
+Vd
+wk
+Vd
+Cl
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+ZL
+KQ
+KQ
+KQ
+BS
 Ty
-Lv
-Ty
-Ty
-Ty
-Ty
-Ty
-ho
-EZ
-hn
-eD
-fO
-fO
-fO
-fO
-xj
-Qh
-ju
-Zz
-cU
-fO
-fO
-Ty
-Ty
-Ty
-Ty
-VV
+BV
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
 iT
-wt
-wt
-Ri
-Ri
-Zi
-jh
-yC
-PB
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+mM
+HG
+nV
+Wz
+wQ
+Xq
+ta
+EU
+lm
+Aj
+rN
+np
+rN
+QJ
+rN
+es
 "}
 (29,1,1) = {"
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-qU
-oD
-Ir
-Ir
-Dh
-ku
-Ty
-Ty
-Ty
-Ty
-Ty
-BI
-fO
-fO
-fO
-fO
-Ty
-Ty
-BI
-fO
-fO
-fO
-fO
-fO
-BI
-Ty
-Ty
-Ty
-Ty
-wt
-Jz
-wt
-wt
-wt
-Ri
-QX
-Fy
-jZ
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+Vd
+Vd
+Vd
+Vd
+HV
+QR
+Cl
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+NW
+rA
+Gr
+HL
+Be
+rA
+lo
+lo
+Fm
+oJ
+oJ
+oJ
+rA
+rA
+gv
+KQ
+KQ
+KQ
+KQ
+KQ
+eY
+KQ
+KQ
+KQ
+KQ
+KQ
+iT
+bm
+CF
+HD
+tK
+ID
+uN
 ta
-hh
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+Jl
+lm
+Aj
+SR
+Yi
+QQ
+oS
+ll
+es
 "}
 (30,1,1) = {"
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-qU
-jd
-Ir
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wk
+wk
+Vd
+KQ
+KQ
+KQ
+KQ
+kA
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+rA
+qO
+CN
+bF
+BP
+rA
+rA
+rA
+rA
+pj
+tA
+KW
+yA
 sM
-VV
-Ty
-Dh
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-wt
-wt
-wt
-wt
-wt
-wt
-Ri
-Dg
-zV
-gF
-Lb
-Ri
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
+rA
+rA
+KQ
+KQ
+KQ
+KQ
+eY
+eY
+KQ
+KQ
+KQ
+KQ
+iT
+ZQ
+yx
+wr
+wr
+dA
+wr
+wr
+iV
+hi
+ik
+nQ
+nQ
+NR
+xv
+ge
 es
 "}
 (31,1,1) = {"
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-DJ
-RM
-RM
-RM
-RM
-wt
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+wg
+wg
+Vd
+Wg
+Vd
+mt
+Vy
+Em
+uJ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+rA
+yk
 Ir
-Nf
-wt
-Jz
-wt
-Jg
-Jg
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
+uq
+MT
+KF
+ch
+Ql
+rA
 Jm
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-aO
+BJ
+KW
+EA
+gk
+Lb
+KA
+KQ
+KQ
+KQ
 UV
-Ty
-Ty
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Ri
-Ri
-Ri
-Ri
-Ri
-Ri
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+Cq
+RD
+Yf
+KQ
+Yj
+KK
+Ms
+PY
+aD
+wr
+PZ
+cv
+Bt
+wr
+fG
+YR
+NR
+NR
+DX
+ws
+Cr
+rN
 es
 "}
 (32,1,1) = {"
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-BT
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-GR
-rn
-Jg
-Ty
-BR
-Jg
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-Ty
-UY
-Fs
-ZQ
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+wg
+WN
+Wg
+Vd
+Vd
+Vd
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+rA
+zX
+Ir
+tp
+hp
+Jt
+bX
+Za
+YN
+bH
+bH
+HN
+pY
+dt
+eQ
+KA
+KQ
+eg
+KQ
+Xu
+Cq
+Cq
+PC
+KQ
+bY
+iT
+YS
+PY
+Jh
+wr
+wG
+zG
+Tv
+wr
+fG
+fG
+fG
+NR
+Nc
+NR
+jv
+QQ
 es
 "}
 (33,1,1) = {"
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-HW
-Ma
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Jz
-kj
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+Vd
+Vd
+Vd
+Vd
+Vy
+mt
+Em
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+eg
+Lw
+Lw
+KQ
+rA
+rA
+xh
+Fy
+DC
+Kd
 XM
-HQ
-Jg
-Jg
-Ty
-Jg
-Ty
-Ty
-Ty
-VV
-Ty
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+Cd
+WE
+kH
+Xo
+QU
+of
+bu
+Qz
+KA
+KQ
+KQ
+Mo
+Xu
+fG
+Cq
+Cq
+Xu
+KQ
+Ts
+YS
+Tc
+ox
+wr
+wr
+aO
+wr
+wr
+fG
+fG
+fG
+fG
+NR
+iD
+xr
+rN
 es
 "}
 (34,1,1) = {"
 es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+Vd
+Vd
+Vd
+Vd
+eY
+Cl
+Vb
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+Gh
+cj
+kO
+Ip
+vg
+rA
+rA
+rA
+rA
+VZ
+AV
+Bd
+mC
+Te
+rA
+rA
+KQ
+KQ
+Xu
+fG
+fG
+YR
+fG
+fG
+PN
+Vu
+pv
+ax
+yK
+fG
+rn
+ce
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+NR
+kV
 es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
-kA
-Ma
-Kw
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-bJ
-lo
-Fs
-Ap
-Fs
-gv
-Iu
-UV
-wt
-Jz
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
 es
 "}
 (35,1,1) = {"
 es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-Ma
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+wg
 Vd
-Ma
-Qx
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-Kw
-At
-UV
-HQ
-eG
-Kw
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+wk
+Vd
+mt
+TE
+KQ
+ih
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+Lw
+KQ
+NW
+rA
+rA
+rA
+rA
+rA
+lo
+lo
+CR
+rA
+rA
+rA
+rA
+rA
+YV
+KQ
+KQ
+KQ
+fG
+fG
+fG
+fG
+QX
+QX
+QX
+QX
+ts
+pn
+QX
+fG
+fG
+ij
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+rN
+vr
+es
 es
 "}
 (36,1,1) = {"
 es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-zG
-Ma
-Es
-Zd
-Ma
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+Vd
+Vd
+QR
+Vd
+Vd
+Em
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Lw
+zf
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+Xu
+YR
+fG
+fG
+fG
+fG
+QX
+lS
+Ue
+uR
+jU
+un
+QX
+fG
+rn
+Os
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+ge
+ge
 es
 es
 "}
 (37,1,1) = {"
 es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-dd
-Qx
-zG
-Ma
-RL
-Hk
-Ma
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-es
-es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+WN
+wk
+eY
+Kz
+Zi
+Mf
+uY
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+jd
+Gd
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KZ
+Jo
+fG
+fG
+fG
+fG
+fG
+QX
+Qy
+dk
+OZ
+vi
+Wu
+QX
+fG
+fG
+dT
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+hQ
+QJ
 es
 es
 "}
 (38,1,1) = {"
 es
-es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-Es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+Vd
+wk
+wk
+nQ
+Da
+KZ
+KQ
+KQ
+SM
+hU
+Ji
+Yn
+Yn
+Yn
+Np
+Xy
+Ln
+KQ
+KQ
+lY
+wN
+Cy
+wN
+lY
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+KQ
+UV
+GZ
+iW
+fG
+fG
 tQ
-Ly
-oQ
-Ma
-Ma
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-es
-es
-es
-es
-es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
+tQ
+EK
+EK
+QX
+OU
+TO
+tQ
+jA
+cb
+xu
+Ri
+Cg
+ds
+YR
+rn
+rn
+fG
+fG
+fG
+fG
+XC
 es
 es
 es
@@ -6483,64 +9625,71 @@ es
 (39,1,1) = {"
 es
 es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-Ql
-RM
-Es
-RL
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-es
-es
-es
-es
-es
-es
-es
-wt
-wt
-wt
-wt
-wt
-es
-es
+TE
+TE
+Tw
+TE
+TE
+jv
+Ug
+MN
+NR
+bJ
+KR
+Xu
+At
+KN
+KN
+jg
+Gg
+xL
+Gg
+Gg
+wN
+Xd
+Wn
+GT
+KQ
+KQ
+kL
+wF
+aq
+aq
+hh
+dl
+sr
+dl
+sr
+dl
+fN
+uu
+QK
+KZ
+KZ
+yr
+KZ
+df
+ts
+Px
+DH
+JQ
+OF
+rU
+AH
+cb
+jm
+QX
+fG
+rn
+dT
+rn
+rn
+FN
+YR
+fG
+fG
+rN
+rN
 es
 es
 es
@@ -6548,64 +9697,71 @@ es
 (40,1,1) = {"
 es
 es
-es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-es
-es
-es
-es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
+TE
+TE
+Bs
+Yp
+rN
+fu
+fG
+fG
+jM
+LM
+fG
+lY
+nu
+lY
+fG
+lY
+fG
+YR
+fG
+KQ
+KQ
+KZ
+pg
+ve
+ck
+IP
+gD
+we
+UY
+ZA
+ZA
+jf
+ZA
+ZA
+jf
+jf
+Fe
+OG
+Vg
+Zk
+nv
+RG
+RG
+Rc
+ji
+jc
+Yl
+aY
+OA
+xJ
+mI
+iM
+OR
+QX
+fG
+fG
+Xb
+rn
+rn
+Hp
+fG
+fG
+fG
+VO
+TJ
 es
 es
 es
@@ -6613,64 +9769,71 @@ es
 (41,1,1) = {"
 es
 es
-es
-es
-es
-es
-es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-MR
-RM
-RM
-RM
-RM
-RM
-es
-es
-es
-es
-es
-es
-es
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-wt
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
-es
+TE
+TE
+TE
+rN
+sL
+rN
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+YR
+pK
+pg
+pg
+fT
+fT
+fT
+mY
+ZA
+jf
+sa
+EM
+ec
+We
+Pc
+JI
+xI
+JJ
+ZA
+pK
+fG
+fG
+tQ
+tQ
+tQ
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+Wr
+KZ
+go
+KZ
+KZ
+zW
+fG
+fG
+fb
+rN
+rN
 es
 es
 es
@@ -6678,45 +9841,916 @@ es
 (42,1,1) = {"
 es
 es
+TE
+TE
+rN
+rN
+bK
+rN
+fb
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+KC
+VU
+KN
+uk
+uk
+ua
+ua
+ua
+ua
+Nl
+Rd
+Rd
+ua
+QP
+dB
+ua
+gm
+CH
+fG
+fG
+rn
+rn
+fI
+tB
+cn
+CD
+fv
+rn
+rn
+YR
+rn
+KZ
+NN
+YR
+rn
+rn
+Iw
+fG
+fG
+fG
+rN
+Zh
+ge
+es
+es
+es
+"}
+(43,1,1) = {"
+es
+es
+TE
+TE
+rN
+rN
+jh
+rN
+dH
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+pk
+ar
+fG
+fG
+ua
+NT
+zL
+ua
+qb
+Pf
+Pf
+Pf
+gh
+CZ
+ua
+fG
+fG
+fG
+fG
+rn
+FN
+NP
+rn
+rn
+rn
+Gf
+XW
+fI
+Fw
+Nq
+KZ
+YR
+YR
+YR
+rn
+rn
+fG
+fG
+fG
+rN
+Cr
 es
 es
 es
 es
+"}
+(44,1,1) = {"
 es
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
+TE
+TE
+rN
+ov
+rN
+lD
+Wh
+rN
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+uk
+fI
+pk
+Lq
+fG
+ua
+ua
+lM
+yg
+sn
+to
+Mb
+ix
+zJ
+vt
+Mk
+ua
+fG
+fG
+fG
+YR
+KZ
+RV
+rn
+rn
+lV
+rn
+rn
+Jg
+rn
+rn
+KZ
+rn
+rn
+YR
+fG
+fG
+fG
+fG
+fG
+rN
+XC
+rN
 es
 es
 es
 es
+"}
+(45,1,1) = {"
 es
 es
-es
-es
-es
-es
-es
+TE
+TE
+TE
+jz
+dH
+ov
+rN
+qU
+aF
+rN
+Nj
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+uk
+pk
+qr
+uk
+fG
+ua
+SI
+Fa
+Ou
+ua
+Dh
+zM
+As
+ua
+jS
+ol
+ua
+fG
+fG
+KZ
+DJ
+sj
+rn
+rn
+QE
 wt
-wt
-wt
-wt
-wt
-wt
+ne
+rn
+hm
+rn
+YR
+KZ
+Vh
+KZ
+fG
+fG
+fG
+fG
+fG
+rN
+CO
+np
+es
+es
+es
+es
+es
+"}
+(46,1,1) = {"
+es
+es
+TE
+TE
+TE
+TE
+lD
+nI
+Hb
+VH
+rN
+rN
+xS
+xS
+NR
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+Mg
+fI
+fG
+fG
+ua
+Ba
+bj
+VV
+ua
+Qb
+hM
+Bp
+ua
+Gy
+Gn
+ua
+fG
+rn
+II
+fG
+fG
+rn
+lV
+Hd
+WA
+iA
+NL
+Oy
+rn
+rn
+rn
+KZ
+fG
+fG
+fG
+fG
+fG
+rN
+TJ
+kV
+rN
+es
+es
+es
+es
+es
+"}
+(47,1,1) = {"
+es
+es
+TE
+TE
+TE
+TE
+ep
+TE
+lD
+qU
+TE
+lb
+Bo
+nQ
+fY
+fY
+Nn
+Al
+fG
+fG
+fG
+fG
+fG
+fG
+YR
+lI
+YR
+fG
+ua
+ua
+ua
+ua
+ua
+ua
+ua
+Zd
+ua
+ua
+ua
+ua
+fI
+RT
+XK
+fG
+fG
+rn
+rn
+mx
+ad
+eF
+rn
+rn
+rn
+rn
+rn
+rn
+fG
+fG
+fG
+fG
+rN
+rN
+VO
+rN
+es
+es
+es
+es
+es
+es
+"}
+(48,1,1) = {"
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fY
+fY
+TE
+TE
+TE
+TE
+fG
+fG
+fG
+fG
+fG
+KZ
+fG
+rn
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+WK
+ni
+vd
+nv
+hg
+rg
+YR
+oZ
+fG
+fG
+fG
+rn
+rn
+rn
+rn
+rn
+fD
+hB
+tC
+YR
+fG
+fG
+fG
+fG
+kj
+Cr
+DP
+ge
+es
+es
+es
+es
+es
+es
+es
+"}
+(49,1,1) = {"
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+Rh
+TE
+TE
+fG
+fG
+fG
+rn
+Tj
+lI
+sI
+zt
+KZ
+fG
+fG
+aL
+fG
+rn
+qZ
+Nq
+fG
+fG
+KZ
+fG
+fG
+KZ
+gq
+fG
+fG
+fG
+fG
+fG
+fG
+sZ
+eb
+rn
+rn
+rn
+fG
+fG
+fG
+fG
+HW
+np
+rN
+es
+es
+es
+es
+es
+es
+es
+es
+"}
+(50,1,1) = {"
+es
+es
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+fG
+rn
+rn
+fG
+fG
+rn
+Tj
+go
+KZ
+fG
+YR
+rn
+rn
+fI
+fG
+fG
+JC
+fG
+fG
+fG
+Tj
+Mp
+cn
+nv
+kB
+Hw
+hB
+Oy
+rn
+rn
+rn
+rn
+fG
+fG
+fG
+rN
+np
+rN
+es
+es
+es
+es
+es
+es
+es
+es
+es
+"}
+(51,1,1) = {"
+es
+es
+es
+es
+es
+es
+es
+es
+es
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+TE
+es
+fG
+fG
+fG
+fG
+rn
+rn
+rn
+Tj
+KZ
+QT
+KZ
+KZ
+bB
+rn
+fG
+lI
+fG
+fG
+fG
+fG
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+fG
+fG
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+"}
+(52,1,1) = {"
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+rn
+rn
+fG
+rn
+fG
+fG
+rn
+rn
+fG
+Hc
+fG
+fG
+fG
+fG
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+rn
+fG
+rn
+fG
+fG
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+"}
+(53,1,1) = {"
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+es
+es
+fG
+fG
+fG
+fG
+fG
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+"}
+(54,1,1) = {"
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+fG
+es
+es
+es
+es
+es
+es
 es
 es
 es
@@ -6740,7 +10774,7 @@ es
 es
 es
 "}
-(43,1,1) = {"
+(55,1,1) = {"
 es
 es
 es
@@ -6751,19 +10785,26 @@ es
 es
 es
 es
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
-RM
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
+es
 es
 es
 es

--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_serene_hunts.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_serene_hunts.dmm
@@ -1,0 +1,12177 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"af" = (
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"ai" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/hazard/fire/wires/alarm,
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/storage/box/ammo/a44roum{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/storage/box/ammo/a44roum{
+	pixel_y = -2;
+	pixel_x = 7
+	},
+/obj/item/storage/box/ammo/a44roum{
+	pixel_y = 7;
+	layer = 3.1
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"ak" = (
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"am" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ap" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"aq" = (
+/obj/structure/table/reinforced,
+/obj/item/kitchen/rollingpin,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"as" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/cocoon/person,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"at" = (
+/obj/structure/spider/fake_eggcluster,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"au" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"av" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"az" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aA" = (
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aE" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aF" = (
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aG" = (
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aI" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aK" = (
+/obj/structure/closet/wall/white/directional/north,
+/obj/item/towel,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"aN" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"aV" = (
+/obj/structure/platform/wood_two{
+	dir = 8
+	},
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/canteen)
+"aZ" = (
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"bb" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"bc" = (
+/obj/machinery/light/broken/directional/east,
+/obj/structure/flippedtable{
+	icon_state = "wood_table";
+	dir = 4
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"bd" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"bg" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bi" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo bay";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"bj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bw" = (
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"bx" = (
+/obj/item/food/meat/slab/goliath,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"bz" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/coffee_cup,
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"bD" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/tarantula,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"bE" = (
+/obj/structure/spider/cocoon/person,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"bH" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"bI" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/table_bell/brass{
+	pixel_y = -1;
+	pixel_x = -5
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"bN" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/phone,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"bO" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bQ" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/closet/wall/white/directional/east,
+/obj/item/soap/deluxe,
+/obj/item/towel,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/toilet)
+"bR" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/shotgun/slug,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"bW" = (
+/turf/closed/wall/concrete,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cc" = (
+/obj/structure/spacevine/dense,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ci" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"cj" = (
+/mob/living/simple_animal/hostile/jungle/seedling/mining,
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"ck" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 4
+	},
+/obj/item/stack/arcadeticket{
+	name = "voucher ticket";
+	singular_name = "voucher ticket";
+	desc = "A punched ticket. Says 'ADMIT ONE' on the front"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"cn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"cu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"cx" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"cB" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -24;
+	name = "containment shutters";
+	id = "cell1"
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"cF" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/barn)
+"cJ" = (
+/obj/structure/fluff/hedge/opaque,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"cN" = (
+/obj/structure/fence,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"cQ" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cR" = (
+/obj/structure/chair/bench/beige,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cT" = (
+/obj/structure/spacevine/weak,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cU" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"dd" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"dp" = (
+/obj/machinery/door/airlock{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"dq" = (
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"dD" = (
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dH" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dN" = (
+/obj/item/trash/pistachios,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"dR" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dY" = (
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"eb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ed" = (
+/obj/structure/bed{
+	icon_state = "dirty_mattress"
+	},
+/obj/structure/safe/floor{
+	open = 1
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"eg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"en" = (
+/obj/item/mob_trophy/shiny{
+	pixel_x = 7
+	},
+/obj/item/mob_trophy/shiny,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"ep" = (
+/obj/structure/flora/ash/garden,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eq" = (
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"es" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"ew" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/spacevine,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ex" = (
+/obj/item/spacecash/bundle/c10,
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_x = 9
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eD" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/powered/hunts/gate)
+"eE" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/ruin/powered/hunts/hotel)
+"eH" = (
+/obj/structure/barricade/wooden,
+/obj/structure/spacevine,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/hotel)
+"eJ" = (
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"eL" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = -6;
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/condiment/oliveoil{
+	pixel_x = 6;
+	pixel_y = 19
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"eO" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"eP" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/orange,
+/obj/machinery/power/floodlight,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"eR" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"eS" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/canteen)
+"eW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eX" = (
+/obj/effect/turf_decal/industrial/stand_clear{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"fg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"fh" = (
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"fk" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fl" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fn" = (
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 3;
+	pixel_x = -13
+	},
+/obj/item/spacecash/bundle/c10,
+/obj/item/spacecash/bundle/c5{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fr" = (
+/obj/item/cigbutt/cigarbutt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"fs" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"ft" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"fv" = (
+/obj/structure/spacevine{
+	pixel_y = 31
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fy" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 8
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fA" = (
+/obj/structure/spacevine,
+/mob/living/simple_animal/hostile/venus_human_trap/mining,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fD" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fF" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"fH" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"fL" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fM" = (
+/turf/open/floor/concrete/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"fO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fS" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fX" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ga" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "bridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"gc" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/turf/open/floor/concrete/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"gk" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gn" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"gr" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -27;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"gt" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gx" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"gy" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/table_bell/brass{
+	pixel_y = 9;
+	pixel_x = 7
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"gD" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"gL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"gU" = (
+/obj/structure/table/wood/reinforced,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"gX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/obj/machinery/light/dim/directional/north,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"gY" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"gZ" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"hc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"he" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"hg" = (
+/obj/structure/platform/ship_four{
+	dir = 5
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hi" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"hm" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hr" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"hw" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/gibspawner/generic/animal,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hy" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"hB" = (
+/obj/structure/platform/ship_four{
+	dir = 4
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hF" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hI" = (
+/obj/item/spacecash/bundle/c10{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/spacecash/bundle/c10{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hL" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hM" = (
+/obj/structure/spacevine,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hP" = (
+/obj/item/kirbyplants,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"hS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"hU" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hV" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"hW" = (
+/obj/structure/closet/mob_capture{
+	opened = 1
+	},
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hunts/shuttle)
+"ia" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear/white,
+/obj/effect/turf_decal/siding/white/corner,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"ig" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"im" = (
+/obj/machinery/light/broken/directional/north,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"io" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "cell5"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"iq" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo bay"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"ir" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"iv" = (
+/obj/item/crowbar/large,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"iy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"iA" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/energybar,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"iB" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"iC" = (
+/obj/machinery/light/broken/directional/west,
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"iD" = (
+/obj/structure/table/reinforced,
+/obj/item/cutting_board,
+/obj/item/food/meat/slab,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"iH" = (
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"iI" = (
+/obj/machinery/power/rtg/geothermal,
+/obj/machinery/power/terminal,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered/hunts/shed)
+"iM" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"iO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile/shuttle,
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "bridge"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"iP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"iT" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"iU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iW" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 9
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"iY" = (
+/obj/machinery/atmospherics/pipe/manifold/orange{
+	dir = 1
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"je" = (
+/obj/structure/table_frame/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"jg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/canteen)
+"ji" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"jm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"jn" = (
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"jq" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = 3
+	},
+/obj/structure/mirror{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/spline/fancy/wood/cee,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"jw" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jx" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/wideband/table{
+	dir = 8;
+	pixel_x = -6;
+	layer = 2.9
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruin/jungle/missive{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"jy" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered/hunts/shed)
+"jB" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jE" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/item/newspaper{
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/cigarette/pipe{
+	pixel_y = 12
+	},
+/obj/item/lighter{
+	pixel_x = 11;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"jF" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "hunt"
+	},
+/turf/open/floor/concrete/reinforced/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"jI" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jJ" = (
+/obj/structure/rack,
+/obj/item/melee/knife/hunting,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"jL" = (
+/obj/structure/closet/wall/blue/directional/east,
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised{
+	name = "Naptime";
+	desc = "A length of pipe and miscellaneous bits of scrap fashioned into a rudimentary single-shot shotgun. The word 'Naptime' has been scrawled onto the barrel."
+	},
+/obj/item/reagent_containers/glass/bottle/dimorlin,
+/obj/item/reagent_containers/glass/bottle/curare,
+/obj/item/reagent_containers/glass/bottle/amanitin,
+/obj/item/reagent_containers/glass/bottle/sodium_thiopental,
+/obj/item/storage/box/ammo/a12g_dart,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"jU" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"jV" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"jY" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/shed)
+"kb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"kn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/item/paper/crumpled/bloody/fluff/ruin/jungle/reminder,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"ks" = (
+/obj/structure/flora/junglebush,
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ky" = (
+/obj/structure/table/wood/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/melee/classic_baton,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"kF" = (
+/obj/item/trash/dote,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"kJ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kK" = (
+/obj/item/shard,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"kL" = (
+/obj/structure/table/wood/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/computer/secure_data/laptop{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"kM" = (
+/turf/open/floor/plasteel/stairs/wood/jungleplanet/lit{
+	dir = 4
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"kN" = (
+/obj/structure/door_assembly/door_assembly_wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"lb" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"ld" = (
+/obj/effect/turf_decal/industrial/warning/corner,
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"le" = (
+/obj/machinery/paystand{
+	desc = "A paystand";
+	name = "pay stand"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"lg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"lk" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"ll" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"lo" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"lr" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"lw" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lA" = (
+/obj/structure/spacevine/weak,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"lJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"lL" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lO" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"lP" = (
+/obj/structure/spacevine/weak,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"lR" = (
+/obj/structure/table/wood,
+/obj/item/trash/boritos,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"lT" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lW" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"lX" = (
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning,
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 24;
+	name = "containment shutters";
+	id = "cell4"
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"lY" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/item/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"lZ" = (
+/mob/living/simple_animal/hostile/morph{
+	melee_damage_lower = 30;
+	melee_damage_upper = 40;
+	vision_range = 5
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"ma" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"mf" = (
+/obj/structure/flora/stump,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"mi" = (
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"mo" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/sauna,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"mr" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/spline/fancy/wood/cee{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"mx" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -25
+	},
+/turf/open/floor/carpet/black,
+/area/ruin/powered/hunts/hotel)
+"mD" = (
+/obj/structure/platform/wood_two/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"mH" = (
+/obj/structure/fence/door/opened{
+	name = "PRIVATE PROPERTY"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"mI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"mK" = (
+/obj/machinery/door/window/southleft{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"mQ" = (
+/obj/item/wrench,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"mY" = (
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/structure/table/wood/reinforced,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"mZ" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/effect/turf_decal/stoneborder{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nc" = (
+/obj/item/ammo_box/magazine/m23/empty,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ne" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"no" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nr" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"ny" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"nC" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 8
+	},
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"nF" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 1
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_y = -5;
+	pixel_x = 10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"nL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small/broken/directional/south,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shed)
+"nP" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nQ" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"nR" = (
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 1
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"nU" = (
+/obj/machinery/computer/helm,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"nY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"od" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"oe" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"of" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"og" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ol" = (
+/obj/machinery/door/airlock{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/barn)
+"om" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"on" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/spacevine/dense,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"ou" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"ov" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/item/ammo_casing/spent/rifle_brass,
+/obj/effect/mob_spawn/human/corpse/indie/manager,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ow" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"oD" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "cell5"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"oI" = (
+/obj/effect/turf_decal/stoneborder/corner,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"oL" = (
+/obj/structure/spacevine/dense,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oO" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/paper/crumpled/bloody/fluff/ruin/jungle/resignation,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"oR" = (
+/obj/structure/rack,
+/obj/item/clothing/head/soft/utility_olive{
+	pixel_x = -11
+	},
+/obj/item/clothing/head/soft/utility_olive{
+	pixel_x = 6
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"oT" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"oY" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/warning,
+/turf/open/floor/wood,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pb" = (
+/obj/structure/closet/wall/white/directional/east,
+/obj/item/soap/deluxe,
+/obj/item/towel,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/toilet)
+"pc" = (
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/toy/plush/sharai{
+	pixel_x = -6
+	},
+/obj/item/toy/plush/rilena{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/toy/plush/tali{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/clothing/suit/hooded/hoodie/rilena,
+/obj/item/clothing/shoes/kindleKicks{
+	pixel_y = -12
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"pd" = (
+/obj/machinery/door/airlock/command,
+/obj/effect/mapping_helpers/airlock/welded,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"pg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/wood/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pj" = (
+/obj/effect/turf_decal/siding/white/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/animal_corpse/goliath,
+/obj/effect/gibspawner/generic/animal,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pm" = (
+/obj/structure/platform/wood_two/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pn" = (
+/obj/machinery/door/airlock/freezer{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"po" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"pt" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 4
+	},
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/poddoor_assembly/shutters{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"pv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"pG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"pJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"pM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"pN" = (
+/obj/structure/spacevine,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pP" = (
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"pS" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pV" = (
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"pW" = (
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"pY" = (
+/obj/structure/spacevine/dense,
+/obj/structure/spacevine/dense{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qb" = (
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	name = "M-15 SUPER SPORTER";
+	desc = "The M-15 Super Sporter is the big brother to our famous M-12 Sporter line, and it sure does pack a punch. Chambered in 5.56 CLIP, the standard issue round of the CMM, this rifle is capable of punching through the toughest of hides."
+	},
+/obj/structure/displaycase{
+	start_showpiece_type = /obj/item/gun/ballistic/automatic/m15;
+	req_access_txt = "101"
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"qc" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"qd" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qj" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"qk" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ql" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"qm" = (
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"qs" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qt" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"qB" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/curtain/cloth/fancy{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/powered/hunts/hotel)
+"qO" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qX" = (
+/obj/structure/closet/crate/bin,
+/obj/item/stack/sheet/animalhide,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"qY" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rc" = (
+/obj/effect/turf_decal/number/right_five,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"re" = (
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"ri" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"rl" = (
+/obj/item/food/meat/slab/goliath,
+/mob/living/simple_animal/hostile/asteroid/wolf,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"rn" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ro" = (
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 24;
+	name = "containment shutters";
+	id = "cell5"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"rq" = (
+/obj/structure/chair/bench/orange/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"rr" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rs" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"rt" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ru" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"rw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"rx" = (
+/obj/structure/platform/ship_four{
+	dir = 10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rD" = (
+/obj/machinery/door/window/southleft{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"rE" = (
+/obj/structure/closet/wall/white/directional/north,
+/obj/item/clothing/under/suit/charcoal,
+/obj/item/clothing/shoes/winterboots/ice_boots{
+	name = "hiking boots"
+	},
+/obj/item/storage/wallet/random,
+/obj/item/modular_computer/tablet,
+/obj/item/spacecash/bundle/c500,
+/obj/item/spacecash/bundle/smallrand,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"rH" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"rI" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"rJ" = (
+/obj/structure/table/reinforced,
+/obj/item/table_bell{
+	pixel_x = 7
+	},
+/obj/item/storage/bag/tray{
+	pixel_y = 12;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"rM" = (
+/obj/structure/platform/ship_four{
+	dir = 6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rN" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"rO" = (
+/turf/closed/mineral/random/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rP" = (
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rQ" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/structure/closet/wall/directional/south,
+/obj/item/taperecorder,
+/obj/item/melee/knife/hunting,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/binoculars,
+/obj/item/clothing/suit/jacket/leather/duster{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/fedora/curator{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/clothing/shoes/workboots{
+	pixel_y = -2;
+	pixel_x = -4
+	},
+/obj/item/clothing/under/suit/tan{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"rS" = (
+/mob/living/basic/bear/cave,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"rT" = (
+/obj/structure/spacevine{
+	pixel_y = -32
+	},
+/obj/structure/spacevine{
+	pixel_y = -32
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rV" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"rZ" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sg" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"si" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold4w/orange,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"sk" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"sq" = (
+/obj/structure/noticeboard{
+	name = "trophy board";
+	desc = "A board for hanging trophies upon.";
+	pixel_y = 29
+	},
+/obj/item/mob_trophy/legion_skull{
+	pixel_y = 27
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"sr" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ss" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"st" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine{
+	pixel_x = 32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sv" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"sw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/wood/jungleplanet/lit{
+	dir = 4
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"sx" = (
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"sy" = (
+/obj/structure/railing/wood,
+/obj/item/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"sB" = (
+/obj/structure/chair/bench/orange{
+	dir = 1
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"sC" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"sK" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/restraints/legcuffs/beartrap{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"sL" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/item/modular_computer/laptop/preset/civilian/rilena,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"sO" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/noslip,
+/area/ruin/powered/hunts/toilet)
+"sQ" = (
+/obj/structure/spacevine/weak,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sR" = (
+/turf/closed/wall/concrete,
+/area/ruin/powered/hunts/barn)
+"sT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sZ" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"td" = (
+/obj/item/reagent_containers/condiment/milk,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"te" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"tf" = (
+/obj/structure/spacevine,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ti" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/structure/sink/kitchen{
+	dir = 8
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"tj" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"tl" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"tm" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 8
+	},
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 3;
+	pixel_x = -13
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"to" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tp" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"ts" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/gate)
+"tt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tx" = (
+/obj/structure/filingcabinet{
+	dir = 4
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"tz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tB" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shed)
+"tD" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine/dense{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tE" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/canteen)
+"tF" = (
+/obj/item/gun/ballistic/automatic/marksman/woodsman,
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"tH" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tJ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo bay"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 4;
+	id = "cargo"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"tL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"tM" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m17/empty{
+	pixel_y = -2;
+	pixel_x = -12
+	},
+/obj/item/ammo_box/magazine/m17/empty{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/item/ammo_box/magazine/m17/empty{
+	pixel_y = -2;
+	pixel_x = 1
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/machinery/light/dim/directional/east,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"tN" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tT" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 9
+	},
+/obj/structure/crate_shelf,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hunts/shuttle)
+"tU" = (
+/obj/machinery/button/door{
+	pixel_x = -22;
+	pixel_y = 6;
+	name = "cargo bay shutters";
+	id = "cargo bay";
+	dir = 4
+	},
+/obj/machinery/button/shieldwallgen{
+	dir = 4;
+	pixel_y = -6;
+	pixel_x = -21;
+	id = "cargo bay"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"tW" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"tY" = (
+/obj/item/spacecash/bundle/c1,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ua" = (
+/obj/structure/sign/poster/contraband/twelve_gauge{
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"uj" = (
+/obj/structure/platform/ship_four/corner,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"un" = (
+/obj/item/clothing/shoes/galoshes{
+	pixel_x = 8;
+	pixel_y = -8
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -24
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"uo" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"us" = (
+/obj/effect/turf_decal/number/left_three,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"ut" = (
+/obj/item/reagent_containers/glass/bucket{
+	name = "feed bucket"
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"uv" = (
+/obj/structure/chair/bench/orange{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"uw" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uy" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uE" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uH" = (
+/obj/structure/spacevine/dense,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"uL" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -25
+	},
+/turf/open/floor/carpet/orange,
+/area/ruin/powered/hunts/hotel)
+"uM" = (
+/obj/effect/turf_decal/stoneborder{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"uR" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uS" = (
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"uV" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uZ" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"vb" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 29
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"vj" = (
+/obj/structure/flippedtable{
+	icon_state = "wood_table";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"vk" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vr" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vw" = (
+/obj/structure/platform/wood_two{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"vJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"vN" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"vO" = (
+/obj/machinery/computer/monitor,
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"vQ" = (
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"vT" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 1
+	},
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 10
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vV" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vW" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wb" = (
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker{
+	pixel_y = 9
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_y = -1;
+	pixel_x = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"wd" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/food/siti_miras,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"wg" = (
+/obj/effect/turf_decal/stoneborder{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wp" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"wx" = (
+/obj/effect/turf_decal/spline/fancy/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"wy" = (
+/obj/structure/platform/wood_two/corner,
+/obj/structure/curtain/cloth,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"wB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wC" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/storage/box/ammo/a8_50r/trac{
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"wI" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell1"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"wK" = (
+/obj/structure/platform/wood_two{
+	dir = 4
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"wL" = (
+/obj/machinery/light/broken/directional/east,
+/mob/living/simple_animal/hostile/asteroid/ice_whelp,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"wO" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"wT" = (
+/obj/structure/rack,
+/obj/item/clothing/under/syndicate/camo{
+	pixel_x = -7
+	},
+/obj/item/clothing/under/syndicate/camo{
+	pixel_x = 7
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"wU" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -24;
+	name = "containment shutters";
+	id = "cell3"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"xg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"xk" = (
+/obj/item/stack/tile/wood/ebony,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"xl" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xm" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xo" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"xq" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"xr" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"xv" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xx" = (
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 24;
+	name = "containment shutters";
+	id = "cell6"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"xy" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/hotel)
+"xA" = (
+/obj/item/food/meat/slab/goliath,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"xG" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"xH" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"xI" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"xK" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"xT" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet{
+	dir = 4
+	},
+/obj/item/toy/plush/kari,
+/turf/open/floor/carpet/cyan,
+/area/ruin/powered/hunts/hotel)
+"xV" = (
+/obj/effect/turf_decal/number/right_four,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"xW" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xZ" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ya" = (
+/obj/structure/spacevine,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/hotel)
+"yc" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yd" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 29
+	},
+/turf/open/floor/carpet/cyan,
+/area/ruin/powered/hunts/hotel)
+"ye" = (
+/obj/structure/spacevine,
+/mob/living/simple_animal/hostile/jungle/seedling/mining,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yi" = (
+/obj/item/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"yk" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"yl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"yn" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yo" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/light/broken/directional/east,
+/obj/structure/spacevine/dense,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"yr" = (
+/obj/item/bodycamera/broadcast_camera,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ys" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"yz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yI" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 29
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yJ" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"yP" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/sauna,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"yU" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yY" = (
+/obj/item/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"zb" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"zd" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"zj" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"zk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"zl" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"zo" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/stairs/wood,
+/area/ruin/powered/hunts/toilet)
+"zq" = (
+/obj/machinery/camera/autoname,
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/fake_eggcluster,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"zs" = (
+/obj/structure/door_assembly/door_assembly_wood,
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/hotel)
+"zt" = (
+/obj/structure/spacevine/dense{
+	pixel_y = 31
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"zy" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zz" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zA" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zD" = (
+/obj/item/ammo_casing/shotgun,
+/obj/item/ammo_casing/shotgun,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"zE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"zG" = (
+/obj/machinery/camera/autoname,
+/obj/item/trash/can/food,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"zH" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"zO" = (
+/obj/structure/platform/ship_four,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zS" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zW" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8
+	},
+/obj/item/trash/can/food/peaches/maint,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Ab" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"Ad" = (
+/obj/effect/mob_spawn/animal_corpse/goliath,
+/obj/effect/gibspawner/generic/animal,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ah" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ai" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"Al" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/obj/item/gun/ballistic/automatic/m12_sporter/empty{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	name = "M-12 SPORTER";
+	desc = "Affordable, effective, tried and tested. The M-12 Sporter is our most popular hunting rifle, and for good reason. The perfect bang for your buck."
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Am" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"Ao" = (
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"AB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"AF" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"AG" = (
+/obj/structure/table/wood/reinforced,
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -27
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"AK" = (
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"AN" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/closet/mob_capture{
+	opened = 1;
+	name = "\improper Damaged Lifeform Containment Unit";
+	desc = "A large closet-like container, used to capture hostile lifeforms for retrieval and analysis. The interior is heavily armored, preventing animals from breaking out while inside. The lock on this one seems a little loose however."
+	},
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hunts/shuttle)
+"AP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"AQ" = (
+/obj/structure/platform/ship_four/corner,
+/obj/item/spacecash/bundle/c10{
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"AT" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/machinery/jukebox/boombox{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/instrument/piano_synth/headphones/spacepods{
+	pixel_y = -4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"AU" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"AX" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"AZ" = (
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	desc = "The M-11 Buckmaster is our preimer shotgun, offering performance on par with military issue weapons for a fraction of the price.";
+	name = "M-11 BUCKMASTER"
+	},
+/obj/structure/displaycase/broken,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/hazard/fire/wires/alarm{
+	layer = 2.7
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Ba" = (
+/obj/structure/platform/ship_four{
+	dir = 1
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bd" = (
+/obj/structure/table/wood,
+/obj/structure/showcase/machinery/tv{
+	name = "\improper Minature Television";
+	desc = "A slightly battered looking TV."
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Be" = (
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/item/stack/ore/salvage/scrapmetal,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Bh" = (
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Bj" = (
+/obj/structure/railing,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bm" = (
+/obj/machinery/light/broken/directional/north,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"Bn" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"Bo" = (
+/turf/closed/wall/mineral/wood,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/jungle/seedling/mining,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Br" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bw" = (
+/turf/open/floor/plasteel/stairs/wood/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"By" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/sec)
+"BE" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"BF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"BH" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"BO" = (
+/obj/structure/chair/bench/orange,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"BQ" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"BR" = (
+/obj/structure/closet/wall/white/directional/north,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/glasses/sunglasses/ballistic{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/under/rank/security/officer,
+/obj/item/storage/wallet/random,
+/obj/item/gun/ballistic/automatic/pistol/m20_auto_elite,
+/obj/item/ammo_box/magazine/m20_auto_elite{
+	pixel_x = 2
+	},
+/obj/item/ammo_box/magazine/m20_auto_elite{
+	pixel_x = -9
+	},
+/obj/item/clothing/head/helmet/m10,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"BZ" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"Cc" = (
+/obj/effect/turf_decal/number/left_one,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Cg" = (
+/obj/structure/fence/door{
+	name = "EMPLOYEES ONLY"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Cn" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 4
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Cs" = (
+/obj/effect/turf_decal/spline/fancy/wood,
+/obj/structure/sign/painting/library{
+	pixel_y = -25
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Cy" = (
+/obj/structure/closet/secure_closet/freezer/fridge{
+	name = "ice machine";
+	desc = "It's a card-locked ice machine."
+	},
+/obj/item/twenty_pounds_of_ice{
+	pixel_y = -8;
+	pixel_x = -6
+	},
+/obj/item/twenty_pounds_of_ice{
+	pixel_y = 2;
+	pixel_x = -6
+	},
+/obj/item/twenty_pounds_of_ice{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/obj/item/twenty_pounds_of_ice{
+	pixel_y = 2;
+	pixel_x = 7
+	},
+/obj/effect/turf_decal/spline/fancy/wood/cee{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"CB" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/warning,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"CJ" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom/table{
+	dir = 8;
+	pixel_y = 17;
+	pixel_x = -6
+	},
+/obj/item/strange_crystal{
+	pixel_x = 13;
+	name = "captain's 'lucky' crystal"
+	},
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -23;
+	id = "bridge";
+	name = "window shutters"
+	},
+/obj/item/overmap_punchcard_spawner/dynamic/mission{
+	name = "helm console punchcard (Lava World)";
+	desc = "A piece of paper with carfully organized holes through it. It appears to have co-ordinates for a Lava world in this sector."
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"CS" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stoneborder{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CT" = (
+/obj/machinery/light/broken/directional/east,
+/obj/item/spacecash/bundle/smallrand,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"CW" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"CX" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"Da" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/obj/item/gun/ballistic/automatic/pistol/m17/empty,
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	name = "M-17 MICROTARGET";
+	desc = "The M-17 Microtarget pistol is a fantastic and versatile choice for any purpose, from small game hunting to self defence. The signature detachable barrel for excellent portability without comprimising accuracy."
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Dc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dd" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/ruin/powered/hunts/hotel)
+"Di" = (
+/mob/living/basic/bear/cave,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/electronics/airlock,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dt" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/pen/fountain,
+/obj/item/paper_bin,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Dy" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/spacevine,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Dz" = (
+/obj/structure/fence/door,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"DF" = (
+/obj/structure/platform/wood_two{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"DG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"DH" = (
+/obj/structure/spacevine{
+	pixel_x = -33
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DJ" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DM" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/spacevine,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"DP" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"DV" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ef" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Eh" = (
+/obj/structure/sauna_oven,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"El" = (
+/obj/structure/kitchenspike,
+/obj/effect/gibspawner/generic/animal,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"En" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"Eo" = (
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered/hunts/shed)
+"Ey" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/hotel)
+"EA" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_y = 13;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_y = 13;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/condiment/mayonnaise{
+	pixel_x = -2;
+	pixel_y = 18
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"EB" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"EF" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"EG" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/item/flashlight/lamp,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = 12;
+	pixel_y = 14
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"EH" = (
+/obj/structure/railing/wood{
+	dir = 6
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"EJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"EN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ER" = (
+/obj/structure/rack,
+/obj/item/clothing/neck/poncho,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"EX" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"EY" = (
+/obj/item/table_bell/brass{
+	pixel_x = -5
+	},
+/obj/structure/table/wood/reinforced,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Fb" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"Fe" = (
+/obj/structure/filingcabinet/double{
+	dir = 4
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Ff" = (
+/obj/structure/spacevine/weak,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fg" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fh" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper,
+/obj/structure/spacevine,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fi" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"Fm" = (
+/obj/structure/rack,
+/obj/item/storage/bag/trash{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 7
+	},
+/obj/item/mop/cyborg,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Fo" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fs" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fu" = (
+/obj/structure/table/wood,
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Fv" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"FG" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"FI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"FJ" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/m12_sporter/empty{
+	pixel_x = -7
+	},
+/obj/item/ammo_box/magazine/m12_sporter/empty{
+	pixel_x = -2
+	},
+/obj/item/ammo_box/magazine/m12_sporter/empty{
+	pixel_x = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"FM" = (
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"FO" = (
+/obj/item/attachment/rail_light,
+/obj/item/attachment/scope{
+	pixel_y = -11;
+	pixel_x = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"FR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"FT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"FX" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "cell4"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"FZ" = (
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"Gb" = (
+/obj/item/ammo_casing/spent/rifle_brass,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ge" = (
+/obj/machinery/washing_machine{
+	pixel_y = 3;
+	pixel_x = -8
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Gg" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Gh" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Gm" = (
+/obj/structure/table/wood/reinforced,
+/obj/structure/hazard/fire/wires/alarm{
+	layer = 2.7
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/a8_50r/trac,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Gn" = (
+/obj/structure/spacevine,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Gq" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Gs" = (
+/obj/structure/table_frame/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/food/salad/fruit,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Gv" = (
+/obj/structure/platform/wood_two{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Gy" = (
+/obj/structure/table/reinforced,
+/obj/structure/reagent_dispensers/servingdish{
+	name = "amimal feed"
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"Gz" = (
+/obj/structure/spacevine,
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/hotel)
+"GA" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"GF" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"GG" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"GH" = (
+/obj/structure/rack,
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/item/ammo_box/magazine/m15/empty{
+	pixel_x = -10
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"GL" = (
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"GV" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ha" = (
+/obj/structure/chair/bench/orange/directional/east,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Hb" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/stoneborder{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hc" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"Hd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"He" = (
+/obj/structure/spacevine/weak,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hh" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hi" = (
+/obj/structure/chair/bench/beige{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Hl" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hm" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Ho" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"Hp" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/toilet)
+"Hr" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -1;
+	pixel_x = -10
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Hs" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ht" = (
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/shotgun/buckshot,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 5;
+	pixel_y = 2;
+	layer = 2.9
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Hx" = (
+/obj/machinery/button/door{
+	dir = 4;
+	pixel_x = -24;
+	name = "containment shutters";
+	id = "cell2"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"HE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"HH" = (
+/obj/structure/railing/wood,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"HI" = (
+/obj/structure/spacevine,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HJ" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"HM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HR" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/turf_decal/industrial/stand_clear/white{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"Ib" = (
+/obj/structure/curtain/cloth/fancy,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/canteen)
+"If" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"Ig" = (
+/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Iv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Iw" = (
+/obj/machinery/light/dim/directional/north,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Iz" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"IB" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"IC" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"ID" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"II" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IJ" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IM" = (
+/obj/structure/railing/corner/wood{
+	dir = 8
+	},
+/obj/structure/railing/corner/wood,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"IN" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IR" = (
+/turf/open/floor/wood/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"IU" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"IZ" = (
+/obj/structure/sign/warning/xeno_mining{
+	pixel_y = 31
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Jc" = (
+/obj/structure/spacevine,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Jh" = (
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/suit/charcoal{
+	pixel_y = -2;
+	pixel_x = 7
+	},
+/obj/item/clothing/under/overalls/brown{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/clothing/shoes/workboots{
+	pixel_y = -8
+	},
+/obj/item/clothing/neck/poncho/orange,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Ji" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"Jj" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Jl" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"Jn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Jp" = (
+/obj/structure/spacevine,
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Js" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"Jt" = (
+/obj/structure/chair/office,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Ju" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"JA" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"JB" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"JC" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"JF" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"JH" = (
+/obj/structure/rack,
+/obj/item/melee/baton/cattleprod/loaded,
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"JI" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"JM" = (
+/obj/structure/curtain/cloth,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/canteen)
+"JT" = (
+/obj/structure/chair/bench/beige{
+	dir = 4
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ka" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Groundskeeper's Shed"
+	},
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Kb" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ke" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Kr" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Kw" = (
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Kx" = (
+/turf/closed/wall/mineral/titanium,
+/area/ruin/powered/hunts/shuttle)
+"Kz" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/cocoon/person,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"KF" = (
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/item/clothing/under/pants/camo{
+	pixel_x = -9
+	},
+/obj/item/clothing/under/pants/camo{
+	pixel_x = 4
+	},
+/obj/structure/sign/poster/official/foam_force_ad{
+	pixel_x = -32
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"KH" = (
+/obj/structure/table/reinforced,
+/obj/item/melee/knife/butcher{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"KJ" = (
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"KN" = (
+/obj/structure/platform/ship_four{
+	dir = 8
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"KO" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"KQ" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"KV" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Lb" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Lh" = (
+/obj/structure/railing/wood{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"Li" = (
+/obj/machinery/camera/autoname,
+/obj/machinery/light/broken/directional/west,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Lj" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ll" = (
+/obj/item/rack_parts,
+/obj/item/attachment/scope{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/structure/noticeboard{
+	name = "trophy board";
+	desc = "A board for hanging trophies upon.";
+	pixel_y = 29
+	},
+/obj/item/clothing/mask/rat/fox{
+	pixel_y = 29;
+	desc = "A taxidermied fox head for mounting on a headboard. You swear it's still staring at you.";
+	name = "fox head"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"Lo" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Lq" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ls" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/tech/grid,
+/area/ruin/powered/hunts/shed)
+"Lv" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell2"
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Lz" = (
+/obj/structure/table/reinforced,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"LB" = (
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian/rilena,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"LC" = (
+/obj/machinery/button/door{
+	dir = 1;
+	pixel_y = -23;
+	id = "hunt";
+	name = "gate shutters"
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/soft/red{
+	pixel_y = 8
+	},
+/obj/item/flashlight/seclite,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"LG" = (
+/obj/structure/railing/wood{
+	dir = 10
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"LI" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/broken/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"LK" = (
+/obj/item/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"LL" = (
+/obj/structure/noticeboard{
+	name = "trophy board";
+	desc = "A board for hanging trophies upon.";
+	pixel_y = 29
+	},
+/obj/item/clothing/mask/rat/bear{
+	pixel_y = 26;
+	name = "bear head";
+	desc = "A taxidermied bear head for mounting on a headboard. You swear it's still staring at you."
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"LN" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"LU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"LY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Mb" = (
+/turf/open/floor/engine/hull/interior,
+/area/ruin/powered/hunts/shuttle)
+"Mf" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mh" = (
+/obj/effect/turf_decal/siding/white/corner,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mi" = (
+/obj/structure/spacevine,
+/obj/vehicle/ridden/lawnmower,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mj" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Mq" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mv" = (
+/obj/effect/turf_decal/siding/white,
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mx" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/broken/directional/south,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"MG" = (
+/obj/structure/chair/office,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"MI" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"MU" = (
+/obj/structure/chair/bench/beige{
+	dir = 1
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"MW" = (
+/obj/effect/turf_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"MZ" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -10
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"Nc" = (
+/obj/effect/turf_decal/siding/white/corner,
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ne" = (
+/obj/structure/rack,
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	name = "M-20 AUTO ELITE";
+	desc = "The perfect union of power and portability, the M-20 Auto Elite was once the standard issue pistol of Star City police forms. Chambered in .44 Roumain for excellent stopping power in a compact package. A large sticker has been pasted onto the bottom: SORRY OUT OF STOCK"
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Ng" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"No" = (
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 10
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_y = -7
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Np" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Nu" = (
+/obj/machinery/vending/snack,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Nx" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Nz" = (
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/towel,
+/obj/item/towel,
+/obj/item/towel,
+/obj/effect/turf_decal/spline/fancy/wood/cee,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"NB" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"ND" = (
+/obj/effect/turf_decal/spline/fancy/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"NG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NJ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"NK" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NL" = (
+/obj/structure/chair/bench/orange/directional/west,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"NO" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"NP" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo bay"
+	},
+/obj/machinery/power/shieldwallgen/atmos/roundstart{
+	dir = 8;
+	id = "cargo"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"NQ" = (
+/obj/item/shard,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"NS" = (
+/obj/effect/turf_decal/siding/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NU" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell6"
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/structure/spacevine,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"NX" = (
+/obj/effect/turf_decal/industrial/stand_clear,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"Oe" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Og" = (
+/obj/effect/turf_decal/techfloor/orange{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/tech,
+/area/ruin/powered/hunts/shuttle)
+"Oi" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/industrial/stand_clear/white,
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"Om" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Op" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Ov" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Oz" = (
+/turf/template_noop,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OC" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OD" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"OG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"OH" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"OO" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/cave/explored)
+"OT" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"OV" = (
+/obj/structure/platform/ship_four/corner{
+	dir = 4
+	},
+/obj/item/spacecash/bundle/c1,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OW" = (
+/obj/item/spacecash/bundle/c1,
+/obj/item/spacecash/bundle/c10{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 1;
+	pixel_x = -9
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OX" = (
+/obj/structure/sign/departments/restroom{
+	pixel_x = 31
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OZ" = (
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Pe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Pf" = (
+/obj/structure/spacevine,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Pn" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Ps" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Pt" = (
+/obj/effect/turf_decal/stoneborder,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Px" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PG" = (
+/obj/item/spacecash/bundle/c1,
+/obj/item/spacecash/bundle/c10{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_y = 9;
+	pixel_x = 10
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PJ" = (
+/obj/structure/spacevine,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PN" = (
+/obj/effect/decal/remains/human,
+/obj/effect/gibspawner/generic/animal,
+/obj/structure/sign/painting/library{
+	pixel_y = 29
+	},
+/obj/item/clothing/head/HoS/cybersun,
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"PP" = (
+/obj/machinery/vending/snack,
+/obj/structure/noticeboard{
+	name = "trophy board";
+	desc = "A board for hanging trophies upon.";
+	pixel_y = 29
+	},
+/obj/item/stack/sheet/animalhide/xeno{
+	pixel_y = 28;
+	auto_scatter = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"PQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PS" = (
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/spawner/random/bedsheet{
+	dir = 4
+	},
+/turf/open/floor/carpet/red/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"PT" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"PU" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/obj/effect/mob_spawn/animal_corpse/goliath,
+/obj/effect/gibspawner/generic/animal,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PV" = (
+/turf/template_noop,
+/area/template_noop)
+"PY" = (
+/obj/structure/table/wood/reinforced,
+/obj/item/reagent_containers/glass/bowl{
+	name = "TAKE ONE"
+	},
+/obj/item/food/candy_corn{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/food/candy_corn{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/food/candy_corn{
+	pixel_y = 5
+	},
+/obj/item/food/candy_corn{
+	pixel_y = 5;
+	pixel_x = -3
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"PZ" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qc" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/fake_eggcluster,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Qe" = (
+/obj/structure/closet/wall/med/directional/north{
+	icon_door = "med_wall";
+	name = "First Aid Closet"
+	},
+/obj/item/stack/medical/gauze/twelve,
+/obj/item/reagent_containers/glass/bottle/ethanol{
+	name = "disinfectant bottle";
+	desc = "A small bottle of alcohol based disinfectant. It appears to be half empty.";
+	list_reagents = list(/datum/reagent/consumable/ethanol = 15);
+	pixel_y = 7;
+	pixel_x = 10
+	},
+/obj/item/stack/medical/bruise_pack{
+	pixel_y = 9
+	},
+/obj/item/storage/pill_bottle/tramal,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/gate)
+"Qf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Qh" = (
+/obj/item/storage/box/ammo/c22lr{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/item/storage/box/ammo/c22lr{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/storage/box/ammo/c22lr{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/item/storage/box/ammo/c22lr{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/storage/box/ammo/c22lr/hp{
+	pixel_y = 6;
+	layer = 3.1
+	},
+/obj/structure/hazard/fire/wires/alarm{
+	layer = 2.7
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Ql" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qm" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qo" = (
+/obj/effect/turf_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"Qq" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qs" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qx" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QA" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "cargo bay";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/shuttle)
+"QG" = (
+/obj/effect/turf_decal/industrial/warning,
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"QL" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/tarantula,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/animal_corpse/goliath,
+/obj/effect/gibspawner/generic/animal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"QR" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"QS" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"QY" = (
+/obj/structure/curtain/cloth,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"QZ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/item/pen/edagger,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Ra" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet,
+/area/ruin/powered/hunts/gate)
+"Rb" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rc" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rg" = (
+/obj/item/spacecash/bundle/c10,
+/obj/item/spacecash/bundle/c5{
+	pixel_x = -7;
+	pixel_y = -6
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rm" = (
+/obj/item/stack/sheet/mineral/wood,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/powered/hunts/hotel)
+"Rp" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rq" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rt" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ru" = (
+/obj/structure/fountain,
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rz" = (
+/obj/structure/closet/wall/white/directional/west{
+	color = "#50C878";
+	name = "gardening supplies"
+	},
+/obj/item/cultivator/rake,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/glass/chem_jug/eznutriment,
+/obj/item/seeds/grass,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"RB" = (
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/hotel)
+"RH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell6"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"RJ" = (
+/obj/structure/rack,
+/obj/item/attachment/silencer{
+	pixel_y = -3;
+	pixel_x = 4
+	},
+/obj/machinery/light/broken/directional/east,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/gun_shop)
+"RN" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"RR" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/crystal,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/powered/hunts/shuttle)
+"RT" = (
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 10
+	},
+/obj/item/spacecash/bundle/c5{
+	pixel_x = 9
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"RW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"Se" = (
+/obj/item/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"Sf" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Sh" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"So" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Sr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"Sv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Sw" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3"
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"Sx" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/shed)
+"Sy" = (
+/turf/open/floor/carpet/royalblue,
+/area/ruin/powered/hunts/hotel)
+"Sz" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_x = 4;
+	pixel_y = 18
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"SB" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"SG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"SN" = (
+/obj/item/ammo_box/magazine/ammo_stack/prefilled/shotgun/buckshot,
+/obj/item/stack/sheet/cardboard{
+	pixel_x = 13;
+	pixel_y = -11;
+	layer = 2.9
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"SP" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Tc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Td" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Tf" = (
+/obj/structure/windoor_assembly{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/carpet/green/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"Tj" = (
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/storage/pill_bottle/aranesp,
+/obj/item/storage/pill_bottle/licarb{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/storage/pill_bottle/finobranc{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/clothing/suit/ianshirt,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -14;
+	pixel_x = 4
+	},
+/obj/item/clothing/under/suit/black_really{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/vest/duster,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Tk" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/broken/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Tm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Tq" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"Tu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Tx" = (
+/mob/living/simple_animal/hostile/venus_human_trap/mining,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TD" = (
+/obj/item/flashlight/flare/burnt,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"TE" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TJ" = (
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"TM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"TN" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TP" = (
+/obj/structure/spacevine/dense,
+/obj/structure/spacevine{
+	pixel_x = 32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TY" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Ua" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"Ub" = (
+/obj/effect/turf_decal/siding/white,
+/obj/structure/spider/stickyweb,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ud" = (
+/obj/structure/platform/ship_four{
+	dir = 9
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ue" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 29
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Uf" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Uh" = (
+/obj/structure/spacevine/dense,
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/obj/structure/spacevine/dense{
+	pixel_y = -32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Uj" = (
+/obj/structure/railing/wood,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"Ur" = (
+/obj/structure/railing/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"Us" = (
+/obj/structure/bed/double,
+/obj/effect/spawner/random/bedsheet/double,
+/turf/open/floor/carpet/royalblue,
+/area/ruin/powered/hunts/hotel)
+"Uv" = (
+/obj/structure/closet/wall/white/directional/north,
+/obj/item/clothing/under/overalls/olive,
+/obj/item/clothing/suit/apron,
+/obj/item/storage/wallet/random,
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"Uy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"UE" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "bubblegumfoot"
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"UG" = (
+/obj/structure/railing/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UI" = (
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"UL" = (
+/obj/item/spacecash/bundle/c10,
+/obj/item/spacecash/bundle/c10{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UR" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"US" = (
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UT" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = 2;
+	pixel_y = 16
+	},
+/obj/item/camera{
+	pixel_y = -3
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"UV" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Va" = (
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vg" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell3"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"Vs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Vt" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = -8
+	},
+/mob/living/basic/bear/cave,
+/obj/effect/mob_spawn/human/corpse/damaged/sauna,
+/obj/item/spacecash/bundle/smallrand,
+/obj/machinery/light/small/broken/directional/west,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor3";
+	pixel_y = 28
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"Vv" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Vy" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/structure/closet/wall/directional/north,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/suit/blacktwopiece{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -7;
+	pixel_x = 4
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/clothing/under/overalls/brown{
+	pixel_x = -9
+	},
+/obj/item/clothing/suit/toggle/windbreaker,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"VB" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"VC" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"VN" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"VS" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/storage/cans/sixbeer,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/food/energybar,
+/obj/item/pizzabox/meat,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"VZ" = (
+/obj/structure/sign/plaques/blank{
+	pixel_y = 30;
+	name = "M-23 WOODSMAN";
+	desc = "Become the King of the Woods with our brand  new M-23 Woodsman rifle. It's mag loaded design and powerful cartridge offers excellent pentration in an easy to use package. "
+	},
+/obj/structure/displaycase_chassis{
+	name = "open display case"
+	},
+/turf/open/floor/carpet/royalblack/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Wa" = (
+/obj/effect/turf_decal/number/left_two,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Wc" = (
+/obj/machinery/light/broken/directional/north,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Wi" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wj" = (
+/obj/effect/turf_decal/number/right_six,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"Wl" = (
+/turf/open/floor/carpet/black/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Wp" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 4
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Wq" = (
+/turf/open/floor/plasteel/white/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"Wr" = (
+/obj/structure/spider/stickyweb,
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"Wt" = (
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/obj/item/ammo_casing/spent/slug/buck,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wu" = (
+/obj/machinery/door/airlock/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"Wx" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/structure/spacevine,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"WE" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"WF" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"WI" = (
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/suit/cybersun_suit{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/clothing/under/syndicate/cybersun/officer{
+	pixel_y = -7;
+	pixel_x = -5
+	},
+/obj/item/clothing/shoes/jackboots{
+	pixel_y = -8
+	},
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"WK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "cell3"
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 4
+	},
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"WL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/asteroid/goliath/pup,
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"WP" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"WR" = (
+/obj/structure/spider/stickyweb,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/sec)
+"WU" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"WY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xa" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+"Xb" = (
+/obj/structure/sign/departments/custodian{
+	pixel_x = -32
+	},
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/spacevine{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xc" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xd" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/stoneborder{
+	dir = 4
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xf" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/ebony/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Xg" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/slab_1/jungleplanet/lit,
+/area/ruin/powered/hunts/sec)
+"Xj" = (
+/obj/machinery/button/door{
+	pixel_x = -6;
+	pixel_y = 23;
+	name = "cargo bay shutters";
+	id = "cargo bay"
+	},
+/obj/machinery/button/shieldwallgen{
+	pixel_x = 6;
+	pixel_y = 21;
+	id = "cargo bay"
+	},
+/turf/open/floor/engine/hull/interior,
+/area/ruin/powered/hunts/shuttle)
+"Xp" = (
+/mob/living/simple_animal/hostile/asteroid/goliath/beast,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xr" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Xu" = (
+/obj/effect/turf_decal/industrial/warning,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/tiles/jungleplanet/lit,
+/area/ruin/powered/hunts/shuttle)
+"Xw" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open{
+	opened = 1
+	},
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/rice,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/canteen)
+"Xy" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"XA" = (
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"XC" = (
+/obj/structure/fluff/hedge/opaque,
+/turf/open/floor/carpet/black/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"XH" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/toilet)
+"XJ" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"XN" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"XP" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"XU" = (
+/obj/structure/platform/wood_two{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"Yb" = (
+/obj/structure/spacevine/weak,
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Yc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/box/ammo/a12g_slug{
+	pixel_x = 10;
+	pixel_y = -6
+	},
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_x = -9;
+	pixel_y = -6
+	},
+/obj/item/storage/box/ammo/a12g_buckshot{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Yg" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/yellow,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ym" = (
+/obj/machinery/light/broken/directional/west,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Yo" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "cell4"
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/hunts/barn)
+"Yp" = (
+/obj/structure/chair/bench/orange,
+/obj/machinery/light/broken/directional/north,
+/turf/open/floor/carpet,
+/area/ruin/powered/hunts/hotel)
+"Yz" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hunts/gun_shop)
+"YA" = (
+/obj/structure/flora/ash/garden,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YC" = (
+/mob/living/simple_animal/hostile/venus_human_trap/mining,
+/turf/open/floor/wood/mahogany/jungleplanet,
+/area/ruin/powered/hunts/hotel)
+"YD" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/poison/giant_spider,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YL" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/cave/explored)
+"YM" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YO" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YQ" = (
+/obj/effect/turf_decal/trimline/opaque/white/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/concrete,
+/area/ruin/powered/hunts/barn)
+"YR" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YT" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YU" = (
+/obj/effect/turf_decal/spline/fancy/wood/cee{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"YW" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 4
+	},
+/mob/living/basic/bear/cave,
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"YX" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"YY" = (
+/obj/structure/platform/wood_two{
+	dir = 1
+	},
+/obj/machinery/light/small/broken/directional/east,
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"YZ" = (
+/turf/open/floor/plasteel/patterned,
+/area/ruin/powered/hunts/shuttle)
+"Zb" = (
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/obj/item/spacecash/bundle/c1{
+	pixel_y = -2;
+	pixel_x = 7
+	},
+/obj/item/spacecash/bundle/c10{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Zc" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle/dark,
+/area/overmap_encounter/planetoid/cave/explored)
+"Zd" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Zg" = (
+/obj/structure/platform/wood_two{
+	dir = 1
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/toilet)
+"Zn" = (
+/obj/effect/turf_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/toilet)
+"Zw" = (
+/obj/item/flashlight/lantern,
+/obj/structure/table/wood,
+/obj/structure/spacevine,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"Zx" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/concrete/reinforced,
+/area/ruin/powered/hunts/barn)
+"Zy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/hazard/fire/wires/alarm,
+/obj/machinery/light/broken/directional/south,
+/obj/structure/hazard/electrical/electric_sparks/alarm,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"Zz" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/orange{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/hunts/barn)
+"ZA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ZD" = (
+/obj/structure/railing/wood,
+/obj/structure/flippedtable{
+	icon_state = "wood_table";
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"ZI" = (
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ZK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/maple,
+/area/ruin/powered/hunts/hotel)
+"ZL" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/concrete/pavement/jungleplanet/lit,
+/area/ruin/powered/hunts/gate)
+"ZN" = (
+/obj/structure/table/wood/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"ZP" = (
+/mob/living/simple_animal/hostile/asteroid/brimdemon,
+/turf/open/floor/wood/maple/jungleplanet,
+/area/ruin/powered/hunts/canteen)
+"ZR" = (
+/obj/structure/janitorialcart,
+/turf/open/floor/wood/ebony,
+/area/ruin/powered/hunts/shed)
+"ZS" = (
+/obj/structure/spacevine,
+/mob/living/simple_animal/hostile/venus_human_trap/mining,
+/turf/open/floor/wood/jungleplanet,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ZT" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/hunts/toilet)
+"ZU" = (
+/obj/structure/railing/wood,
+/obj/item/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/ebony/jungleplanet/lit,
+/area/ruin/powered/hunts/canteen)
+"ZV" = (
+/obj/machinery/door/airlock/wood,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/jungleplanet,
+/area/ruin/powered/hunts/gun_shop)
+"ZX" = (
+/obj/structure/railing/wood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/ruin/powered/hunts/toilet)
+"ZZ" = (
+/obj/effect/turf_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/mahogany,
+/area/ruin/powered/hunts/hotel)
+
+(1,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+rO
+PV
+PV
+PV
+rO
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+"}
+(2,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+YT
+YT
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+rO
+rO
+rO
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+rO
+rO
+PV
+PV
+PV
+"}
+(3,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Qm
+uw
+rt
+YT
+bg
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(4,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+bg
+bg
+MI
+Mf
+Fo
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+PV
+"}
+(5,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+bg
+VB
+bg
+Fo
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+rO
+rO
+rO
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(6,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+aG
+MI
+MI
+Va
+Ey
+Tj
+LI
+Dd
+Ey
+PS
+Wx
+WI
+Ey
+Ey
+Ey
+Ey
+Ey
+Jh
+Tk
+eE
+Ey
+xT
+xI
+pc
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(7,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+MI
+bg
+MI
+Fo
+po
+Ey
+OH
+OZ
+mx
+Ey
+PN
+YC
+FG
+Ey
+Dt
+AG
+Fe
+Ey
+Op
+OZ
+uL
+Ey
+yd
+cn
+sk
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(8,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+bg
+VB
+bg
+Va
+po
+Ey
+iM
+EX
+SP
+Ey
+DM
+GA
+QZ
+Ey
+Iw
+xg
+sv
+Ey
+AT
+Xa
+SP
+Ey
+Uf
+Xa
+sL
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(9,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+YT
+Tx
+po
+Ey
+Ey
+Ey
+Ey
+tj
+Ey
+tj
+eH
+Ey
+Ey
+gy
+PY
+Tf
+Ey
+Ey
+Ey
+xy
+Ey
+Iz
+Ey
+Ey
+Ey
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(10,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+YA
+YT
+Va
+po
+Rm
+CG
+pJ
+oo
+rw
+xs
+rw
+Om
+zs
+cO
+ZK
+Sr
+ZK
+SG
+RB
+kb
+ZK
+FR
+tL
+tL
+tL
+eO
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(11,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+fL
+YT
+Qm
+rT
+Ey
+Nu
+uQ
+Bq
+lh
+LY
+lh
+pr
+RB
+rY
+zk
+Ji
+zk
+Ho
+RB
+WL
+Fb
+DA
+zk
+Ua
+zk
+qm
+Ey
+rO
+rO
+rO
+rO
+rO
+rO
+PV
+PV
+"}
+(12,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+fL
+TN
+YT
+Va
+po
+pN
+Ey
+Ey
+Ey
+Ey
+tj
+Ey
+Ey
+tj
+Ey
+BO
+EJ
+ow
+FM
+uv
+Ey
+rY
+Ho
+Ey
+xy
+Ey
+Ey
+Ey
+Ey
+rO
+rO
+rO
+Va
+rO
+rO
+PV
+PV
+"}
+(13,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Fo
+Fo
+Fo
+YM
+fX
+TN
+HI
+TN
+Ey
+Vy
+Tk
+bb
+Ey
+mr
+jq
+Ey
+Yp
+FM
+ow
+EJ
+sB
+Ey
+Cy
+Nz
+Ey
+ZZ
+LI
+rQ
+Ey
+rO
+rO
+rO
+rO
+Fo
+rO
+rO
+PV
+PV
+"}
+(14,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+DJ
+DJ
+gk
+nP
+nP
+Va
+YT
+CB
+TN
+Ey
+Sy
+gx
+Cs
+Ey
+ya
+Gz
+Gz
+Ey
+ma
+ow
+FM
+Ey
+Ey
+Ey
+Ey
+Ey
+vb
+Gq
+Sy
+Ey
+rO
+rO
+rO
+Va
+Va
+yU
+Va
+PV
+PV
+"}
+(15,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+YA
+YT
+YT
+TN
+Fo
+DJ
+DJ
+nP
+nP
+DJ
+TN
+YR
+Ov
+TN
+Ey
+Us
+jE
+EG
+Ey
+pY
+DJ
+nP
+Ey
+Wu
+Ab
+Wu
+Ey
+US
+cc
+Uh
+Ey
+UT
+Sz
+Us
+Ey
+rO
+rO
+rO
+TN
+YA
+Fo
+Qm
+PV
+PV
+"}
+(16,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+YT
+nP
+es
+nP
+nP
+YT
+YM
+Va
+Va
+nP
+nP
+Va
+YT
+Ov
+Va
+Ey
+qB
+qB
+qB
+Ey
+DJ
+nP
+nP
+Bj
+kM
+sw
+kM
+HM
+YO
+Td
+nP
+Ey
+qB
+qB
+qB
+Ey
+nP
+Ov
+Va
+yU
+es
+sQ
+es
+PV
+PV
+"}
+(17,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+es
+es
+nP
+nP
+fL
+YT
+YT
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Va
+PJ
+cc
+PJ
+cc
+DH
+nP
+uE
+dD
+yC
+Qq
+EN
+qk
+yC
+dD
+nP
+bR
+US
+PJ
+cc
+cc
+US
+nP
+Ov
+Fo
+Va
+nP
+es
+es
+PV
+PV
+"}
+(18,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Fo
+Fo
+nP
+nP
+nP
+gk
+DJ
+fL
+Yz
+Yz
+PP
+zE
+HE
+wT
+KF
+Hr
+Yz
+Yz
+zt
+DJ
+DJ
+YO
+nP
+bR
+dD
+dD
+yz
+xW
+rZ
+Px
+fO
+dD
+dD
+nP
+YO
+bR
+DJ
+nP
+DJ
+DJ
+Ov
+TN
+Va
+Ah
+es
+YT
+PV
+PV
+"}
+(19,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+TN
+TN
+TN
+xr
+TN
+Va
+Yz
+AZ
+iv
+hc
+hc
+Wl
+yl
+Wl
+ER
+Yz
+tD
+nP
+bR
+nP
+Td
+dD
+dD
+yz
+xW
+uV
+rP
+rP
+Px
+fO
+dD
+dD
+nP
+DJ
+DJ
+bR
+nP
+nP
+Ov
+Va
+es
+nP
+ad
+Va
+PV
+PV
+"}
+(20,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Qm
+Va
+TN
+xr
+xr
+TN
+Ps
+Yz
+VZ
+hc
+hc
+hc
+Wl
+yl
+Wl
+oR
+Yz
+nP
+nP
+nP
+nP
+dD
+dD
+yz
+xW
+uV
+og
+rP
+rP
+rP
+Px
+fO
+yC
+dD
+DJ
+nP
+nP
+YO
+bR
+Ov
+Va
+Ps
+Ps
+YT
+fL
+PV
+PV
+"}
+(21,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Qm
+Ps
+xr
+TN
+xr
+Ps
+Va
+Yz
+qb
+cU
+hc
+iH
+Ht
+sg
+sg
+iT
+Yz
+uE
+nP
+nP
+dD
+yC
+yz
+xW
+uV
+dD
+JT
+JT
+JT
+dD
+rP
+Px
+Jn
+dD
+dD
+YO
+nP
+nP
+nP
+Ov
+fL
+Va
+xr
+xr
+TN
+PV
+PV
+"}
+(22,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+Va
+YM
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+sq
+GL
+Gm
+SN
+Yc
+bU
+Sf
+Yz
+Yz
+nP
+dD
+dD
+oT
+xW
+uV
+dD
+dD
+Ud
+KN
+rx
+dD
+dD
+rP
+Px
+fO
+dD
+dD
+qs
+nP
+nP
+Ov
+Va
+Ps
+Va
+xr
+fL
+PV
+PV
+"}
+(23,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+Va
+Yz
+Yz
+VS
+ed
+iA
+Yz
+Da
+GL
+GL
+wC
+zD
+Iv
+Iv
+Ef
+Zy
+Yz
+kJ
+dD
+yz
+yc
+EN
+dD
+dD
+Ud
+OV
+hI
+nF
+rx
+dD
+dD
+rP
+Px
+Xy
+yC
+yC
+DJ
+dD
+bW
+Ue
+Va
+Va
+xr
+Hs
+PV
+PV
+"}
+(24,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+YT
+Yz
+Bd
+dN
+Kw
+xk
+Yz
+Ne
+GL
+GL
+oO
+hc
+iH
+eJ
+eu
+KQ
+PT
+Bw
+jw
+yc
+rP
+EN
+cR
+Ud
+Cn
+Rg
+KJ
+OW
+vT
+rx
+MU
+rP
+rP
+dH
+Ke
+Ke
+xZ
+jw
+WU
+rP
+TN
+Fo
+rP
+TN
+PV
+PV
+"}
+(25,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+YT
+Va
+YT
+Yz
+lR
+CW
+vI
+vI
+Yz
+Al
+GL
+GL
+bI
+Tu
+hc
+OT
+QO
+Vs
+ZV
+pg
+ZA
+ZA
+ID
+Oe
+cR
+Ba
+fn
+ex
+Ru
+Zb
+RT
+zO
+MU
+rP
+NH
+NH
+qY
+rP
+rP
+rP
+mH
+Ad
+rP
+Wt
+Fo
+Va
+PV
+PV
+"}
+(26,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+YT
+YA
+Va
+Yz
+bz
+vI
+vI
+iP
+Yz
+Yz
+LL
+GL
+le
+iH
+iH
+pv
+Ao
+eJ
+PT
+Bw
+on
+OC
+rP
+EN
+cR
+hg
+fy
+tY
+UL
+No
+AQ
+rM
+MU
+rP
+rP
+Mh
+Rc
+jB
+Rc
+Rc
+WU
+rP
+Rc
+Rc
+Va
+YM
+PV
+PV
+"}
+(27,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+Yz
+wb
+fh
+fh
+Np
+Yz
+jj
+BH
+iH
+iH
+iH
+iH
+cu
+NO
+Tm
+Yz
+Ju
+dD
+Dc
+PU
+lT
+dD
+dD
+hg
+tm
+PG
+uj
+rM
+dD
+dD
+rP
+Mh
+hL
+dD
+dD
+yC
+yC
+bW
+yI
+dD
+TN
+dD
+YR
+PV
+PV
+"}
+(28,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+YT
+Yz
+Yz
+Xf
+vI
+AP
+QY
+Sv
+mI
+mI
+ai
+OG
+Qh
+NJ
+iT
+Yz
+Yz
+nP
+dD
+dD
+Dc
+zz
+lw
+dD
+dD
+hg
+hB
+rM
+dD
+dD
+rP
+pj
+hw
+dD
+dD
+nP
+Td
+nP
+Ov
+Va
+Va
+Hs
+Fo
+Va
+PV
+PV
+"}
+(29,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+YT
+YT
+Yz
+Yz
+Yz
+Yz
+Yz
+hP
+FO
+zw
+ua
+LU
+zw
+LU
+sK
+Yz
+uE
+nP
+WY
+yC
+yC
+Dc
+KV
+lw
+dD
+Hi
+Hi
+Hi
+dD
+qY
+Mh
+hL
+dD
+dD
+nP
+bR
+nP
+nP
+Ov
+YM
+Fo
+GG
+Va
+Hs
+PV
+PV
+"}
+(30,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+YT
+YT
+YT
+Va
+xr
+xr
+Va
+fL
+Yz
+Yz
+Ll
+RJ
+Yz
+FJ
+tM
+GH
+Yz
+Yz
+nP
+nP
+nP
+nP
+dD
+dD
+Dc
+zz
+tH
+aE
+NH
+rP
+rP
+Mh
+hL
+dD
+dD
+qs
+nP
+nP
+nP
+nP
+Ov
+nP
+nP
+TN
+Ps
+Ps
+Ps
+PV
+"}
+(31,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+YT
+YT
+Br
+NK
+xr
+xr
+Ps
+YR
+Va
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+Yz
+nP
+IU
+nP
+nP
+nP
+nP
+dD
+dD
+Dc
+hm
+ID
+av
+oe
+Mh
+hL
+dD
+dD
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+TN
+Hs
+Va
+PV
+"}
+(32,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Va
+Ps
+Ps
+Ps
+GG
+TN
+TN
+CB
+nP
+nP
+nP
+nP
+cc
+cc
+cc
+bR
+nP
+nP
+uE
+nP
+nP
+nP
+dD
+yC
+Dc
+YW
+EN
+Mh
+hL
+Kr
+Kr
+Sx
+Sx
+Ge
+Zd
+Rz
+Fm
+ZR
+Sx
+iI
+jy
+Sx
+Ps
+Yg
+yU
+PV
+"}
+(33,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+Ps
+xr
+Ps
+Fo
+Va
+Va
+of
+nP
+nP
+nP
+cx
+bR
+DJ
+DJ
+DJ
+nP
+nP
+bR
+nP
+nP
+nP
+nP
+dD
+dD
+HP
+eW
+qk
+Kr
+dD
+TN
+Sx
+sC
+fr
+Nx
+FI
+Nx
+Hk
+UV
+tB
+nL
+Sx
+YT
+YT
+Ps
+PV
+"}
+(34,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Qm
+Va
+TN
+TN
+YM
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+TP
+TP
+st
+DJ
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+dD
+HP
+eW
+qk
+Kr
+TN
+TN
+Sx
+LB
+Zw
+uH
+qt
+Gn
+un
+Sx
+Eo
+Ls
+Sx
+nP
+es
+Ps
+PV
+"}
+(35,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Va
+Fo
+GG
+TN
+DJ
+nP
+eS
+Xw
+rl
+El
+El
+JA
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+UG
+UG
+UG
+vV
+dD
+Qq
+EN
+qk
+dD
+ss
+Kb
+jY
+Sx
+Sx
+Sx
+Ka
+Sx
+Sx
+Sx
+Sx
+Sx
+Sx
+Va
+es
+Ps
+PV
+"}
+(36,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Qm
+Va
+Va
+uE
+nP
+nP
+eS
+bx
+td
+xA
+ak
+re
+eS
+mY
+BF
+cy
+EY
+fg
+Uy
+AX
+IR
+IR
+IR
+IR
+rr
+Qq
+no
+tN
+qd
+oL
+oL
+fk
+fA
+Hl
+Xb
+xm
+IJ
+pS
+oY
+MI
+bg
+fL
+Va
+Ps
+cQ
+Ps
+"}
+(37,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Fo
+Va
+TN
+nP
+nP
+uE
+nP
+eS
+pn
+eS
+eS
+eS
+eS
+eS
+gU
+jn
+jn
+ZN
+tW
+ap
+wy
+wK
+wK
+wK
+wK
+mD
+Qq
+Ig
+qk
+dD
+OX
+Wi
+hM
+hM
+hM
+ye
+hM
+ZS
+Mi
+lL
+TN
+Va
+yU
+es
+nP
+Ps
+PV
+"}
+(38,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Va
+Va
+nP
+DJ
+nP
+eS
+eS
+rH
+ou
+ou
+Wq
+eS
+XC
+XC
+jn
+XC
+XC
+Mx
+eS
+eS
+sx
+Lh
+sx
+LG
+vw
+Qq
+EN
+qk
+dD
+Hp
+IB
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hs
+Fo
+Hs
+rt
+bg
+"}
+(39,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Qm
+YT
+Va
+DJ
+nP
+eS
+XA
+ou
+KH
+EA
+Wq
+eS
+Ha
+Ha
+ZP
+Ha
+Ha
+xK
+Uy
+jg
+TJ
+au
+vJ
+ZD
+vw
+Qq
+EN
+qk
+Kr
+Hp
+YU
+Hp
+Vt
+Hp
+MZ
+Hp
+BR
+Ur
+XU
+mo
+Hp
+Hp
+Va
+fL
+YT
+rt
+"}
+(40,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Fo
+Va
+nP
+eS
+gX
+Wq
+iD
+eL
+aZ
+eS
+hi
+Gs
+jn
+vj
+vj
+jn
+ru
+Ib
+Se
+vJ
+vJ
+ZU
+vw
+uy
+EN
+qk
+yC
+Hp
+ND
+Hp
+xG
+Hp
+IB
+Hp
+Uv
+ZX
+Zg
+UE
+mo
+Hp
+Hp
+Va
+Va
+Va
+"}
+(41,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+YT
+Va
+TN
+TN
+Va
+Br
+Va
+eS
+nK
+Wq
+Lz
+AF
+yk
+eS
+NL
+NL
+jn
+rq
+Be
+jn
+xH
+tE
+TJ
+TJ
+cj
+TJ
+vw
+Qq
+EN
+qk
+dD
+Hp
+ny
+gr
+IC
+gr
+WF
+Hp
+aK
+Uj
+Zg
+Hd
+gD
+Eh
+Hp
+Fo
+nP
+PV
+"}
+(42,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+YT
+TN
+TN
+Va
+fL
+Va
+eS
+ig
+af
+aq
+rJ
+pM
+eS
+XC
+XC
+jn
+cJ
+cJ
+rS
+xH
+jg
+TJ
+yY
+TJ
+sy
+vw
+Qq
+EN
+qk
+dD
+Hp
+im
+Zn
+ql
+ql
+wx
+sO
+jV
+IM
+zo
+dq
+Sw
+ti
+Hp
+nP
+nP
+Va
+"}
+(43,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+YT
+YT
+rt
+TN
+TN
+eS
+eS
+zH
+iy
+gL
+Jx
+JM
+Qf
+bH
+jn
+jn
+jn
+jn
+xH
+jg
+TJ
+je
+vJ
+HH
+vw
+Qq
+EN
+qk
+Di
+Hp
+Hp
+Am
+rD
+xq
+mK
+Hp
+rE
+Ur
+DF
+dq
+yP
+Hp
+Hp
+nP
+nP
+Va
+"}
+(44,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+cT
+Va
+qO
+bg
+rt
+TN
+YT
+eS
+qX
+eR
+FT
+ou
+JM
+Qf
+jn
+rS
+jn
+lJ
+lJ
+wd
+eS
+he
+lY
+he
+EH
+vw
+Qq
+eW
+NS
+yC
+dD
+Hp
+ZT
+bQ
+XH
+pb
+Hp
+aK
+Uj
+YY
+hy
+Hp
+Hp
+YA
+YM
+Va
+PV
+"}
+(45,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+Va
+Va
+MI
+MI
+rt
+YT
+Va
+eS
+eS
+eS
+kN
+eS
+eS
+UI
+Fu
+SB
+XC
+yi
+bc
+LK
+eS
+aV
+Gv
+Gv
+Gv
+pm
+Qq
+eW
+dH
+Xy
+dD
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Hp
+Fo
+Va
+Ff
+Va
+PV
+"}
+(46,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+YT
+YT
+MI
+MI
+qO
+YT
+Va
+fl
+rP
+aF
+Dj
+Vv
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+Hb
+Xd
+Xd
+CS
+dD
+Qq
+eW
+NH
+NS
+dD
+dD
+qs
+nP
+qs
+nP
+nP
+qs
+nP
+nP
+Ov
+nP
+YM
+YT
+Ff
+Va
+PV
+"}
+(47,1,1) = {"
+PV
+PV
+PV
+Va
+TN
+Va
+YT
+YT
+bg
+bg
+MI
+MI
+bg
+fl
+rP
+sY
+eW
+rP
+rP
+rP
+rP
+rP
+rP
+rP
+rP
+NH
+eg
+NH
+rP
+rP
+oY
+dD
+Qq
+eW
+NH
+yn
+fO
+dD
+dD
+nP
+nP
+DJ
+nP
+Td
+DJ
+nP
+Ov
+Va
+rV
+ad
+Va
+Va
+PV
+"}
+(48,1,1) = {"
+PV
+PV
+PV
+Va
+Va
+Va
+Va
+Va
+bg
+Fo
+Va
+bg
+Va
+fl
+rP
+rP
+IN
+ID
+ID
+ID
+nY
+ID
+ZA
+ZA
+ZA
+Gh
+ZA
+ZA
+ZA
+ZA
+Cg
+NG
+uR
+WE
+lw
+rP
+Px
+fO
+dD
+dD
+nP
+nP
+nP
+nP
+nP
+nP
+Ov
+nP
+rV
+nP
+nP
+PV
+PV
+"}
+(49,1,1) = {"
+PV
+PV
+Va
+Va
+YT
+TN
+TN
+TN
+Va
+Va
+pV
+Va
+YT
+DV
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+wg
+mZ
+dD
+Qq
+oe
+IN
+fD
+rP
+Px
+fO
+dD
+yC
+nP
+Td
+nP
+nP
+nP
+Ov
+GG
+DJ
+DJ
+Qm
+PV
+PV
+"}
+(50,1,1) = {"
+PV
+PV
+Va
+MI
+MI
+Va
+TN
+TN
+YT
+pV
+pV
+YT
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+Dc
+OC
+rP
+IN
+lw
+og
+Px
+fO
+dD
+dD
+nP
+nP
+nP
+nP
+Ov
+fL
+TN
+TN
+Va
+PV
+PV
+"}
+(51,1,1) = {"
+PV
+Va
+YT
+YT
+bg
+rt
+bg
+bg
+bg
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Dc
+OC
+rP
+IN
+lw
+rP
+Px
+fO
+dD
+nP
+DJ
+nP
+nP
+Ov
+Fo
+yU
+MI
+bg
+PV
+PV
+"}
+(52,1,1) = {"
+PV
+Va
+rt
+YT
+pV
+YT
+bg
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Dc
+OC
+rP
+Xp
+lw
+rP
+qk
+dD
+nP
+nP
+nP
+nP
+Ov
+Va
+vr
+Mf
+Qm
+PV
+PV
+"}
+(53,1,1) = {"
+PV
+bg
+bg
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Dc
+OC
+rP
+IN
+lw
+qk
+dD
+uE
+nP
+nP
+DJ
+Ov
+Hs
+bg
+bg
+Va
+PV
+PV
+"}
+(54,1,1) = {"
+Va
+MI
+YM
+TN
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+NB
+lW
+gZ
+rI
+NB
+rI
+XP
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Dc
+OC
+rP
+EN
+qk
+dD
+nP
+nP
+nP
+nP
+Ov
+YT
+TN
+VB
+MI
+PV
+PV
+"}
+(55,1,1) = {"
+Va
+Br
+Va
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+NB
+DP
+rI
+XJ
+NB
+BQ
+NB
+XP
+gZ
+NB
+rI
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Dc
+OC
+eW
+NS
+dD
+nP
+nP
+YO
+Td
+Ov
+YT
+YA
+YT
+YT
+PV
+PV
+"}
+(56,1,1) = {"
+Va
+YT
+YT
+YT
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pP
+lr
+lr
+gZ
+DP
+BQ
+BQ
+BQ
+rI
+rI
+NB
+Lq
+NB
+ci
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+dD
+dD
+Qq
+eW
+NS
+dD
+nP
+nP
+nP
+nP
+Ov
+YT
+YT
+YT
+Va
+PV
+PV
+"}
+(57,1,1) = {"
+Va
+YT
+YT
+GG
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+NB
+OO
+jU
+jU
+te
+ci
+NB
+iB
+lO
+lW
+NB
+rI
+rI
+BQ
+DP
+VC
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+Va
+dD
+Qq
+eW
+NS
+dD
+YO
+nP
+nP
+nP
+Ov
+YT
+fL
+nP
+DJ
+PV
+PV
+"}
+(58,1,1) = {"
+TN
+TN
+Va
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+rI
+jU
+jU
+jU
+ir
+NB
+YX
+YX
+YX
+NB
+BQ
+BQ
+BQ
+NB
+So
+gZ
+So
+NB
+pV
+pV
+pV
+oI
+uM
+uM
+uM
+uM
+dD
+Qq
+eW
+NS
+dD
+nP
+nP
+nP
+YO
+Ov
+Va
+DJ
+nP
+DJ
+PV
+PV
+"}
+(59,1,1) = {"
+Va
+Va
+YT
+YM
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+NB
+rs
+fH
+BQ
+BQ
+VC
+YX
+YX
+NB
+XN
+So
+NB
+DP
+rn
+YL
+YX
+YL
+BQ
+pV
+pV
+pV
+Pt
+Qs
+ZA
+ZA
+ZA
+NG
+uR
+to
+qk
+dD
+yC
+yC
+dD
+dD
+Ov
+nP
+DJ
+nP
+DJ
+PV
+PV
+"}
+(60,1,1) = {"
+Va
+az
+JB
+YT
+pV
+pV
+pV
+pV
+NB
+NB
+NB
+lW
+YL
+BQ
+BQ
+YL
+BQ
+te
+jU
+JC
+jU
+Lo
+Lo
+lO
+lO
+NB
+lO
+BQ
+BQ
+pV
+pV
+pV
+eD
+dp
+eD
+eD
+wg
+dD
+Qq
+eW
+NS
+dD
+By
+By
+By
+dD
+Hh
+YR
+Qm
+DJ
+DJ
+nP
+PV
+"}
+(61,1,1) = {"
+YM
+bg
+bg
+YT
+pV
+pV
+pV
+pV
+rI
+So
+YX
+QS
+BQ
+bd
+BQ
+BQ
+NB
+lO
+HJ
+lO
+Mj
+Lo
+Lo
+sr
+lO
+NB
+Zc
+YX
+YX
+NB
+pV
+pV
+eD
+CX
+ts
+eD
+eD
+dD
+Qq
+eW
+NS
+yC
+By
+Kz
+By
+By
+Hh
+Kr
+Va
+DJ
+nP
+PV
+PV
+"}
+(62,1,1) = {"
+Va
+TN
+YM
+Va
+pV
+pV
+pV
+pV
+NB
+lP
+jU
+NB
+ci
+jU
+NB
+YX
+YX
+lO
+iB
+iB
+BQ
+BQ
+BQ
+NB
+BQ
+XJ
+NB
+YX
+YX
+gY
+pV
+pV
+eD
+If
+bw
+tx
+eD
+dD
+HP
+PQ
+NS
+yC
+By
+Wr
+WR
+By
+By
+dD
+GG
+TN
+Va
+PV
+PV
+"}
+(63,1,1) = {"
+Va
+TN
+TN
+Va
+pV
+pV
+pV
+NB
+NB
+jU
+sZ
+YX
+jU
+BQ
+BQ
+Lo
+YX
+So
+ci
+lO
+lO
+NB
+Mj
+gZ
+BQ
+BQ
+NB
+gY
+NB
+lW
+pV
+pV
+eD
+bw
+If
+En
+eD
+dD
+HP
+bj
+tN
+nI
+Xg
+Fi
+bD
+WR
+By
+dD
+TN
+YT
+YT
+PV
+PV
+"}
+(64,1,1) = {"
+Va
+YR
+Va
+es
+es
+pV
+pV
+pV
+XP
+bd
+bd
+ci
+NB
+Sh
+Xc
+Xr
+NB
+zd
+DP
+XP
+So
+ci
+rI
+lO
+So
+rI
+rI
+NB
+rI
+NB
+pV
+pV
+eD
+Qe
+qc
+LC
+eD
+dD
+HP
+eW
+qk
+yC
+By
+Fv
+Tq
+WR
+By
+dD
+yU
+TN
+Va
+PV
+PV
+"}
+(65,1,1) = {"
+Va
+nP
+qs
+es
+BQ
+pV
+pV
+pV
+DP
+bd
+bd
+NB
+jU
+BQ
+BQ
+NB
+YX
+YL
+YL
+ne
+XJ
+NB
+NB
+Mj
+Xr
+TD
+rI
+NB
+NB
+dY
+eD
+eD
+eD
+eD
+ck
+bN
+eD
+dD
+HP
+eW
+qk
+dD
+By
+ky
+tp
+kL
+By
+dD
+Va
+Va
+TN
+Va
+PV
+"}
+(66,1,1) = {"
+Va
+YT
+nP
+nP
+pV
+pV
+pV
+pV
+NB
+YX
+QS
+Gb
+nc
+BQ
+BQ
+rI
+YX
+BQ
+BQ
+Xc
+BQ
+NB
+rI
+BQ
+BQ
+So
+rI
+YX
+vQ
+vQ
+vQ
+HR
+jF
+Oi
+ZL
+ZL
+ZL
+jw
+Rt
+eW
+qk
+dD
+dD
+bO
+bO
+bO
+bO
+dD
+Va
+dD
+Hs
+Va
+dD
+"}
+(67,1,1) = {"
+Va
+Va
+ep
+pV
+pV
+pV
+pV
+NB
+NB
+DP
+NB
+YX
+ov
+Gb
+NB
+So
+Xr
+BQ
+BQ
+BQ
+BQ
+gZ
+EB
+NB
+BQ
+Lj
+NB
+vQ
+Ra
+Ra
+Ra
+lb
+jF
+om
+AK
+AK
+AK
+rP
+NH
+eW
+Px
+jw
+jw
+jw
+jw
+jw
+jw
+Va
+jw
+Va
+Hs
+fL
+Va
+"}
+(68,1,1) = {"
+Va
+Va
+Va
+YT
+pV
+pV
+pV
+pV
+NB
+NB
+NB
+Gb
+Gb
+Gb
+NB
+gZ
+NB
+Mj
+NB
+lO
+iB
+lO
+sr
+NB
+BQ
+NB
+jU
+vQ
+Ra
+AB
+Ra
+QG
+jF
+om
+AK
+AK
+AK
+rP
+rP
+eW
+NH
+rP
+rP
+rP
+rP
+rP
+Va
+rP
+Va
+rP
+rP
+Va
+Va
+"}
+(69,1,1) = {"
+YA
+Va
+Va
+vk
+es
+pV
+pV
+pV
+NB
+eq
+ci
+ll
+tF
+yr
+nc
+YX
+BQ
+lP
+rI
+lO
+lO
+lO
+lO
+NB
+Xr
+NB
+jU
+vQ
+vQ
+vQ
+vQ
+QG
+jF
+om
+AK
+AK
+AK
+rP
+rP
+eW
+aA
+Rc
+Rc
+sc
+Rc
+Rc
+Va
+Va
+Rc
+fL
+Rc
+Va
+Va
+"}
+(70,1,1) = {"
+Va
+YT
+nP
+nP
+pV
+pV
+pV
+pV
+NB
+NB
+NB
+fs
+BQ
+nc
+NB
+NB
+BQ
+EB
+NB
+rI
+BQ
+NB
+YX
+Sh
+BQ
+NB
+jU
+NB
+vQ
+vQ
+ys
+HR
+jF
+ia
+zl
+WP
+WP
+Rc
+OC
+EN
+qk
+Kr
+bO
+bO
+Kr
+Kr
+Kr
+Kr
+Va
+dD
+dD
+dD
+PV
+"}
+(71,1,1) = {"
+Va
+YT
+nP
+nP
+pV
+pV
+pV
+XP
+NB
+So
+rI
+BQ
+XJ
+BQ
+BQ
+DP
+gZ
+lW
+lO
+lO
+BQ
+rI
+NB
+BQ
+BQ
+rI
+lr
+NB
+lO
+dY
+eD
+eD
+eD
+eD
+eD
+FZ
+mi
+dD
+Qq
+tt
+PZ
+bO
+YO
+UR
+YO
+YO
+Bo
+fv
+Qm
+fL
+Va
+PV
+PV
+"}
+(72,1,1) = {"
+Va
+Va
+nP
+nP
+pV
+pV
+pV
+NB
+lW
+NB
+NB
+BQ
+BQ
+rI
+rI
+NB
+Lo
+NB
+YX
+NB
+NB
+iB
+YX
+XP
+rI
+Mj
+jU
+NB
+NB
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+bO
+TE
+tt
+Dy
+tf
+YO
+UR
+DJ
+YO
+jI
+dD
+yU
+fL
+GG
+PV
+PV
+"}
+(73,1,1) = {"
+Va
+Va
+YT
+qs
+es
+pV
+pV
+pV
+pV
+NB
+YX
+XP
+NB
+rI
+NB
+rI
+Xr
+gZ
+rI
+rI
+Mj
+Xr
+YX
+rI
+NB
+NB
+Lj
+Lo
+lO
+XP
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+yC
+HP
+eW
+qk
+tf
+UR
+Rq
+YO
+am
+Jp
+dD
+Va
+YT
+YT
+PV
+PV
+"}
+(74,1,1) = {"
+Va
+Va
+Va
+nP
+es
+pV
+pV
+pV
+pV
+NB
+Jj
+NB
+BQ
+BQ
+XJ
+lA
+XJ
+XN
+BQ
+jU
+YX
+NB
+XP
+lO
+QR
+jU
+bd
+YX
+NB
+lO
+pV
+pV
+pV
+pV
+pV
+pV
+Va
+yC
+aI
+EN
+Dy
+dD
+nP
+YO
+nP
+YO
+jI
+dD
+nP
+es
+YT
+PV
+PV
+"}
+(75,1,1) = {"
+Va
+Va
+Ps
+NK
+YT
+pV
+pV
+pV
+pV
+NB
+jU
+jU
+Xr
+NB
+rI
+rI
+BQ
+YL
+YL
+ci
+gZ
+BQ
+Pn
+lO
+lO
+jU
+jU
+NB
+GF
+NB
+pV
+pV
+pV
+pV
+pV
+Va
+zS
+dD
+ew
+ji
+Dy
+dD
+YO
+nP
+nP
+YO
+Bo
+dD
+YA
+es
+YT
+Va
+PV
+"}
+(76,1,1) = {"
+es
+sQ
+YT
+Ps
+NK
+pV
+pV
+pV
+pV
+pV
+gZ
+rI
+NB
+YX
+NB
+DP
+BQ
+BQ
+BQ
+ci
+ks
+NB
+NB
+YX
+lO
+YX
+rN
+NB
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+zS
+Va
+dD
+Fh
+eW
+NS
+dD
+nP
+nP
+YO
+dD
+Hh
+nP
+nP
+es
+YT
+yU
+PV
+"}
+(77,1,1) = {"
+es
+sQ
+es
+Ps
+Ps
+Ps
+pV
+pV
+pV
+pV
+NB
+NB
+rI
+XP
+ci
+jU
+jU
+jU
+jU
+jU
+jU
+YX
+So
+rI
+lO
+NB
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+po
+zy
+dD
+Qq
+eW
+NS
+dD
+Jc
+YO
+dD
+dD
+Ov
+Va
+nP
+ad
+YT
+Va
+PV
+"}
+(78,1,1) = {"
+nP
+sQ
+YT
+Va
+YT
+Ps
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+NB
+DP
+jU
+OO
+OO
+rI
+NB
+XP
+YX
+YX
+Mj
+NB
+rI
+NB
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+po
+po
+dD
+Qq
+ZI
+qk
+dD
+yC
+yC
+dD
+Va
+Ov
+nP
+nP
+nP
+yU
+YT
+PV
+"}
+(79,1,1) = {"
+PV
+Va
+Va
+Va
+Ps
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+po
+bO
+Qq
+Fs
+qk
+dD
+Va
+Va
+Qm
+Va
+Ov
+nP
+ad
+nP
+Qm
+Va
+PV
+"}
+(80,1,1) = {"
+PV
+PV
+Va
+Va
+Ps
+Ps
+YT
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+po
+po
+tf
+Qq
+iU
+NS
+dD
+Va
+Fo
+po
+Va
+Ov
+YT
+es
+DJ
+YT
+PV
+PV
+"}
+(81,1,1) = {"
+PV
+PV
+PV
+Va
+Ps
+Mq
+fS
+YT
+YT
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+zS
+zS
+zS
+zS
+zS
+Qm
+Va
+dD
+TE
+iU
+NS
+tf
+Va
+zy
+Va
+Fo
+Ov
+YT
+nP
+es
+YT
+Va
+PV
+"}
+(82,1,1) = {"
+PV
+PV
+PV
+Va
+Ps
+Ps
+Fo
+YM
+TN
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+pV
+zS
+zS
+zS
+zS
+hF
+Va
+Va
+po
+dD
+Qq
+PQ
+NS
+dD
+po
+Va
+po
+po
+Ov
+YT
+TN
+YR
+Va
+YT
+YT
+"}
+(83,1,1) = {"
+PV
+PV
+PV
+Va
+NK
+Fo
+Va
+nP
+nP
+nP
+YT
+nP
+YT
+Va
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+zS
+zS
+zS
+Va
+Va
+Va
+dD
+HP
+PQ
+qk
+dD
+Va
+Va
+fL
+Va
+Ov
+YT
+YT
+YT
+rt
+MI
+YA
+"}
+(84,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+es
+nP
+Rb
+nP
+bR
+nP
+TN
+sR
+sR
+Li
+at
+sR
+nQ
+Ym
+NQ
+sR
+zq
+iC
+Qc
+sR
+JF
+Gy
+ut
+BZ
+sR
+sR
+zS
+zS
+YA
+Va
+po
+dD
+HP
+eb
+qk
+bO
+Fo
+Va
+Hs
+Va
+Ov
+YT
+YT
+rt
+rt
+YT
+Va
+"}
+(85,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+Va
+nP
+nP
+uE
+nP
+YT
+YT
+sR
+at
+Wp
+uZ
+sR
+kK
+Wp
+Bh
+sR
+uZ
+Wp
+uZ
+sR
+mQ
+TY
+AU
+wO
+JH
+sR
+zS
+zS
+Va
+po
+Va
+dD
+Qq
+EN
+NS
+dD
+Va
+Va
+Fo
+Va
+Ov
+YR
+MI
+rt
+bg
+uw
+Va
+"}
+(86,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+YT
+YT
+nP
+nP
+DJ
+nP
+YR
+Va
+sR
+Vg
+WK
+Vg
+sR
+ri
+Lv
+ri
+sR
+ri
+pt
+wI
+sR
+jm
+DG
+Pe
+Jt
+Zx
+sR
+zS
+zS
+Va
+Va
+Hs
+dD
+YD
+Fs
+PZ
+dD
+Va
+Qm
+po
+Va
+Ov
+YT
+bg
+bg
+bg
+bg
+PV
+"}
+(87,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+YT
+YT
+TN
+Va
+Fo
+YT
+fL
+YT
+sR
+nR
+hV
+us
+wU
+TY
+Hc
+Wa
+Hx
+uS
+hV
+Cc
+cB
+Zz
+DG
+dd
+bE
+tl
+sR
+zS
+Va
+QL
+Va
+Va
+dD
+TE
+eW
+Mv
+dD
+Va
+po
+Va
+Va
+Ov
+Va
+YT
+rt
+He
+PV
+PV
+"}
+(88,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+TN
+YT
+TN
+TN
+YA
+Va
+sR
+Bm
+iY
+VN
+gn
+gn
+eP
+Jl
+Jl
+Js
+si
+Jl
+Jl
+iW
+pW
+Pe
+pG
+sR
+sR
+Va
+Va
+Va
+Va
+Va
+dD
+Qq
+eW
+qk
+dD
+Hs
+Va
+Va
+Qm
+Ov
+TN
+TN
+Va
+YA
+PV
+PV
+"}
+(89,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+TN
+Ps
+xr
+xr
+Ps
+yU
+sR
+YQ
+Hc
+Wj
+xx
+TY
+wp
+rc
+ro
+uS
+Hc
+xV
+lX
+TY
+TY
+Pe
+TY
+jJ
+sR
+Va
+Va
+zy
+Va
+po
+dD
+TE
+EN
+NS
+dD
+Va
+fL
+Fo
+Va
+Ov
+TN
+TN
+Yb
+Fo
+TN
+PV
+"}
+(90,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Qm
+Ps
+Ps
+Fo
+Va
+sR
+RH
+NU
+RH
+sR
+oD
+io
+oD
+sR
+FX
+Yo
+FX
+sR
+TY
+pW
+ft
+MG
+aN
+sR
+po
+Tc
+Va
+Va
+Va
+dD
+TE
+Fs
+Gg
+bO
+po
+fL
+zS
+po
+Ov
+Va
+xr
+YT
+Va
+TN
+yU
+"}
+(91,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+Va
+Ps
+Ps
+Fg
+BE
+YT
+sR
+Pf
+oJ
+fF
+sR
+Bh
+Hm
+Bh
+sR
+Bh
+zW
+lZ
+sR
+IZ
+pW
+vN
+as
+Ai
+sR
+Va
+Va
+Va
+Hs
+YA
+dD
+Qq
+EN
+NS
+dD
+EF
+zS
+Fo
+zS
+Ov
+Va
+Ps
+Yg
+TN
+Va
+PV
+"}
+(92,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+Fo
+Ps
+Ps
+Qm
+fS
+Va
+sR
+sR
+yo
+Pf
+sR
+nQ
+wL
+en
+sR
+zG
+CT
+kF
+sR
+Wc
+uS
+Pe
+TY
+sR
+sR
+po
+Tc
+fL
+Va
+Va
+dD
+Qq
+EN
+qk
+dD
+Va
+Va
+Va
+Va
+Ov
+Ps
+Yg
+Ps
+Oz
+PV
+PV
+"}
+(93,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+TN
+Va
+Va
+Va
+Va
+Va
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+sR
+cF
+sR
+ol
+sR
+sR
+Va
+Va
+Va
+Va
+Va
+Va
+dD
+Qq
+EN
+qk
+dD
+po
+po
+Qm
+Va
+Ov
+YM
+Yg
+Ps
+Ps
+TN
+PV
+"}
+(94,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+bg
+bg
+bg
+fS
+TN
+TN
+Va
+YT
+Va
+Va
+fL
+Hs
+YA
+Va
+YM
+Ov
+Va
+Va
+zS
+bO
+aI
+lg
+Ub
+Bb
+Va
+Va
+Va
+Va
+Va
+Va
+zy
+dD
+Qq
+EN
+qk
+dD
+Va
+Fo
+Va
+Va
+Ov
+Va
+uo
+YT
+Va
+Va
+PV
+"}
+(95,1,1) = {"
+PV
+PV
+PV
+PV
+bg
+MI
+bg
+bg
+bg
+Qm
+Va
+Va
+YT
+Va
+yU
+Va
+YR
+Va
+YM
+Va
+Va
+Ov
+zy
+Va
+Qm
+bO
+aI
+tt
+PZ
+yC
+po
+Va
+fL
+Qm
+po
+Va
+dD
+dD
+Qq
+eW
+qk
+dD
+Va
+Va
+Va
+Va
+Ov
+Fo
+Va
+YT
+yU
+Va
+PV
+"}
+(96,1,1) = {"
+PV
+PV
+PV
+PV
+bg
+bg
+ld
+Qo
+Qo
+xo
+xo
+xo
+xo
+xo
+xo
+xo
+xo
+xo
+Qo
+Qo
+nr
+bW
+Va
+Qm
+Va
+dD
+Qq
+Fs
+NS
+yC
+Hs
+Va
+Va
+Va
+Va
+dD
+dD
+yz
+yc
+eW
+qk
+dD
+QL
+Va
+Va
+Va
+Ov
+Va
+rV
+YR
+Va
+Ps
+PV
+"}
+(97,1,1) = {"
+PV
+PV
+PV
+PV
+TN
+MI
+qj
+eX
+fM
+fM
+fM
+Kx
+Kx
+Kx
+Kx
+QA
+yJ
+fM
+RW
+NX
+lk
+Ov
+Va
+Va
+Hs
+yC
+HP
+eW
+NS
+dD
+Va
+Va
+Va
+po
+dD
+dD
+yz
+yc
+rP
+eW
+qk
+dD
+Qm
+Va
+Va
+fL
+Ov
+nP
+DJ
+DJ
+Ps
+Ps
+PV
+"}
+(98,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+MI
+qj
+RW
+ga
+ga
+Kx
+Kx
+Bn
+TM
+Og
+hW
+Kx
+Kx
+Xj
+fM
+lo
+Hh
+dD
+dD
+dD
+yC
+Qq
+EN
+NS
+dD
+dD
+dD
+dD
+dD
+dD
+yz
+Ql
+rP
+wB
+uV
+qk
+dD
+Va
+Qx
+Qm
+Va
+Ov
+nP
+DJ
+TN
+Ps
+Ps
+PV
+"}
+(99,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+qj
+fM
+iO
+jx
+CJ
+Kx
+YZ
+YZ
+od
+hS
+tU
+tJ
+Mb
+fM
+lo
+Rp
+jw
+Ke
+Ke
+Lb
+Rt
+EN
+Px
+jw
+jw
+Ke
+Ke
+GV
+jw
+Rt
+rP
+Qs
+sT
+Mh
+hL
+dD
+Va
+Va
+Qm
+Va
+Ov
+nP
+nP
+nP
+Va
+Ps
+PV
+"}
+(100,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+TN
+qj
+fM
+iO
+nU
+RR
+pd
+zj
+zj
+KO
+JI
+zj
+iq
+Mb
+RW
+lk
+Dz
+rP
+NH
+NH
+II
+II
+zv
+ZA
+ZA
+ZA
+ID
+ID
+ZA
+ZA
+hU
+xv
+uV
+Nc
+hL
+dD
+dD
+Va
+Hs
+zS
+zS
+Ov
+Hs
+DJ
+DJ
+TN
+YA
+nP
+"}
+(101,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+YT
+Xu
+RW
+iO
+vO
+jL
+Kx
+YZ
+YZ
+YZ
+kn
+Ng
+NP
+Mb
+RW
+lk
+LN
+Rc
+Rc
+Rc
+Rc
+Rc
+Rc
+Rc
+Rc
+dR
+vW
+tz
+zA
+Rc
+Rc
+Rc
+Rc
+hL
+dD
+dD
+Va
+Va
+gt
+zS
+zS
+Ov
+GG
+DJ
+DJ
+Va
+DJ
+DJ
+"}
+(102,1,1) = {"
+PV
+PV
+PV
+PV
+YT
+Va
+Xu
+RW
+ga
+ga
+Kx
+Kx
+OD
+RN
+tT
+AN
+Kx
+Kx
+Mb
+fM
+lo
+Hh
+dD
+yC
+yC
+yC
+dD
+dD
+dD
+bO
+bO
+bO
+bO
+bO
+dD
+dD
+dD
+bO
+dD
+dD
+Va
+fL
+zS
+zS
+zS
+zS
+Ov
+nP
+nP
+Va
+TN
+DJ
+nP
+"}
+(103,1,1) = {"
+PV
+PV
+PV
+PV
+YT
+Va
+Xu
+eX
+fM
+fM
+fM
+Kx
+Kx
+Kx
+Kx
+bi
+yJ
+fM
+fM
+gc
+lk
+Ov
+Va
+Va
+Hs
+Va
+Va
+Va
+fL
+zS
+zS
+zS
+mf
+zS
+Va
+fL
+Va
+Hs
+Va
+Va
+Qm
+Va
+zy
+zS
+EF
+zS
+Ov
+TN
+es
+YT
+YR
+yU
+nP
+"}
+(104,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+YT
+zb
+hr
+hr
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+nC
+hr
+hr
+hr
+MW
+bW
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+cN
+bW
+Va
+YT
+He
+Va
+TN
+PV
+"}
+(105,1,1) = {"
+PV
+PV
+PV
+PV
+Va
+Va
+YT
+Va
+TN
+Qm
+TN
+Va
+YT
+YT
+YR
+YT
+Va
+Fo
+YT
+YT
+YT
+TN
+TN
+Fo
+TN
+Va
+fS
+Qm
+rV
+YR
+nP
+es
+nP
+DJ
+nP
+ep
+Ps
+NK
+Ps
+TN
+TN
+xl
+bR
+yU
+nP
+TN
+Fo
+TN
+YM
+Va
+yU
+Va
+PV
+"}
+(106,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+Va
+TN
+TN
+TN
+fX
+Va
+TN
+Ff
+Va
+Fo
+Va
+Qm
+YT
+YT
+TN
+Qm
+GG
+YT
+YT
+TN
+YM
+Qm
+nP
+rV
+nP
+nP
+DJ
+nP
+es
+Yg
+Yg
+Ps
+TN
+Va
+fS
+TN
+vk
+bR
+DJ
+DJ
+DJ
+yU
+YT
+Va
+YT
+Va
+Va
+PV
+"}
+(107,1,1) = {"
+PV
+PV
+PV
+PV
+PV
+PV
+Va
+Va
+PV
+Va
+Va
+Oz
+Va
+TN
+GG
+Va
+PV
+Va
+Va
+Fo
+Va
+PV
+YT
+YT
+PV
+Oz
+YR
+YA
+YT
+YT
+Va
+fL
+TN
+Va
+Yg
+Ps
+Va
+Va
+yU
+Va
+nP
+nP
+Va
+TN
+TN
+Va
+YM
+Va
+Fo
+Va
+Va
+PV
+PV
+"}

--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_surface_ramzi.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_surface_ramzi.dmm
@@ -1,0 +1,4748 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ad" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-6"
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"an" = (
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"aX" = (
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light_switch{
+	pixel_x = -12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"bg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"bj" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"bn" = (
+/obj/structure/flora/stump,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bs" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/canteen)
+"bN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"bO" = (
+/turf/open/water/jungle/lit,
+/area/overmap_encounter/planetoid/jungle/explored)
+"bX" = (
+/obj/structure/closet/secure_closet/armorycage{
+	anchored = 1;
+	locked = 0;
+	req_access = null
+	},
+/obj/item/storage/box/ammo/c45,
+/obj/item/storage/box/ammo/c45,
+/obj/item/storage/toolbox/ammo/c10mm,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/item/storage/box/ammo/a12g_buckshot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"cf" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/medical)
+"cA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cI" = (
+/obj/structure/crate_shelf,
+/obj/structure/closet/crate/medical,
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/radiation,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"cO" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cS" = (
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/mapping_helpers/crate_shelve,
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"cT" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cX" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"cY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"dk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 9
+	},
+/obj/structure/table,
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"dp" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort)
+"dw" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dJ" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"dO" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ef" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -10;
+	pixel_y = 0;
+	density = 0
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"ej" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort)
+"en" = (
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"es" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ey" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eF" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"eW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/electrical)
+"fb" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-5"
+	},
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fi" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/storage)
+"fj" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"fE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/syndiemoth{
+	pixel_x = -32
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = 0;
+	pixel_y = 6
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"fI" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"fU" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gl" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gu" = (
+/obj/structure/flora/stump,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gG" = (
+/obj/structure/spacevine,
+/obj/structure/flora/ash/garden,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"gO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/flippedtable{
+	icon_state = "wood_table";
+	table_type = /obj/structure/table/wood;
+	dir = 2
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/officer/smg{
+	name = "Jerry";
+	desc = "A paranoid officer of the Ramzi Clique, cradling a compact submachinegun in blackened gloves.";
+	weapon_drop_chance = 100;
+	environment_smash = 0
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"gQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ruin/jungle/syndifort/jerry)
+"gY" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/dorms)
+"ha" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"hb" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"hf" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"hg" = (
+/obj/machinery/power/smes{
+	output_level = 15000;
+	charge = 1.5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"hh" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hj" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"hk" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled{
+	name = "old paper scrap";
+	desc = "This one looks like it dates back to the Inter-Corporate War.";
+	default_raw_text = "REMINDER: Disable intake pump in event of radiological event. Do not reactivate until line has been thoroughly cleaned."
+	},
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/jungle/syndifort/atmos)
+"ho" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hF" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "jungle_syndicate_cargo_door"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"hH" = (
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"hJ" = (
+/obj/effect/turf_decal/syndicateemblem/middle/middle,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"hL" = (
+/obj/structure/cable{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ib" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/ruin/jungle/syndifort/storage)
+"ic" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"ig" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"ii" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"ik" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"il" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
+/obj/item/shard{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"it" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/middle,
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"iN" = (
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"iW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jb" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/wideband/table{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/radio/intercom/table{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"jk" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jq" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort/storage)
+"jr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"jN" = (
+/mob/living/simple_animal/hostile/human/ramzi/melee/sawbones,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 5
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/medical)
+"jS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"kf" = (
+/obj/item/reagent_containers/glass/bucket/wooden{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ki" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = -8
+	},
+/obj/item/attachment/bayonet{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/stack/ore/salvage/scrapmetal{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"kp" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/obj/item/stack/cable_coil/cut/red,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ky" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kz" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/dorms)
+"kJ" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/junglebush,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"kL" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"kP" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"kY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"kZ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/atmos)
+"lq" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"lA" = (
+/obj/machinery/atmospherics/components/trinary/filter/on/layer4{
+	dir = 1;
+	filter_type = "o2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"lD" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/jungle/syndifort/electrical)
+"lG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_x = -19;
+	pixel_y = 8
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"me" = (
+/obj/structure/safe,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/spacecash/bundle/smallrand,
+/obj/machinery/light/directional/east,
+/obj/item/spacecash/bundle/smallrand,
+/obj/item/folder/documents/syndicate/red,
+/obj/item/melee/energy/flyssa,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"mh" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/clothing/under/syndicate/ramzi,
+/obj/item/clothing/under/syndicate/ramzi/overalls,
+/obj/item/clothing/under/syndicate/ramzi/overalls,
+/obj/item/clothing/head/ramzi/flap,
+/obj/item/clothing/head/ramzi,
+/obj/item/clothing/head/ramzi,
+/obj/item/clothing/glasses/hud/security/sunglasses/ramzi,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/suit/ramzi,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/jungle/syndifort/dorms)
+"mk" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/full,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"mo" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"mD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"mN" = (
+/obj/structure/flora/junglebush/c,
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"mR" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/tracker,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"nH" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/armory)
+"nI" = (
+/obj/machinery/porta_turret/ruin/ramzi/light{
+	id = "jungle_syndicate_turrets";
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort/jerry)
+"nT" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/structure/table/wood,
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/jungle/syndifort/dorms)
+"og" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"ov" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"oA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 4
+	},
+/obj/effect/turf_decal/borderfloorblack/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"oK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/radiation{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 4
+	},
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged{
+	weapon_drop_chance = 100;
+	environment_smash = 0
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"oL" = (
+/obj/item/chair{
+	dir = 8;
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"pi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "jungle_syndicate_lockdown";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/electrical)
+"pk" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled{
+	default_raw_text = "NOTE: Get spare field emitters. Flyssa will only last a few more weeks on this one.";
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"pq" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/medical)
+"px" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 15
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"pB" = (
+/obj/machinery/door/window/southleft{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/catwalk_floor,
+/area/ruin/jungle/syndifort/dorms)
+"pC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"pF" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/jungle/syndifort/jerry)
+"pX" = (
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"pZ" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/structure/mirror{
+	pixel_y = 35
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/jungle/syndifort/dorms)
+"qa" = (
+/obj/structure/salvageable/machine{
+	pixel_x = -4;
+	pixel_y = -3;
+	name = "broken fallout sampler"
+	},
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qd" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/jerry)
+"qe" = (
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"qh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#543C30"
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"qq" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qr" = (
+/obj/effect/turf_decal/corner/opaque/orange,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"qt" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qx" = (
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qL" = (
+/obj/item/food/grown/sweet_potato,
+/obj/item/food/grown/sweet_potato,
+/obj/item/food/grown/sweet_potato,
+/obj/structure/closet/crate/wooden,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/mushroom/chanterelle,
+/obj/item/food/grown/eggplant,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/garlic,
+/obj/item/food/grown/grapes,
+/obj/item/food/grown/apple,
+/obj/item/food/grown/apple,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"qV" = (
+/obj/machinery/light/small/directional/west,
+/obj/item/attachment/rail_light{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/armory)
+"qY" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"rd" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/chair{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/canteen)
+"rt" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"rG" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/dorms)
+"rN" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/modular_computer/laptop/preset/civilian/rilena{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door{
+	id = "jungle_syndicate_lockdown";
+	name = "Lockdown Blast Doors";
+	pixel_x = -23;
+	pixel_y = -3;
+	dir = 4
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/gun_maint_kit{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/machinery/turretid/lethal{
+	pixel_x = -28;
+	desc = "Used to control a facility's automated defenses.";
+	id = "jungle_syndicate_turrets";
+	pixel_y = -15;
+	req_access = list(150)
+	},
+/obj/machinery/button/door{
+	id = "jungle_syndicate_cargo_door";
+	name = "Storage Room Blast Door";
+	pixel_x = -23;
+	pixel_y = 8;
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"sf" = (
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"sm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"sr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"sw" = (
+/obj/structure/barricade/sandbags,
+/obj/item/stack/cable_coil/cut/red,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"sF" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/computer/monitor/retro{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"sI" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"sL" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/solar_control{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/electrical)
+"sQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8;
+	color = "#543C30"
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"sR" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"tf" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8-10"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/electrical)
+"tt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"tE" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/item/gun_maint_kit/small{
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"tK" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"tL" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uc" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uf" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ug" = (
+/obj/structure/flora/junglebush,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uh" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"uj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#543C30"
+	},
+/obj/structure/closet/wall/red/directional/east,
+/obj/item/spacecash/bundle/pocketchange,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/modular_computer/laptop/preset/civilian,
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"ur" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/canteen)
+"us" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"uu" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"uC" = (
+/obj/structure/flora/stump,
+/obj/structure/spacevine/weak,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"uV" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 19;
+	pixel_y = 9
+	},
+/obj/item/chair{
+	dir = 8;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"ve" = (
+/obj/effect/turf_decal/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"vs" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"vJ" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/hardsuit/syndi,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/jerry)
+"wo" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort)
+"ws" = (
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"wu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"wN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"wT" = (
+/obj/structure/cable{
+	icon_state = "5-9"
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"xa" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/atmos)
+"xu" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/left,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"xA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"xC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	dir = 8;
+	pixel_x = 25;
+	pixel_y = 6;
+	id = "jungle_syndie_bridge_window";
+	name = "Window Cover"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"xF" = (
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = -7;
+	pixel_y = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"xM" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yc" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yd" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ye" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yf" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yh" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters{
+	id = "jungle_syndie_bridge_window";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort)
+"yj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/stack/sheet/metal/twenty,
+/obj/item/stack/sheet/glass/twenty,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/electrical)
+"ym" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"ys" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/porta_turret/ruin/ramzi{
+	dir = 6;
+	id = "jungle_syndicate_turrets"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort)
+"yJ" = (
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"yR" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/item/chair{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"yZ" = (
+/turf/template_noop,
+/area/template_noop)
+"zv" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zB" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/electrical)
+"zH" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/grass/jungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/human/ramzi/melee/hatchet/engi,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zK" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"zM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet/red_gold,
+/area/ruin/jungle/syndifort/jerry)
+"zN" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"zU" = (
+/obj/structure/closet/wall/white/directional/west,
+/obj/structure/sink/chem{
+	pixel_x = 4;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/onion,
+/obj/item/reagent_containers/condiment/milk,
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"zX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Aa" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ai" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -9;
+	pixel_y = -19
+	},
+/turf/open/floor/carpet/red_gold,
+/area/ruin/jungle/syndifort/jerry)
+"Aq" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/door/airlock{
+	id_tag = "jungle_syndie_shitter"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/dorms)
+"At" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/canteen)
+"Au" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ax" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 10
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"AJ" = (
+/obj/effect/spawner/bunk_bed,
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/structure/sign/poster/rilena/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/jungle/syndifort/dorms)
+"Ba" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Bh" = (
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/corner/opaque/syndiered/diagonal{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/canteen)
+"Bi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"BS" = (
+/obj/effect/spawner/random/vending/cola,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Cg" = (
+/obj/structure/chair/plastic,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth{
+	environment_smash = 0
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Co" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/item/shard{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/item/storage/bag/tray/cafeteria{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Cr" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"CD" = (
+/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/medical)
+"CI" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/mob/living/simple_animal/hostile/human/ramzi/ranged/space/shotgun,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort)
+"CO" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/storage)
+"Dc" = (
+/obj/effect/turf_decal/syndicateemblem/top/middle,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"Df" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/dorms)
+"Dt" = (
+/mob/living/basic/cow{
+	faction = list("neutral","Ramzi Clique");
+	name = "ramzi clique cow";
+	desc = "Known for their milk, just don't tip them over... or do, considering that they're loyal to the Ramzi Clique."
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"DC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/table,
+/obj/structure/sign/poster/contraband/syndicate_recruitment{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"DE" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wall/directional/north,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"DF" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 10
+	},
+/obj/structure/table/chem,
+/obj/item/storage/firstaid/medical{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/medical)
+"Ea" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Eg" = (
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"Eo" = (
+/obj/structure/cable{
+	icon_state = "6-9"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ev" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 1
+	},
+/obj/effect/turf_decal/corner/opaque/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"EH" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"EK" = (
+/obj/structure/flora/rock,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"EZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Fs" = (
+/obj/structure/cable/yellow{
+	icon_state = "6-9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ft" = (
+/obj/machinery/suit_storage_unit/industrial,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"FA" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/corner/opaque/black/diagonal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort/storage)
+"FP" = (
+/mob/living/simple_animal/hostile/human/ramzi/melee/machete,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ge" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/right,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -3
+	},
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"Gk" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Gs" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"GL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5;
+	color = "#543C30"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged{
+	environment_smash = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"GQ" = (
+/obj/machinery/atmospherics/components/trinary/mixer/flipped/on/layer4{
+	node2_concentration = 0.78;
+	node1_concentration = 0.22
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"GR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/arcade/battle,
+/obj/structure/sign/poster/contraband/syndicate{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/canteen)
+"Hb" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Hd" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Hf" = (
+/obj/structure/closet/secure_closet/armorycage{
+	anchored = 1;
+	locked = 0;
+	req_access = null
+	},
+/obj/item/ammo_box/magazine/m12g_bulldog/empty,
+/obj/item/ammo_box/magazine/m12g_bulldog,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/item/ammo_box/magazine/m10mm_ringneck,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/magazine/m10mm_cottonmouth,
+/obj/item/ammo_box/magazine/m10mm_cottonmouth/empty,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"Hk" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/jungle/syndifort/dorms)
+"Hz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"HN" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"HV" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/medical)
+"HY" = (
+/obj/structure/crate_shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/wooden,
+/obj/item/pickaxe/mini{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/shovel{
+	pixel_x = 0;
+	pixel_y = -6
+	},
+/obj/item/hatchet/wooden,
+/obj/item/stack/sheet/mineral/wood/twentyfive,
+/obj/item/storage/box/emptysandbags,
+/obj/item/storage/box/emptysandbags,
+/obj/item/storage/box/emptysandbags,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel/mono/dark/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"Ik" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/effect/turf_decal/syndicateemblem/top/left,
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"Jg" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ji" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"Jq" = (
+/obj/machinery/atmospherics/components/trinary/filter/on/layer4{
+	dir = 1;
+	filter_type = "n2"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"JI" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"JV" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin{
+	name = "contamination bin";
+	desc = "A bin marked to be used for radioactive waste, such as contaminated suits."
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"JZ" = (
+/obj/structure/closet/crate/rations,
+/obj/structure/crate_shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/kitchen/fork/plastic,
+/obj/item/melee/knife/plastic,
+/obj/item/melee/knife/plastic,
+/obj/item/melee/knife/plastic,
+/obj/item/melee/knife/plastic,
+/obj/item/melee/knife/plastic,
+/obj/item/melee/knife/plastic,
+/turf/open/floor/plasteel/mono/dark/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"Kb" = (
+/obj/structure/flora/junglebush/b,
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Kc" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Kh" = (
+/obj/item/ammo_casing/spent/pistol_steel,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Kj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Kk" = (
+/obj/effect/turf_decal/corner/opaque/syndiered,
+/obj/machinery/microwave,
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Kw" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"KJ" = (
+/obj/effect/turf_decal/syndicateemblem/middle/left,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"KM" = (
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/item/geiger_counter,
+/obj/structure/closet/radiation/empty,
+/obj/item/geiger_counter,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"KP" = (
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Lm" = (
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters,
+/obj/machinery/griddle,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Lr" = (
+/obj/machinery/suit_storage_unit/inherit/industrial,
+/obj/item/clothing/suit/space/hardsuit/syndi/ramzi,
+/obj/item/clothing/mask/gas/ramzi,
+/obj/item/tank/internals/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/jungle/syndifort/armory)
+"Ls" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 9
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged{
+	environment_smash = 0
+	},
+/obj/structure/flippedtable{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Lu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/south,
+/obj/machinery/fax/ruin,
+/obj/structure/table/wood,
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"LA" = (
+/obj/item/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 11;
+	pixel_y = -12
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"LG" = (
+/obj/structure/spacevine/dense,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"LJ" = (
+/obj/machinery/porta_turret/ruin/ramzi/light{
+	id = "jungle_syndicate_turrets";
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort/medical)
+"LO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/ammo_casing/spent/pistol_steel,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mi" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-6"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Mk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"MT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Nd" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-5"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Nf" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Nn" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/machinery/door/poddoor/preopen{
+	id = "jungle_syndicate_lockdown"
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Ny" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"NI" = (
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"NU" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/floordetail/pryhole,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Oh" = (
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/gec{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "x";
+	layer = 3.5;
+	paint_colour = "#FF0000";
+	pixel_x = 1;
+	pixel_y = 34
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"Oj" = (
+/obj/machinery/porta_turret/ruin/ramzi/light{
+	id = "jungle_syndicate_turrets";
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/ruin/jungle/syndifort)
+"Ol" = (
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Oq" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ot" = (
+/obj/effect/turf_decal/syndicateemblem/middle/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/jungle,
+/area/ruin/jungle/syndifort/storage)
+"OC" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/electrical)
+"OE" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/item/cutting_board{
+	pixel_x = -1;
+	pixel_y = 0
+	},
+/obj/structure/table/reinforced,
+/obj/item/food/grown/potato{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/item/melee/knife{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"OG" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/turf_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"OI" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/turret/ruin,
+/obj/structure/spacevine/dense,
+/turf/open/floor/plating/jungleplanet{
+	icon_state = "plating_rust"
+	},
+/area/overmap_encounter/planetoid/jungle/explored)
+"OJ" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/line{
+	dir = 9
+	},
+/obj/structure/table/chem,
+/obj/item/clothing/neck/stethoscope,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/ramzi{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/medical)
+"OO" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/item/chair{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"OV" = (
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/flora/grass/jungle/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"OW" = (
+/obj/item/analyzer{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "6-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-6"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"Pp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/patterned/ridged,
+/area/ruin/jungle/syndifort/canteen)
+"Pq" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/flora/grass/jungle,
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ps" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PS" = (
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PW" = (
+/obj/structure/cable/yellow{
+	icon_state = "5-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"PX" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Qf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = -9;
+	pixel_y = -19
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/dorms)
+"Qx" = (
+/obj/structure/flora/junglebush,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QG" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"QI" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/electrical)
+"QN" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/jungle/syndifort/dorms)
+"QZ" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"Rk" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rl" = (
+/obj/structure/flora/grass/jungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rn" = (
+/obj/structure/spacevine,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rq" = (
+/obj/structure/flora/stump,
+/obj/structure/spacevine,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Ru" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10;
+	color = "#543C30"
+	},
+/obj/structure/closet/wall/red/directional/south,
+/obj/item/toy/plush/rilena,
+/obj/item/poster/random_rilena,
+/obj/item/poster/random_rilena,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken6"
+	},
+/area/ruin/jungle/syndifort/dorms)
+"Rv" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Rz" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort/atmos)
+"RD" = (
+/obj/effect/turf_decal/siding/wood/end,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/ruin/jungle/syndifort/jerry)
+"Sl" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Sp" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/storage)
+"Sz" = (
+/obj/structure/flora/rock,
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"SO" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"SP" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ST" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"SU" = (
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"Te" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"Tl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Tz" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TG" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"TK" = (
+/obj/structure/flora/junglebush,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TT" = (
+/obj/effect/turf_decal/solarpanel,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	icon_state = "0-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8-10"
+	},
+/turf/open/floor/plasteel,
+/area/overmap_encounter/planetoid/jungle/explored)
+"TV" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Uj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 2;
+	color = "#543C30"
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -20
+	},
+/obj/structure/table/wood,
+/obj/item/pen{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/walnut{
+	icon_state = "wood-broken7"
+	},
+/area/ruin/jungle/syndifort/dorms)
+"Uy" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants,
+/obj/item/seeds/grass,
+/obj/item/seeds/potato,
+/obj/item/seeds/potato,
+/obj/item/seeds/sweet_potato,
+/obj/item/seeds/wheat,
+/obj/item/seeds/wheat,
+/obj/item/seeds/berry,
+/obj/item/seeds/berry,
+/obj/item/seeds/eggplant,
+/obj/item/seeds/garlic,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UO" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"UX" = (
+/obj/machinery/button/door{
+	pixel_y = 23;
+	id = "jungle_syndie_shitter";
+	name = "Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/jungle/syndifort/dorms)
+"Vn" = (
+/mob/living/simple_animal/hostile/human/ramzi/civilian,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"Vx" = (
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"VU" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"VV" = (
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"VX" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/grenade/c4,
+/obj/item/grenade/frag,
+/obj/item/grenade/frag,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -20;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"Wd" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 8
+	},
+/obj/machinery/recharger{
+	anchored = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/armory)
+"Wj" = (
+/obj/structure/flora/grass/jungle/b,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wl" = (
+/obj/structure/flora/stump,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wm" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/grass/jungle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Wx" = (
+/obj/effect/turf_decal/corner/opaque/orange/three_quarters,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/human/ramzi/ranged/cottonmouth,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+"WA" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	req_access = list(150,10);
+	populate = 0
+	},
+/obj/item/clothing/under/syndicate/gec,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/ramzi/flap,
+/obj/item/clothing/suit/hazardvest,
+/turf/open/floor/plasteel/mono/dark,
+/area/ruin/jungle/syndifort/electrical)
+"WG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/closet/wall/red/directional/west,
+/obj/item/clothing/under/syndicate/ramzi/officer,
+/obj/item/clothing/suit/armor/ramzi/officer,
+/obj/item/clothing/head/ramzi/beret,
+/obj/item/spacecash/bundle/pocketchange,
+/obj/item/blackmarket_uplink,
+/obj/item/paper/crumpled{
+	default_raw_text = "Some indies showed up a few weeks ago. Tried to attack the base. No dead on our end, and they had someone go down - they were carrying a pretty nice plushie, so I took it - but they ran off with a personnel manifest. If that gets to the Republic we're in some shit."
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/item/toy/plush/rilena,
+/turf/open/floor/carpet/red_gold,
+/area/ruin/jungle/syndifort/jerry)
+"WJ" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/end,
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/medical)
+"WN" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/jungleplanet,
+/area/ruin/jungle/syndifort/storage)
+"WP" = (
+/obj/structure/flora/ash/garden,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"WQ" = (
+/obj/effect/turf_decal/spline/fancy/opaque/syndiered{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/jungle/syndifort/canteen)
+"WX" = (
+/obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/jungle/syndifort)
+"Xc" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/junglebush,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort/electrical)
+"Xo" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xs" = (
+/obj/item/paper/crumpled{
+	default_raw_text = "jerry said we all need to go to lockdown. someone put out an open bounty to kill him pretty brutally and recover a plush. its gonna suck to put the tables back once this one lifts"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"Xt" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/obj/item/ammo_box/magazine/m10mm_ringneck{
+	pixel_x = 9;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort)
+"XE" = (
+/turf/closed/wall/concrete/reinforced,
+/area/ruin/jungle/syndifort/jerry)
+"XR" = (
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"XW" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"XY" = (
+/obj/item/stack/cable_coil/cut/red{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/stock_parts/capacitor{
+	pixel_x = -9;
+	pixel_y = -7
+	},
+/obj/structure/spacevine,
+/turf/open/floor/plating/asteroid/dirt/jungle/dark,
+/area/overmap_encounter/planetoid/jungle/explored)
+"XZ" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/atmos)
+"Ya" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/north,
+/obj/item/ammo_box/magazine/m45_cobra{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/ammo_box/magazine/m45_cobra{
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/obj/structure/flippedtable{
+	icon_state = "wood_table";
+	table_type = /obj/structure/table/wood;
+	dir = 2
+	},
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"Yj" = (
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning,
+/obj/effect/turf_decal/trimline/opaque/syndiered/filled/warning{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"YH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 5
+	},
+/obj/effect/turf_decal/borderfloorblack,
+/obj/structure/cable{
+	icon_state = "6-10"
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/nuclearbomb/beer{
+	desc = "A Corporate War-era atomic bomb, stripped of its payload and filled with booze. Its control panel lights are dimly flickering, a beer-tap next to them.";
+	name = "syndicate beer keg";
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"YR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9;
+	color = "#543C30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/wood/walnut{
+	color = "#543c30";
+	icon_state = "wood-broken5"
+	},
+/area/ruin/jungle/syndifort/dorms)
+"Za" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/corner/opaque/syndiered/three_quarters{
+	dir = 8
+	},
+/obj/effect/turf_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/canteen)
+"Zd" = (
+/obj/effect/turf_decal/corner/opaque/syndiered{
+	dir = 8
+	},
+/obj/effect/turf_decal/corner/opaque/black{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -20
+	},
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"Zj" = (
+/obj/effect/spawner/bunk_bed{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	color = "#543C30"
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/jungle/syndifort/dorms)
+"Zo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/walnut,
+/area/ruin/jungle/syndifort/jerry)
+"ZB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/asteroid/dirt/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ZF" = (
+/obj/effect/turf_decal/corner/opaque/syndiered,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating/rust,
+/area/ruin/jungle/syndifort)
+"ZG" = (
+/obj/structure/spacevine,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/asteroid/dirt/grass/jungle,
+/area/overmap_encounter/planetoid/jungle/explored)
+"ZL" = (
+/obj/item/wrench/syndie{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/item/weldingtool/largetank{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/item/crowbar/syndie{
+	pixel_x = -11;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/corner/opaque/orange{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
+/obj/item/storage/toolbox/syndicate/empty{
+	pixel_x = 5;
+	pixel_y = -6
+	},
+/obj/item/wirecutters/syndie{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/screwdriver/nuke{
+	pixel_x = -11;
+	pixel_y = 6
+	},
+/obj/item/multitool/syndie{
+	pixel_x = -11;
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/jungle/syndifort/electrical)
+
+(1,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+qx
+bO
+bO
+dw
+qx
+Vx
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+"}
+(2,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+Vx
+dw
+bO
+qx
+qx
+Vx
+qx
+qx
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+"}
+(3,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+qx
+ws
+eF
+bO
+sR
+ws
+ws
+qx
+Vx
+qx
+ws
+yZ
+Gs
+Sz
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+qx
+VV
+yZ
+"}
+(4,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+TK
+Kb
+qx
+bO
+sR
+qx
+bO
+FP
+SP
+Aa
+qx
+dw
+ws
+ho
+yZ
+dw
+dO
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+SP
+uf
+uf
+sw
+"}
+(5,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+yJ
+qt
+Aa
+TK
+bO
+bO
+sR
+qx
+bO
+qL
+XW
+Ol
+Vx
+dw
+Rl
+ws
+dw
+dw
+Wl
+dO
+yZ
+yZ
+yZ
+yZ
+qx
+qx
+uf
+OI
+Rk
+"}
+(6,1,1) = {"
+yZ
+yZ
+qx
+dw
+ws
+ws
+SP
+TK
+ws
+bO
+bO
+bO
+bO
+bO
+bO
+Uy
+ws
+kf
+qx
+dw
+Rl
+Wm
+es
+es
+an
+qq
+yZ
+yZ
+qx
+fU
+Sz
+XY
+Cr
+Ps
+"}
+(7,1,1) = {"
+yZ
+TK
+Ol
+qx
+qx
+qt
+ye
+Nd
+OO
+gY
+gY
+gY
+gY
+bO
+bO
+bO
+Dt
+Ol
+ws
+HN
+HN
+HN
+dw
+qx
+qx
+qx
+Ba
+yZ
+fU
+Hd
+fU
+yf
+EK
+jk
+"}
+(8,1,1) = {"
+qx
+qx
+Aa
+qx
+Mi
+ws
+PW
+OO
+gY
+gY
+Zj
+QN
+gY
+bO
+bO
+bO
+bO
+WP
+dw
+HN
+nI
+zX
+zX
+zX
+MT
+hH
+Vx
+ws
+Hd
+KP
+kp
+qx
+PS
+yZ
+"}
+(9,1,1) = {"
+Ol
+dw
+Ol
+ws
+uc
+EZ
+qt
+gY
+gY
+mh
+sr
+Ru
+gY
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+XE
+yJ
+ws
+ws
+eF
+qx
+Eo
+qx
+Wl
+ky
+VV
+ws
+ws
+yZ
+"}
+(10,1,1) = {"
+ws
+Ol
+mR
+cT
+Xo
+Kj
+ws
+gY
+Hk
+YR
+Ji
+xA
+gY
+gQ
+WG
+qd
+gO
+ef
+rN
+jb
+XE
+XE
+HV
+HV
+HV
+zv
+qx
+hL
+fb
+VV
+OO
+ws
+yZ
+yZ
+"}
+(11,1,1) = {"
+yJ
+qx
+ws
+ws
+ws
+Fs
+ws
+gY
+AJ
+uj
+nT
+Qf
+gY
+zM
+Ai
+XE
+Ya
+pF
+RD
+ii
+fE
+XE
+OJ
+DF
+HV
+HV
+HN
+xM
+ws
+ws
+ws
+yZ
+yZ
+yZ
+"}
+(12,1,1) = {"
+yZ
+ws
+dw
+ye
+yd
+qY
+ad
+gY
+gY
+gY
+gY
+Df
+gY
+XE
+vJ
+XE
+Zo
+xC
+wu
+bg
+Lu
+XE
+jN
+cf
+WJ
+HV
+LJ
+HN
+wT
+OO
+ws
+yZ
+yZ
+yZ
+"}
+(13,1,1) = {"
+yZ
+yd
+dw
+dJ
+pC
+ws
+ws
+cA
+gY
+pB
+gY
+sQ
+qh
+gY
+XE
+XE
+XE
+wo
+uh
+yh
+fi
+fi
+pq
+CD
+HV
+HV
+Tl
+hh
+ws
+OO
+OO
+yZ
+yZ
+yZ
+"}
+(14,1,1) = {"
+yZ
+qx
+qx
+ws
+Bi
+ws
+OC
+pi
+gY
+UX
+Aq
+tt
+Uj
+gY
+Kk
+zU
+bs
+Ev
+ov
+mo
+fi
+FA
+kP
+dk
+DC
+fi
+ib
+Kh
+ws
+HN
+ws
+yZ
+yZ
+yZ
+"}
+(15,1,1) = {"
+yZ
+qx
+Ol
+ye
+Gk
+zv
+OC
+Xd
+gY
+pZ
+gY
+GL
+lG
+gY
+OE
+At
+bs
+Ax
+WX
+tK
+CO
+WN
+Ik
+KJ
+xu
+hF
+ZB
+Xs
+Cg
+HN
+jk
+OO
+yZ
+yZ
+"}
+(16,1,1) = {"
+yZ
+yZ
+yd
+TT
+ws
+yJ
+OC
+eW
+gY
+gY
+gY
+kz
+rG
+gY
+Lm
+WQ
+bs
+DE
+EH
+tK
+fi
+rt
+Dc
+hJ
+it
+hF
+LO
+Kh
+ws
+HN
+ws
+OO
+yZ
+yZ
+"}
+(17,1,1) = {"
+yZ
+yZ
+ws
+ws
+ws
+ws
+OC
+zB
+sL
+OC
+BS
+oA
+Ls
+px
+rd
+ur
+bs
+hb
+JI
+ZF
+Sp
+jq
+cS
+Ot
+Ge
+hF
+LO
+ws
+Kh
+ws
+ws
+Ol
+yZ
+yZ
+"}
+(18,1,1) = {"
+yZ
+yZ
+yJ
+ws
+yd
+OC
+OC
+zB
+yj
+OC
+ig
+fj
+cY
+Pp
+bN
+OG
+ym
+bj
+ej
+Zd
+fi
+JZ
+HY
+cI
+fi
+fi
+ZB
+eF
+HN
+jk
+ws
+Ol
+Jg
+yZ
+"}
+(19,1,1) = {"
+yZ
+SO
+dO
+qx
+ws
+OC
+hg
+tf
+QI
+OC
+YH
+oL
+Hz
+ha
+Mk
+yR
+bs
+NU
+CI
+Hb
+fi
+fi
+fi
+fi
+fi
+Sl
+Rv
+Oj
+HN
+ws
+yd
+PS
+Ol
+yZ
+"}
+(20,1,1) = {"
+yZ
+dw
+Wl
+qx
+yJ
+OC
+OW
+wN
+Te
+OC
+Za
+il
+jS
+OU
+LA
+kY
+Yj
+Nf
+dp
+QZ
+Kc
+TG
+zN
+Nn
+ey
+ws
+HN
+HN
+HN
+ws
+ws
+PS
+ws
+yZ
+"}
+(21,1,1) = {"
+yZ
+cO
+VV
+TK
+ws
+OC
+aX
+ZL
+Wx
+OC
+GR
+uV
+ic
+Co
+og
+Bh
+bs
+hj
+Xt
+oK
+wo
+KM
+JV
+wo
+OV
+ws
+ws
+qt
+ws
+yJ
+ws
+QG
+OO
+ws
+"}
+(22,1,1) = {"
+yZ
+cO
+VV
+qx
+Ol
+OC
+OC
+VU
+OC
+OC
+xa
+xa
+XZ
+xa
+xa
+nH
+nH
+nH
+sI
+nH
+nH
+wo
+wo
+wo
+ws
+en
+eF
+Kw
+cX
+ws
+Kw
+yd
+zv
+OO
+"}
+(23,1,1) = {"
+yZ
+OO
+VV
+qx
+qx
+OC
+lD
+NI
+pX
+OC
+xF
+qr
+SU
+Rz
+hf
+nH
+bX
+qV
+mk
+VX
+mD
+nH
+Kw
+ws
+ws
+ik
+vs
+zK
+yd
+Kw
+ws
+yd
+ws
+ws
+"}
+(24,1,1) = {"
+yZ
+yZ
+cO
+dw
+dw
+OC
+WA
+Vn
+sm
+uu
+sf
+Eg
+Jq
+lA
+kL
+nH
+Hf
+Wd
+tE
+pk
+ki
+nH
+ws
+ws
+ws
+Oq
+yd
+ug
+ST
+yJ
+ws
+ws
+ws
+yd
+"}
+(25,1,1) = {"
+yZ
+yZ
+VV
+cO
+cO
+OC
+OC
+ve
+sF
+OC
+Oh
+qe
+GQ
+us
+hk
+nH
+nH
+Lr
+me
+Ft
+nH
+nH
+ws
+yJ
+hh
+ws
+Qx
+kJ
+uC
+tL
+qq
+qx
+yZ
+yZ
+"}
+(26,1,1) = {"
+yZ
+yZ
+Aa
+cO
+cO
+qa
+OC
+OC
+OC
+OC
+xa
+xa
+xa
+kZ
+kZ
+nH
+nH
+nH
+nH
+nH
+nH
+zv
+ws
+hh
+qt
+ws
+TK
+VV
+fU
+OO
+ws
+yZ
+yZ
+yZ
+"}
+(27,1,1) = {"
+yZ
+yZ
+yZ
+OO
+mN
+gG
+fU
+ws
+ws
+ws
+qx
+VV
+ws
+Rn
+Rq
+VV
+XR
+jr
+ZG
+ZG
+Wj
+Wj
+Pq
+qx
+ws
+yJ
+TK
+gu
+OO
+OO
+yZ
+yZ
+yZ
+yZ
+"}
+(28,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+Au
+KP
+VV
+fU
+ws
+qx
+VV
+VV
+qx
+VV
+VV
+Tz
+yc
+qx
+qx
+Kw
+Rl
+Rl
+zH
+TV
+PX
+TK
+Sz
+OO
+KP
+qx
+yZ
+yZ
+yZ
+yZ
+"}
+(29,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+LG
+KP
+KP
+VV
+yc
+ws
+bn
+qx
+UO
+ws
+ws
+ys
+HN
+ws
+Ea
+ws
+iW
+fI
+gl
+dw
+Xc
+KP
+KP
+KP
+KP
+fU
+yZ
+yZ
+yZ
+yZ
+"}
+(30,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+VV
+OO
+KP
+UO
+qx
+ws
+qx
+qx
+ws
+ws
+HN
+HN
+HN
+ws
+lq
+Ny
+qx
+qx
+qx
+dw
+qx
+iN
+VV
+fU
+iN
+yZ
+yZ
+yZ
+yZ
+yZ
+"}
+(31,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+OO
+KP
+Au
+Au
+Au
+OO
+qx
+qx
+yJ
+ws
+ws
+ws
+ws
+Aa
+dw
+Rl
+yZ
+yZ
+yZ
+TV
+yZ
+ws
+yd
+iN
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+"}
+(32,1,1) = {"
+yZ
+yZ
+yZ
+yZ
+yZ
+OO
+OO
+Au
+Au
+Gs
+dw
+qx
+qx
+yZ
+ws
+ws
+ws
+dw
+dw
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+yZ
+"}

--- a/mod_celadon/maps/code/ruins/ruin.dm
+++ b/mod_celadon/maps/code/ruins/ruin.dm
@@ -386,6 +386,20 @@
 	suffix = "jungle_surface_ninjashrine.dmm"
 	cost = 2
 
+/datum/map_template/ruin/jungle/serene_hunt
+	name = "Serene Hunt"
+	id = "senere_hunt"
+	description = "Serene Outdoor's premier hunting resort and outlet. Well, it was until all the animals got out anyways."
+	suffix = "jungle_serene_hunts.dmm"
+	cost = 4
+
+	/datum/map_template/ruin/jungle/ramzi_base	//Оффовская ремапнутая Syndicate
+	name = "Ramzi Base"
+	id = "razmi_base"
+	description = "An ICW-era nuclear bunker formerly operated by Ramzi Clique."
+	suffix = "jungle_surface_ramzi.dmm"
+	cost = 3
+
 //							///
 //		MARK: Lavaland
 //							///


### PR DESCRIPTION
## Описание / Что этот PR делает
Перенос оффовских руин для джунглей.
## Причина создания ПР / Почему это хорошо для игры
Крутые руины, крутые ремапы старых руин, хорошие сделанные руины.
## Демонстрация изменений / Тестирование
<img width="3424" height="1696" alt="image" src="https://github.com/user-attachments/assets/812a0e89-223d-4a55-84e7-36c71dca5b32" />
<img width="1024" height="1088" alt="image" src="https://github.com/user-attachments/assets/e7c6cc29-3075-40e4-8800-3a7510567eba" />
<img width="1760" height="2240" alt="image" src="https://github.com/user-attachments/assets/5282f292-323d-40e2-8536-c00ef999c24f" />

## Список изменений

```yml
🆑
map: Добавляет Serene Hunts, Ramzi Base (ремап Syndicate), ремап Frontiersmen Cave
/🆑
```
