### PR TITLE
TWEAK: Select Equipment sort Ship Outfits

### DIFF
--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -141,7 +141,8 @@
 		cached_outfits = list()
 		cached_outfits += list(outfit_entry("General", /datum/outfit, "Naked", priority=TRUE))
 		cached_outfits += make_outfit_entries("General", subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman))
-		cached_outfits += make_outfit_entries("Jobs", typesof(/datum/outfit/job))
+		cached_outfits += make_outfit_entries("Ship Outfits", typesof(/datum/outfit/job/cel))						// [CELADON-EDIT] - SHIP_JOBS
+		cached_outfits += make_outfit_entries("Jobs", typesof(/datum/outfit/job) - typesof(/datum/outfit/job/cel))	// [/CELADON-EDIT]
 		cached_outfits += make_outfit_entries("Plasmamen Outfits", typesof(/datum/outfit/plasmaman))
 
 	data["outfits"] = cached_outfits


### PR DESCRIPTION
## Описание / Что этот PR делает
Сортирует аутфиты кораблей от общих что есть в билде в Select Equipment

## Причина создания ПР / Почему это хорошо для игры
Более практично для разработчиков потестить свои же аутфиты, а маперам проверить не допустили ли ошибку при добавлении корабля с ролями.

## Демонстрация изменений / Тестирование
<img width="387" height="103" alt="image" src="https://github.com/user-attachments/assets/5f8b55f2-6813-4df1-b5e1-4e7535ae794e" />

## Список изменений

```yml
🆑
tweak: Улучшение сортировки в Select Equipment 
admin: Сортировка ролей в Select Equipment
/🆑
```
