### PR TITLE
FIX: Pistol caliber amount changes + 8x58

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_stacks/prefab_stacks/premade_pistol_stacks.dm
@@ -11,7 +11,7 @@
 /obj/item/storage/box/ammo/c10mm/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/surplus
@@ -26,7 +26,7 @@
 /obj/item/storage/box/ammo/c10mm_surplus/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/ap
@@ -40,7 +40,7 @@
 /obj/item/storage/box/ammo/c10mm_ap/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/ap = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/ap = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/hp
@@ -54,7 +54,7 @@
 /obj/item/storage/box/ammo/c10mm_hp/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/hp = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/rubber
@@ -68,7 +68,7 @@
 /obj/item/storage/box/ammo/c10mm_rubber/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/rubber = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c10mm/rubber = 4)
 	generate_items_inside(items_inside,src)
 
 // 9x18mm (Commander + SABR)
@@ -85,7 +85,7 @@
 /obj/item/storage/box/ammo/c9mm/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/surplus
@@ -99,7 +99,7 @@
 
 /obj/item/storage/box/ammo/c9mm_surplus/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/surplus = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/surplus = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/ap
@@ -113,7 +113,7 @@
 /obj/item/storage/box/ammo/c9mm_ap/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/ap = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/ap = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/hp
@@ -127,7 +127,7 @@
 /obj/item/storage/box/ammo/c9mm_hp/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/hp = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/rubber
@@ -141,7 +141,7 @@
 /obj/item/storage/box/ammo/c9mm_rubber/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/rubber = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c9mm/rubber = 4)
 	generate_items_inside(items_inside,src)
 
 // .45 (Candor + C20R)
@@ -157,7 +157,7 @@
 /obj/item/storage/box/ammo/c45/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45 = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45 = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/surplus
@@ -172,7 +172,7 @@
 /obj/item/storage/box/ammo/c45_surplus/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/surplus = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/surplus = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/ap
@@ -186,7 +186,7 @@
 /obj/item/storage/box/ammo/c45_ap/PopulateContents()
 	..()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/ap = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/ap = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/hp
@@ -199,7 +199,7 @@
 
 /obj/item/storage/box/ammo/c45_hp/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/hp = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/rubber
@@ -212,7 +212,7 @@
 
 /obj/item/storage/box/ammo/c45_rubber/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/rubber = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c45/rubber = 4)
 	generate_items_inside(items_inside,src)
 
 // .22 LR (Himehabu, Pounder)
@@ -228,7 +228,7 @@
 
 /obj/item/storage/box/ammo/c22lr/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/ap
@@ -242,7 +242,7 @@
 
 /obj/item/storage/box/ammo/c22lr/ap/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/ap = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/ap = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/hp
@@ -256,7 +256,7 @@
 
 /obj/item/storage/box/ammo/c22lr/hp/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/hp = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/rubber
@@ -270,7 +270,7 @@
 
 /obj/item/storage/box/ammo/c22lr/rubber/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/rubber = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c22lr/rubber = 4)
 	generate_items_inside(items_inside,src)
 
 // .357
@@ -285,7 +285,7 @@
 
 /obj/item/storage/box/ammo/a357/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357 = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357 = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/match
@@ -298,7 +298,7 @@
 
 /obj/item/storage/box/ammo/a357_match/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/match = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/match = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/hp
@@ -311,7 +311,7 @@
 
 /obj/item/storage/box/ammo/a357_hp/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a357/hp = 4)
 	generate_items_inside(items_inside,src)
 
 // .45-70 (Hunting Revolver, Beacon)
@@ -327,7 +327,7 @@
 
 /obj/item/storage/box/ammo/a4570/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570 = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570 = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/match
@@ -340,7 +340,7 @@
 
 /obj/item/storage/box/ammo/a4570_match/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/match = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/match = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/hp
@@ -353,7 +353,7 @@
 
 /obj/item/storage/box/ammo/a4570_hp/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/hp = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/hp = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/explosive
@@ -366,7 +366,7 @@
 
 /obj/item/storage/box/ammo/a4570_explosive/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/explosive = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/a4570/explosive = 4)
 	generate_items_inside(items_inside,src)
 
 // .38 Special
@@ -382,7 +382,7 @@
 
 /obj/item/storage/box/ammo/c38/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c38 = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c38 = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c38/surplus
@@ -396,7 +396,7 @@
 
 /obj/item/storage/box/ammo/c38_surplus/PopulateContents()
 	var/static/items_inside = list(
-		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c38/surplus = 3)
+		/obj/item/ammo_box/magazine/ammo_stack/prefilled/c38/surplus = 4)
 	generate_items_inside(items_inside,src)
 
 /obj/item/ammo_box/magazine/ammo_stack/prefilled/c38/trac

--- a/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -104,21 +104,6 @@ MARK: 5.56x45
 	ammo_type = /obj/item/ammo_casing/a308/surplus
 	max_ammo = 10
 
-//
-// MARK: 8x58
-//
-
-//Стандартные безгильзовые патроны калибра 8x58
-
-/obj/item/ammo_box/magazine/ammo_stack/prefilled/a858
-	ammo_type = /obj/item/ammo_casing/caseless/a858
-	max_ammo = 10
-
-/obj/item/storage/box/ammo/a858_ammo_box
-	name = "Ammo box (8x58mm Caseless)"
-	desc = "A box of standard 8x58mm ammo."
-	icon = 'mod_celadon/_storage_icons/icons/items/weapons/ammo/ammo.dmi'
-	icon_state = "a858box"
 
 //
 // MARK: 410x76


### PR DESCRIPTION
## Описание / Что этот PR делает
Данный ПР обновляет кор-код, подтягивая изменения (но не включает ПР shiptest-ss13#5788)
9 мм, 10 мм, .45, .45-70, .38 теперь имеют 4 стака патронов в коробке. Пистолетные калибры теперь живы, а не являются одними из самих дорогих патронов... По приколу.
+ фиксит пустую коробку 8x58 путем её удаления. И уменьшает кол-во патронов в стаке с 10 до 5, урезая кол-во с коробки 8x58 с 40 до 20.

## Причина создания ПР / Почему это хорошо для игры
Пистолетные калибры жуть как сосали. Обновить код хорошо. Удалить что-то ненужное тоже хорошо. Спрайтик лишь жалко.
## Демонстрация изменений / Тестирование
Локалка компилится. Карты вроде как не затронуты, ибо коробок не было. Значит все окей.

## Список изменений

```yml
🆑
del: удаляет пустую коробку 8x58 из игры. 
balance: 9 мм, 10 мм, .45, .45-70, .38 теперь имеют 4 стака патронов в коробке. 8x58 40 -> 20 в коробке. 
balance: Стак патронов теперь по 5 пуль, а не по 10.
/🆑
```
