### PR TITLE
REBALANCE: Tiered thrusters fixes and rebalance

### DIFF
--- a/code/game/machinery/shuttle/shuttle_engine_types.dm
+++ b/code/game/machinery/shuttle/shuttle_engine_types.dm
@@ -121,7 +121,7 @@
 	// fuel_use = 80
 	// thrust = 15 // CELADON-EDIT - ORIGINAL
 	fuel_use = 80
-	thrust = 5
+	thrust = 8
 	// [/CELADON-EDIT] - кто вообще видел эти движки в игре ???
 	//All fuel code already handled
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1135,7 +1135,10 @@
 	id = "basic_shuttle"
 	display_name = "Basic Shuttle Research"
 	description = "Research the technology required to create and use basic shuttles."
-	prereq_ids = list("bluespace_travel", "adv_engi")
+	// [CELADON-EDIT] - CELADON_BALANCE - Трогаем РнД ещё раз
+	// prereq_ids = list("bluespace_travel", "adv_engi")
+	prereq_ids = list("bluespace_basic","regulated_bluespace", "engineering")
+	// [/CELADON-EDIT]
 	design_ids = list("engine_plasma", "engine_fire", "engine_ion", "engine_heater", "engine_fire_heater", "engine_smes", "shuttle_helm", "rapid_shuttle_designator")
 	// [CELADON-EDIT] - CELADON_BALANCE - Трогаем РнД
 	// research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000) // CELADON-EDIT - ORIGINAL
@@ -1148,15 +1151,10 @@
 	id = "exp_shuttle"
 	display_name = "Experimental Shuttle Research"
 	description = "A bunch of engines and related shuttle parts that are likely not really that useful, but could be in strange situations."
-	// [CELADON-EDIT] - CELADON_BALANCE - Трогаем РнД
-	// prereq_ids = list("basic_shuttle") // CELADON-EDIT - ORIGINAL
-	prereq_ids = list("t3_ion")
+	prereq_ids = list("basic_shuttle")
 	design_ids = list("engine_expulsion")
-	// research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000) // CELADON-EDIT - ORIGINAL
-	// export_price = 2500 // CELADON-EDIT - ORIGINAL
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
-	export_price = 7500
-	// [/CELADON-EDIT]
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 2500
 
 ////////////////////// IPC Parts ///////////////////////
 /datum/techweb_node/ipc_organs

--- a/mod_celadon/balance/code/engine/circuits.dm
+++ b/mod_celadon/balance/code/engine/circuits.dm
@@ -1,17 +1,17 @@
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech1
 	name = "1st gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech1
-	req_components = list(/obj/item/stock_parts/capacitor = 2,
-		/obj/item/stock_parts/micro_laser = 2)
+	req_components = list(/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/micro_laser = 3)
 
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech2
 	name = "2nd gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech2
-	req_components = list(/obj/item/stock_parts/capacitor = 2,
-		/obj/item/stock_parts/micro_laser = 2)
+	req_components = list(/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/micro_laser = 3)
 
 /obj/item/circuitboard/machine/shuttle/engine/electric/tech3
 	name = "3rd gen Ion Thruster (Machine Board)"
 	build_path = /obj/machinery/power/shuttle/engine/electric/tech3
-	req_components = list(/obj/item/stock_parts/capacitor = 2,
-		/obj/item/stock_parts/micro_laser = 2)
+	req_components = list(/obj/item/stock_parts/capacitor = 3,
+		/obj/item/stock_parts/micro_laser = 3)

--- a/mod_celadon/balance/code/engine/enginebalance.dm
+++ b/mod_celadon/balance/code/engine/enginebalance.dm
@@ -8,7 +8,8 @@
 */
 /obj/machinery/power/shuttle/engine/electric/tech1
 	name = "1st gen ion thruster"
-	desc = "A thruster that expels charged particles to generate thrust."
+	desc = "An overclocked thruster that generates 1.5 times more thrust than regular with increased energy consumption. Like other thrusters, it can be upgraded with stock parts to improve efficiency. \n\
+		Don't forget to increase the power output of the precharger to get all its power."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech1
 	icon_state = "tech1"
 	icon_state_off = "tech1_off"
@@ -19,7 +20,8 @@
 
 /obj/machinery/power/shuttle/engine/electric/tech2
 	name = "2nd gen ion thruster"
-	desc = "A thruster that expels charged particles to generate thrust."
+	desc = "An advanced thruster that generates 1.75 times more thrust than regular with increased energy consumption. Like other thrusters, it can be upgraded with stock parts to improve efficiency. \n\
+		Don't forget to increase the power output of the precharger to get all its power."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech2
 	icon_state = "tech2"
 	icon_state_off = "tech2_off"
@@ -31,7 +33,8 @@
 
 /obj/machinery/power/shuttle/engine/electric/tech3
 	name = "3rd gen ion thruster"
-	desc = "A thruster that expels charged particles to generate thrust."
+	desc = "A highly-advanced thruster that expels charged particles to generate 2 times more thrust. Like other thrusters, it can be upgraded with stock parts to improve efficiency. \n\
+		Don't forget to increase the power output of the precharger to get all its power."
 	circuit = /obj/item/circuitboard/machine/shuttle/engine/electric/tech3
 	icon_state = "tech3"
 	icon_state_off = "tech3_off"

--- a/mod_celadon/balance/code/engine/enginebalance.dm
+++ b/mod_celadon/balance/code/engine/enginebalance.dm
@@ -1,7 +1,7 @@
 /*
 /obj/machinery/power/shuttle/engine/electric
 После пра оффов эффективность двигателя стала зависеть от деталей внутри https://github.com/shiptest-ss13/Shiptest/pull/5441
-У премиумных двигателей т3 детали, но обычная плата
+У премиумных двигателей т3 детали, но обычная плата. Имеют в стоке т3, т.е. у них 16 траста
 В стоке сейчас у обычных ионных thrust = 4
 С т3 деталями у обычного ионного thrust = 12
 В целом, т2 и т3 не встречаются, а их никто нормально не балансил в РнД, но чтобы их забалансить нужно трогать все РнД.
@@ -14,8 +14,8 @@
 	icon_state_off = "tech1_off"
 	icon_state_closed = "tech1"
 	icon_state_open = "tech1_open"
-	thrust = 5 // с т2 10, с т3 15, с т4 20. Премиум имеют в стоке т3, т.е. у них
-	power_per_burn = 50000
+	thrust = 6 // с т2 12, с т3 18, с т4 24.
+	power_per_burn = 75000 // 50000*1.5
 
 /obj/machinery/power/shuttle/engine/electric/tech2
 	name = "2nd gen ion thruster"
@@ -25,7 +25,7 @@
 	icon_state_off = "tech2_off"
 	icon_state_closed = "tech2"
 	icon_state_open = "tech2_open"
-	thrust = 6 // с т2 12, с т3 18, с т4 24
+	thrust = 7 // с т2 14, с т3 21, с т4 28
 	// Мы же знаем, что никто из игроков не знает про фичу того, что можно увеличить вывод в СМЕСе и получать их истинный траст?
 	power_per_burn = 100000 // 50000*2
 

--- a/mod_celadon/balance/code/engine/enginebalance.dm
+++ b/mod_celadon/balance/code/engine/enginebalance.dm
@@ -1,3 +1,11 @@
+/*
+/obj/machinery/power/shuttle/engine/electric
+После пра оффов эффективность двигателя стала зависеть от деталей внутри https://github.com/shiptest-ss13/Shiptest/pull/5441
+У премиумных двигателей т3 детали, но обычная плата
+В стоке сейчас у обычных ионных thrust = 4
+С т3 деталями у обычного ионного thrust = 12
+В целом, т2 и т3 не встречаются, а их никто нормально не балансил в РнД, но чтобы их забалансить нужно трогать все РнД.
+*/
 /obj/machinery/power/shuttle/engine/electric/tech1
 	name = "1st gen ion thruster"
 	desc = "A thruster that expels charged particles to generate thrust."
@@ -6,8 +14,8 @@
 	icon_state_off = "tech1_off"
 	icon_state_closed = "tech1"
 	icon_state_open = "tech1_open"
-	thrust = 6
-	power_per_burn = 35000
+	thrust = 5 // с т2 10, с т3 15, с т4 20. Премиум имеют в стоке т3, т.е. у них
+	power_per_burn = 50000
 
 /obj/machinery/power/shuttle/engine/electric/tech2
 	name = "2nd gen ion thruster"
@@ -17,8 +25,9 @@
 	icon_state_off = "tech2_off"
 	icon_state_closed = "tech2"
 	icon_state_open = "tech2_open"
-	thrust = 11
-	power_per_burn = 100000
+	thrust = 6 // с т2 12, с т3 18, с т4 24
+	// Мы же знаем, что никто из игроков не знает про фичу того, что можно увеличить вывод в СМЕСе и получать их истинный траст?
+	power_per_burn = 100000 // 50000*2
 
 /obj/machinery/power/shuttle/engine/electric/tech3
 	name = "3rd gen ion thruster"
@@ -28,5 +37,5 @@
 	icon_state_off = "tech3_off"
 	icon_state_closed = "tech3"
 	icon_state_open = "tech3_open"
-	thrust = 30
-	power_per_burn = 250000
+	thrust = 8 // с т2 16, с т3 24, с т4 32.
+	power_per_burn = 150000 // 50000*3

--- a/mod_celadon/balance/code/engine/rnd.dm
+++ b/mod_celadon/balance/code/engine/rnd.dm
@@ -38,7 +38,7 @@
 	id = "t2_ion"
 	display_name = "Second generation ion Propulsion"
 	description = "Upgrade to Second Gen ion engines for advanced cosmic navigation."
-	prereq_ids = list("adv_power","emp_adv","high_efficiency","practical_bluespace","t1_ion")
+	prereq_ids = list("adv_power","emp_adv","high_efficiency","bluespace_travel","t1_ion")
 	design_ids = list("engine_ion_t2")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 7500

--- a/mod_celadon/balance/code/engine/rnd.dm
+++ b/mod_celadon/balance/code/engine/rnd.dm
@@ -20,7 +20,7 @@
 	name = "Machine Design (Ion Thruster Board) 3nd generation"
 	desc = "The circuit board for an 3nd generation ion thruster."
 	id = "engine_ion_t3"
-	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/bluespace = 1000, /datum/material/silver = 2000,/datum/material/diamond = 1500)
+	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/bluespace = 1000, /datum/material/silver = 2000, /datum/material/diamond = 1500)
 	build_path = /obj/item/circuitboard/machine/shuttle/engine/electric/tech3
 	category = list ("Shuttle Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -28,8 +28,8 @@
 /datum/techweb_node/t1_shuttle_tech
 	id = "t1_ion"
 	display_name = "First generation ion Propulsion"
-	description = "Pioneer space travel with First Gen ion engines—where it all began."
-	prereq_ids = list("basic_shuttle")
+	description = "Pioneer space travel with First Gen prototype ion engines."
+	prereq_ids = list("practical_bluespace","adv_engi","basic_shuttle")
 	design_ids = list("engine_ion_t1")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
@@ -38,7 +38,7 @@
 	id = "t2_ion"
 	display_name = "Second generation ion Propulsion"
 	description = "Upgrade to Second Gen ion engines for advanced cosmic navigation."
-	prereq_ids = list("t1_ion")
+	prereq_ids = list("adv_power","emp_adv","high_efficiency","practical_bluespace","t1_ion")
 	design_ids = list("engine_ion_t2")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	export_price = 7500
@@ -47,7 +47,7 @@
 	id = "t3_ion"
 	display_name = "Third generation ion Propulsion"
 	description = "Unleash ultimate exploration with Third Gen ion propulsion."
-	prereq_ids = list("t2_ion")
+	prereq_ids = list("bluespace_power","micro_bluespace","emp_super","anomaly_research","t2_ion","exp_shuttle")
 	design_ids = list("engine_ion_t3")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 10000

--- a/mod_celadon/balance/code/engine/rnd.dm
+++ b/mod_celadon/balance/code/engine/rnd.dm
@@ -27,8 +27,8 @@
 
 /datum/techweb_node/t1_shuttle_tech
 	id = "t1_ion"
-	display_name = "First generation ion Propulsion"
-	description = "Pioneer space travel with First Gen prototype ion engines."
+	display_name = "First Generation Ion Propulsion"
+	description = "Overclocked thrusters with higher propulsion and energy consumption. Further upgrades can increase its potential using standard stock parts."
 	prereq_ids = list("practical_bluespace","adv_engi","basic_shuttle")
 	design_ids = list("engine_ion_t1")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
@@ -36,8 +36,8 @@
 
 /datum/techweb_node/t2_shuttle_tech
 	id = "t2_ion"
-	display_name = "Second generation ion Propulsion"
-	description = "Upgrade to Second Gen ion engines for advanced cosmic navigation."
+	display_name = "Second Generation Ion Propulsion"
+	description = "Unlocks advanced ion thrusters with significantly higher propulsion as well as energy consumption. Further upgrades can increase its potential using standard stock parts."
 	prereq_ids = list("adv_power","emp_adv","high_efficiency","bluespace_travel","t1_ion")
 	design_ids = list("engine_ion_t2")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
@@ -45,8 +45,8 @@
 
 /datum/techweb_node/t3_shuttle_tech
 	id = "t3_ion"
-	display_name = "Third generation ion Propulsion"
-	description = "Unleash ultimate exploration with Third Gen ion propulsion."
+	display_name = "Third Generation Ion Propulsion"
+	description = "Research into next-generation ion propulsion systems. Enables the construction of incredibly potent ion drives with extreme power draw. Further upgrades can increase its potential using standard stock parts."
 	prereq_ids = list("bluespace_power","micro_bluespace","emp_super","anomaly_research","t2_ion","exp_shuttle")
 	design_ids = list("engine_ion_t3")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)


### PR DESCRIPTION
## Описание / Что этот PR делает
Режет двигатели, фиксит их неполную силу, позволяет нормально ставить в них детали и получать от этого бонус к мощности.
Изменяет РнД-прогрессию по двигателям, делая её более плавной.
Кратко: режет изначальный траст тирным двигателям, но при этом позволяет тирным двигателям нормально взаимодействовать с запчастями, выводя их траст на новый уровень.
Данный реворк направлен на то, чтобы сохранить текущий баланс двигателей (хотя интересным его не назвать - я бы подвинул базовую возможную скорость кораблей чуть выше, с 4 до 5 тяги у ионок).
Базовое изучение шаттлов смещено сильно вниз по ветке, используя популярные направления + одну дополнительную технологию.
Это позволит инженерным кораблям восстанавливать двигатели или строить новые почти сразу после их появления (правда, очки РнД всё ещё остаются ограничивающим фактором). Но это не так критично, поскольку место тоже является ограничением.
Если попытаться предсказать, Т1 трастер, возможно, станет одним из самых популярных вариантов из-за близости к популярным веткам исследований (хотя Advanced Engineering популярным не назвать).
Т2 и, в особенности, Т3 становятся доступны только тогда, когда у игроков уже много очков РнД, а это значит, что у них есть ксеносы или зомби для диссекции.
И хотя сильный скейл РнД-очков сейчас редкость из-за редких руин с зомби, Т2 всё ещё будет в два раза дешевле Т3. Но обычно РнД-скачок происходит именно тогда, когда появляется сильный скейл, потому что РнД зачастую находится на двух границах получения очков: либо ты часами лутаешь крохи, либо находишь одну руину и получаешь огромное количество очков.
### Характеристики
Т1 ионный: 
- thrust = 6 // с т2 деталями 12, с т3 18, с т4 24.
- power_per_burn = 75000 // 50000*1.5
Требуется ставить в precharger выше отдачу до 75 KW

Т2 ионный: 
- thrust = 7 // с т2 14, с т3 21, с т4 28.
- power_per_burn = 100000 // 50000*2
Требуется ставить в precharger выше отдачу до 100 KW

Т3 ионный: 
- thrust = 8 // с т2 16, с т3 24, с т4 32.
- power_per_burn = 150000 // 50000*3
Требуется ставить в precharger выше отдачу до 150 KW

### Мапперам
Не бойтесь теперь ставить их на корабли (кроме как т3 ионных, пожалуй, но это зависит от вас), ибо их прогрессия теперь больше зависит от деталей. Сейчас премиумные двигатели идут с т3 запчастями в стоке. Ставить тирные двигатели из РнД лучше, т.к. те дают меньше траста, но в теории могут быть разогнаны деталями. В целом, развитие корабля зависит больше от вас.
## Причина создания ПР / Почему это хорошо для игры
Фиксы это хорошо. 
Данный ПР делает развитие двигателей в РнД более интересным, т.к. позволяет более интересный инженерный геймплей с участием двигателей через более плавную прогрессию по ионным двигателям вместо раша до т3 двигателя, ибо те все находились в одной ветке ПОДРЯД.
## Демонстрация изменений / Тестирование
Скриншоты требований двигателей
### Базовое исследование

<img width="855" height="575" alt="image" src="https://github.com/user-attachments/assets/3d5f9d19-484b-458a-9430-d621009f4818" />

### Т1 ионные

<img width="875" height="536" alt="image" src="https://github.com/user-attachments/assets/cd51c59d-2d6d-4342-b6e8-2f0f5d7e98e0" />

### Т2 ионные

<img width="670" height="592" alt="image" src="https://github.com/user-attachments/assets/8884f735-c240-4803-bd4c-b8a400381a19" />

### Т3 ионные

<img width="451" height="681" alt="image" src="https://github.com/user-attachments/assets/cbc1bfcd-7783-40b1-b021-a3b7988f0830" />


## Список изменений

```yml
🆑
balance: Уменьшает total thrust для тирных двигателей. Меняет значение кол-ва деталей в них с 2 до 3. Изменены их ветки в РнД, выстраивая более плавную прогрессию по ним. Уменьшает им изначальный thrust с т1 деталями. Баффает expulsion thruster, поднимая ему траст с 5 до 8.
fix: Кривое значение thrust из-за некорректного числа деталей в двигателях.
/🆑
```
