### PR TITLE
RETURN: Goliath Mother - boom death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -216,6 +216,14 @@
 		visible_message(span_warning("[src] digs one of its tentacles under [target]!"))
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(tturf, src)
 
+// [CELADON-ADD] - Возвращает взрыв маленьким голиафам
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/death()
+	. = ..()
+	visible_message(span_warning("[src] explodes!"))
+	explosion(get_turf(loc),0,0,0,flame_range = 3, adminlog = FALSE)
+	gib()
+// [CELADON-ADD]
+
 //Tentacles have less stun time compared to regular variant, to balance being able to use them much more often.  Also, 10 more damage.
 /obj/effect/temp_visual/goliath_tentacle/broodmother/trip()
 	var/latched = FALSE


### PR DESCRIPTION
## Описание / Что этот PR делает
Возвращает взрыв маленьким голиафам, который был удален на Апстриме.

## Причина создания ПР / Почему это хорошо для игры
Без него их не гибает, делая бой с матерью голиафов очень простым.
Так как не создает повторно миньонов, пока лежат трупы прошлых которых не гибает после изменения.

## Список изменений

```yml
🆑
fix: Мелкие голиафы вновь создают взрывы после смерти
/🆑
```
