### PR TITLE
REVERT: Mining drill Ore - Hate vibe-coders, Cat-AI-fixes

### DIFF
--- a/code/modules/mining/ore_veins.dm
+++ b/code/modules/mining/ore_veins.dm
@@ -118,12 +118,6 @@ GLOBAL_LIST_EMPTY(ore_veins)
 	return ..()
 
 /obj/structure/vein/proc/begin_spawning()
-	// [CELADON-ADD] - CELADON_FIXES - FIXES_DRILLCLASS - Проверяем, не завершена ли миссия перед запуском спавна
-	if(istype(our_drill, /obj/machinery/drill/mission))
-		var/obj/machinery/drill/mission/mission_drill = our_drill
-		if(mission_drill.num_current >= mission_drill.num_wanted)
-			return
-	// [/CELADON-ADD]
 	currently_spawning = TRUE
 	START_PROCESSING(SSprocessing, src)
 
@@ -138,17 +132,6 @@ GLOBAL_LIST_EMPTY(ore_veins)
 /obj/structure/vein/process(seconds_per_tick)
 	if(!currently_spawning)
 		return
-	// [CELADON-ADD] - CELADON_FIXES - FIXES_DRILLCLASS - Проверяем, существует ли бур
-	if(!our_drill || QDELETED(our_drill))
-		stop_spawning()
-		return
-	// Дополнительная проверка для буров миссии
-	if(istype(our_drill, /obj/machinery/drill/mission))
-		var/obj/machinery/drill/mission/mission_drill = our_drill
-		if(mission_drill.num_current >= mission_drill.num_wanted)
-			stop_spawning()
-			return
-	// [/CELADON-ADD]
 	try_spawning_spawner()
 
 /obj/structure/vein/proc/try_spawning_spawner()
@@ -173,6 +156,8 @@ GLOBAL_LIST_EMPTY(ore_veins)
 /obj/structure/vein/proc/pick_tile(list/peel)
 	if(!length(peel))
 		peel = turf_peel(spawn_distance_max, spawn_distance_min, src, TRUE)
+	if(!length(peel))
+		return get_turf(src)
 	var/turf/open/spawning_tile
 	if(length(peel))
 		spawning_tile = pick(peel)
@@ -186,21 +171,9 @@ GLOBAL_LIST_EMPTY(ore_veins)
 	return spawning_tile
 
 /obj/structure/vein/proc/increment_wave_tally()
-	// [CELADON-EDIT] - CELADON_FIXES - FIXES_DRILLCLASS - Добавлена проверка QDELETED для защиты от удаленных буров
-	//if(!our_drill || !our_drill.active)
-	//	wave_tally = 0
-	//	return TRUE
-	if(!our_drill || QDELETED(our_drill) || !our_drill.active)
+	if(!our_drill || !our_drill.active)
 		wave_tally = 0
 		return TRUE
-
-	// Проверяем, не завершена ли миссия (для буров миссии)
-	if(istype(our_drill, /obj/machinery/drill/mission))
-		var/obj/machinery/drill/mission/mission_drill = our_drill
-		if(mission_drill.num_current >= mission_drill.num_wanted)
-			wave_tally = 0
-			return FALSE
-	// [/CELADON-EDIT]
 	wave_tally += 1
 	if(wave_tally > waves_per_break)
 		wave_tally = 0

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -247,6 +247,9 @@ CRUSHER_MARK_ON_MOBS
 FIXES_JELLY_BLOOD
 - EDIT, ADD: `code/modules/mob/living/carbon/human/species_types/jellypeople.dm` - Фиксим уровень крови здоровья
 
+FIXES_MOB_SPAWNER
+- REMOVE: `code/modules/mining/ore_veins.dm` - убраны селинги из спавнера Т3 бура в джунглях
+
 FIXES_CALL_TO_SHIP
 - ADD: `code/game/machinery/hologram.dm` - добавлено возвращение TRUE, чтобы интерфейс обновлялся
 

--- a/mod_celadon/fixes/README.md
+++ b/mod_celadon/fixes/README.md
@@ -247,9 +247,6 @@ CRUSHER_MARK_ON_MOBS
 FIXES_JELLY_BLOOD
 - EDIT, ADD: `code/modules/mob/living/carbon/human/species_types/jellypeople.dm` - Фиксим уровень крови здоровья
 
-FIXES_MOB_SPAWNER
-- REMOVE: `code/modules/mining/ore_veins.dm` - убраны селинги из спавнера Т3 бура в джунглях
-
 FIXES_CALL_TO_SHIP
 - ADD: `code/game/machinery/hologram.dm` - добавлено возвращение TRUE, чтобы интерфейс обновлялся
 

--- a/mod_celadon/fixes/_fixes.dme
+++ b/mod_celadon/fixes/_fixes.dme
@@ -39,7 +39,6 @@
 #include "code/weebstick.dm"
 #include "code/dynamic_datum.dm"
 #include "code/alternative_clothing.dm"
-#include "code/faction.dm"
 #include "code/dock_empty_space_fix.dm"
 #include "code/sledgehammer.dm"
 #include "code/hooded.dm"

--- a/mod_celadon/fixes/code/faction.dm
+++ b/mod_celadon/fixes/code/faction.dm
@@ -1,3 +1,0 @@
-// Даем фракцию для бура чтобы crew мобы его атаковали
-/obj/machinery/drill
-	var/list/faction = list("crew")


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет ошибку когда бур не мог найти место для спавна мобов, из-за чего они просто не спавнились и создавала рантайм.
> Нет это не фича, оно не выдает ошибки только из-за рекурсии вечно пытаясь найти место под спавн мобов.

## Причина создания ПР / Почему это хорошо для игры
Как же много мусора приходится выносить за вашими вайб-кодерами...
- revert: #2235 
> И ради этого нужно было выносить мне мозги неделю чтоб я залил это... Оно буквально ничего не делает...

## Список изменений

```yml
🆑
del: Вайб-кодеры с их вайб-кодом
fix: Если бур не найдет место под спавн
/🆑
```
