### PR TITLE
ADD: Spraycan (Баллончик с краской) - Позволяет перекрашивать одежду с инвентарем в харме

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -136,6 +136,9 @@
 		to_chat(user, span_notice("You fix the damage on [src] with [cloth]."))
 		return TRUE
 
+	if(istype(tool, /obj/item/toy/crayon/spraycan) && user.a_intent == INTENT_HARM)	// [CELADON-ADD] - Allows coloring clothes with spray can on harm intent
+		return																		// [/CELADON-ADD]
+
 	return ..()
 
 /obj/item/clothing/dropped(mob/user)


### PR DESCRIPTION
## Описание / Что этот PR делает
Spraycan (Баллончик с краской) - Позволяет перекрашивать одежду с инвентарем в харме

## Причина создания ПР / Почему это хорошо для игры
Больше проклятых цветов под перекрас?

## Список изменений

```yml
🆑
add: Spraycan (Баллончик с краской) - Позволяет перекрашивать одежду с инвентарем в харме
/🆑
```
