### PR TITLE
HOT-FIX: Замена аранеспа на куреалл в синдисигах

### DIFF
--- a/mod_celadon/balance/code/cigarette.dm
+++ b/mod_celadon/balance/code/cigarette.dm
@@ -1,3 +1,3 @@
-//Возвращаем синди сигаретам куреалл(ака омнизин ака трикордразин) в реагенты вместо аранеспа??????? Кошка молодец ниче не скажешь
+// Возвращаем синди сигаретам cureall (ака омнизин ака трикордразин) в реагенты вместо aranesp.
 /obj/item/clothing/mask/cigarette/syndicate
 	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/medicine/cureall = 4)

--- a/mod_celadon/balance/code/cigarette.dm
+++ b/mod_celadon/balance/code/cigarette.dm
@@ -1,3 +1,3 @@
-//Возвращаем синди сигаретам Омнизин в реагенты вместо синаптизина
+//Возвращаем синди сигаретам куреалл(ака омнизин ака трикордразин) в реагенты вместо аранеспа??????? Кошка молодец ниче не скажешь
 /obj/item/clothing/mask/cigarette/syndicate
-	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/drug/aranesp = 4)
+	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/medicine/cureall = 4)


### PR DESCRIPTION
## Описание / Что этот PR делает
Заменяет аранесп в синдисигах на куреалл
### Изначально, давно-давно там был синаптизин и аранесп
## Причина создания ПР / Почему это хорошо для игры
Кошка закинул это в некий ПР с фиксом вещей с оффов (#2474), очень смешно получается, синдимейнеры немного задыхались от сижек
Стаминареген от сигарет это не круто, никотин и так режет станы, теперь они будут лечить
## Демонстрация изменений / Тестирование
Билд комплится и работает, чеки прошли
## Список изменений

```yml
🆑
fix: Исправлен вайбкод кошки - аранесп в синдисигах заменен на куреалл
/🆑
```
