### PR TITLE
FIX-NERF: Cyber stomach fix (nerfed 10x)

### DIFF
--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -215,7 +215,7 @@
 	desc = "A basic device designed to mimic the functions of a human stomach"
 	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
-	metabolism_efficiency = 0.7 // not as good at digestion
+	metabolism_efficiency = 0.07 // not as good at digestion
 	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
 
 /obj/item/organ/stomach/cybernetic/tier2


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправлена ошибка в коде - из-за чего кибер-желудок базового уровня был в 10 / 5 раз эффективнее чем аналоги тиров выше.

## Причина создания ПР / Почему это хорошо для игры
Блять почему я узнаю об этом не из баг-репортов, а из чата? Нет, ну серьезно?
Кто-то в Апстриме забыл один нолик в цифрах.

## Демонстрация изменений / Тестирование
<img width="341" height="182" alt="image" src="https://github.com/user-attachments/assets/13dafad8-9601-4e7d-bac8-b3215de950e8" />

## Список изменений

```yml
🆑
fix: Правильные цифры в метаболизма в кибер-желудков
balance: Нерф кибер-желудков
/🆑
```
