### PR TITLE
FIX: Добавил поддержку UTF-8 символов в HTML страницу редактирования pAI.

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -88,6 +88,7 @@ SUBSYSTEM_DEF(pai)
 
 
 	var/dat = ""
+	dat += "<meta charset=\"utf-8\">"
 	dat += {"
 			<style type="text/css">
 
@@ -152,7 +153,7 @@ SUBSYSTEM_DEF(pai)
 	for(var/datum/paiCandidate/c in SSpai.candidates)
 		available.Add(check_ready(c))
 	var/dat = ""
-
+	dat += "<meta charset=\"utf-8\">"
 	dat += {"
 			<style type="text/css">
 

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -88,7 +88,7 @@ SUBSYSTEM_DEF(pai)
 
 
 	var/dat = ""
-	dat += "<meta charset=\"utf-8\">"
+	dat += "<meta charset=\"utf-8\">" // [CELADON-ADD] - Поддержка UTF-8 символов.
 	dat += {"
 			<style type="text/css">
 
@@ -153,7 +153,7 @@ SUBSYSTEM_DEF(pai)
 	for(var/datum/paiCandidate/c in SSpai.candidates)
 		available.Add(check_ready(c))
 	var/dat = ""
-	dat += "<meta charset=\"utf-8\">"
+	dat += "<meta charset=\"utf-8\">" // [CELADON-ADD] - Поддержка UTF-8 символов.
 	dat += {"
 			<style type="text/css">
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Чинит отображение символов в окне редактирования pAI из гостов.

 
## Причина создания ПР / Почему это хорошо для игры
По умолчанию браузер видимо использует формат Win-1252 для символов, что и результировалось в характерные неверные символы. Фикс переводит формат текста окна из Win-1252 на UTF-8.
Работа по баг-репорту: resolve #2801


## Демонстрация изменений / Тестирование
<img width="396" height="428" alt="Screenshot_1681" src="https://github.com/user-attachments/assets/ddfc89a1-ac83-4562-98dd-8ac698c77800" />

## Список изменений

```yml
🆑
fix: Исправлено отображение кириллицы в окне ПИИ.
/🆑
```
