### PR TITLE
[ADD] Добавление Blast Door Circuit в автолат для контролирования бласт дверей и затворов

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1032,6 +1032,16 @@
 	build_path = /obj/item/stock_parts/cell/emergency_light
 	category = list("initial", "Electronics")
 
+// [CELADON-ADD]
+/datum/design/blast_door_circuit
+	name = "Blast door circuit"
+	id = "blast_door_circuit"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/glass = 20)
+	build_path = /obj/item/assembly/control
+	category = list("initial", "Electronics")
+// [/CELADON-ADD]
+
 /datum/design/packageWrap
 	name = "Package Wrapping"
 	id = "packagewrap"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1032,16 +1032,6 @@
 	build_path = /obj/item/stock_parts/cell/emergency_light
 	category = list("initial", "Electronics")
 
-// [CELADON-ADD]
-/datum/design/blast_door_circuit
-	name = "Blast door circuit"
-	id = "blast_door_circuit"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = 20)
-	build_path = /obj/item/assembly/control
-	category = list("initial", "Electronics")
-// [/CELADON-ADD]
-
 /datum/design/packageWrap
 	name = "Package Wrapping"
 	id = "packagewrap"

--- a/mod_celadon/balance/_balance.dme
+++ b/mod_celadon/balance/_balance.dme
@@ -4,6 +4,7 @@
 #include "_balance.dm"
 
 #include "code/designs/autolathe_designs.dm"
+#include "code/designs/autolathe_new_designs.dm"
 
 #include "code/engine/circuits.dm"
 #include "code/engine/enginebalance.dm"

--- a/mod_celadon/balance/code/designs/autolathe_designs.dm
+++ b/mod_celadon/balance/code/designs/autolathe_designs.dm
@@ -1,5 +1,8 @@
 // MARK: Autolathe Designs
 
+// Для добавления новых датумов используйте другой файл: mod_celadon\balance\code\designs\autolathe_new_designs.dm
+// Коркод файл с design для автолата: code\modules\research\designs\autolathe_designs.dm
+
 /datum/design/bucket
 	materials = list(/datum/material/iron = 200)
 
@@ -353,11 +356,6 @@
 
 /datum/design/miniature_power_cell
 	materials = list(/datum/material/glass = 200)
-
-// [CELADON-ADD]
-/datum/design/blast_door_circuit
-	materials = list(/datum/material/glass = 200)
-// [/CELADON-ADD]
 
 /datum/design/packageWrap
 	materials = list(/datum/material/iron = 200, /datum/material/glass = 200)

--- a/mod_celadon/balance/code/designs/autolathe_designs.dm
+++ b/mod_celadon/balance/code/designs/autolathe_designs.dm
@@ -354,6 +354,11 @@
 /datum/design/miniature_power_cell
 	materials = list(/datum/material/glass = 200)
 
+// [CELADON-ADD]
+/datum/design/blast_door_circuit
+	materials = list(/datum/material/glass = 200)
+// [/CELADON-ADD]
+
 /datum/design/packageWrap
 	materials = list(/datum/material/iron = 200, /datum/material/glass = 200)
 

--- a/mod_celadon/balance/code/designs/autolathe_new_designs.dm
+++ b/mod_celadon/balance/code/designs/autolathe_new_designs.dm
@@ -1,0 +1,14 @@
+// MARK: Autolathe Designs
+
+// В данном файле прописываются новые датумы для последующего добавления в автолат.
+// Возможно в будущем стоит переместить этот файл в другую категорию, а не balance.
+// Для изменения баланса коркод вещей в автолате: mod_celadon\balance\code\designs\autolathe_designs.dm
+// Коркод файл с design для автолата: code\modules\research\designs\autolathe_designs.dm
+
+/datum/design/blast_door_circuit
+	name = "Blast Door Circuit"
+	id = "blast_door_circuit"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/glass = 200)
+	build_path = /obj/item/assembly/control
+	category = list("initial", "Electronics")


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет схему для контроля бласт дверей и затворок. Насчёт грифа можно не беспокоиться, изменить id можно только мультитулом, держа в руке плату, и только на цифровые значения от 1 до 100.
## Причина создания ПР / Почему это хорошо для игры
Finally, будет место откуда можно взять эту схему, кроме как скручивать с уже имеющихся кнопок на аванпосте и кораблях.
## Демонстрация изменений / Тестирование
<img width="582" height="68" alt="2026-04-10_23-18-37" src="https://github.com/user-attachments/assets/e2efe1d7-5046-4759-94d3-4dda0f9ee46f" />

Тут уже идут скрины того как эта штука выглядит и то, как она работает при использовании с ней мультитула, было добавлено задолго до меня, но добавляю скрины сюда чтоб никому не надо было перепроверять мои слова
<img width="144" height="255" alt="2026-04-10_23-19-11" src="https://github.com/user-attachments/assets/897844b1-5f2e-4b4b-a3c5-50d6a8b02189" />
<img width="552" height="331" alt="2026-04-10_23-19-50" src="https://github.com/user-attachments/assets/a12127c5-01d5-4009-a729-980647b39196" />


## Список изменений
```yml
🆑
add: Добавлен дизайн схемы для контроля бласт дверей и затворок в автолат.
/🆑
```
