### PR TITLE
ADD: New colors adminwho roles, and tweak who - procs

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,14 +1,14 @@
 
 ////////////////////////////////
 /proc/message_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
+	msg = "<span class=\"adminlog\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,
 		confidential = TRUE)
 
 /proc/relay_msg_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
+	msg = "<span class=\"adminlog\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,14 +1,20 @@
 
 ////////////////////////////////
 /proc/message_admins(msg)
+	// [CELADON-EDIT] - Admin Log Formatting
+	// OLD_CODE: msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
 	msg = "<span class=\"adminlog\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
+	// [CELADON-EDIT]
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,
 		confidential = TRUE)
 
 /proc/relay_msg_admins(msg)
+	// [CELADON-EDIT] - Admin Log Formatting
+	// OLD_CODE: msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
 	msg = "<span class=\"adminlog\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
+	// [/CELADON-EDIT]
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -168,9 +168,9 @@
 	var/list/staff_list
 	switch(staff_type)
 		if("admin")
-			staff_list = get_staff_list(GLOB.admins, R_ADMIN, TRUE)
-		else if("developer")
-			staff_list = get_staff_list(GLOB.admins, R_DEBUG, TRUE)
+			staff_list = get_staff_list(GLOB.admins, R_BAN, TRUE)
+		if("developer")
+			staff_list = get_staff_list(GLOB.admins, R_BAN, FALSE)
 		//("mentor")
 		//	staff_list = get_staff_list(GLOB.mentors)
 

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -1,5 +1,3 @@
-#define NO_ADMINS_ONLINE_MESSAGE "Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond."
-
 /// BYOND's string procs don't support being used on datum references (as in it doesn't look for a name for stringification)
 /// We just use this macro to ensure that we will only pass strings to this BYOND-level function without developers needing to really worry about it.
 #define LOWER_TEXT(thing) lowertext(UNLINT("[thing]"))
@@ -15,7 +13,7 @@
 	set name = "Who"
 	set category = "OOC"
 
-	var/msg = "<b>Current Players:</b>\n"
+	var/msg = ""
 
 	var/list/Lines = list()
 	var/columns_per_row = DEFAULT_WHO_CELLS_PER_ROW
@@ -27,7 +25,7 @@
 			if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
 				log_admin("[key_name(usr)] checked advanced who in-round")
 			for(var/client/C in GLOB.clients)
-				var/entry = "\t[C.key]"
+				var/entry = "• [C.key]"
 				if(!C.prefs?.whois_visible)
 					entry += "\[<b>WhoIs-Invisible</b>\]"
 				if(C.holder && C.holder.fakekey)
@@ -106,7 +104,7 @@
 
 	var/admin_data = staff_info["admin"]["data"]
 	lines += span_bold(admin_data ? span_bold(staff_info["admin"]["header"]) : staff_info["admin"]["empty_header"])
-	lines += admin_data || NO_ADMINS_ONLINE_MESSAGE
+	lines += admin_data || span_info("Все запросы к администрации передаются в Discord. Если в данный момент администраторов нет в игре, сообщение автоматически уходит в Discord, где его увидят и отреагируют.")
 
 	//// Add disclaimer if other staff exists
 	//if(!admin_data && (staff_info["developer"]["data"]))
@@ -183,5 +181,3 @@
 
 		formatted += jointext(info, " ")
 	return jointext(formatted, "\n")
-
-#undef NO_ADMINS_ONLINE_MESSAGE

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -6,6 +6,11 @@
 
 #define DEFAULT_WHO_CELLS_PER_ROW 4
 
+/client/verb/staffwho()
+	set category = "Admin"
+	set name = "Adminwho"
+	staff_who("Adminwho")
+
 /client/verb/who()
 	set name = "Who"
 	set category = "OOC"
@@ -76,12 +81,9 @@
 	msg += "</tr></table>"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
-	to_chat(src, span_infoplain("[msg]"))
+	to_chat(src, fieldset_block(span_bold("Current Players"), span_infoplain(msg), "boxed_message"), type = MESSAGE_TYPE_OOC)
 
-/client/verb/adminwho()
-	set category = "Admin"
-	set name = "Adminwho"
-
+/*
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)
@@ -120,7 +122,7 @@
 				msg += "<b>\t[C.key]</b> is a Mentor \n"
 		msg += span_info("Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.")
 	to_chat(src, msg)
-
+*/
 #undef DEFAULT_WHO_CELLS_PER_ROW
 
 /client/proc/staff_who(via)
@@ -132,25 +134,25 @@
 			"empty_header" = "No Admins Currently Online",
 			"data" = generate_staff_list("admin")
 		),
-		"maintainer" = list(
-			"header" = "Current Maintainers:",
-			"data" = generate_staff_list("maintainer")
+		"developer" = list(
+			"header" = "Current Developers:",
+			"data" = generate_staff_list("developer")
 		),
-		"mentor" = list(
-			"header" = "Current Mentors:",
-			"data" = generate_staff_list("mentor")
-		)
+		//"mentor" = list(
+		//	"header" = "Current Mentors:",
+		//	"data" = generate_staff_list("mentor")
+		//)
 	)
 
 	var/admin_data = staff_info["admin"]["data"]
-	lines += span_bold(admin_data ? staff_info["admin"]["header"] : staff_info["admin"]["empty_header"])
+	lines += span_bold(admin_data ? span_bold(staff_info["admin"]["header"]) : staff_info["admin"]["empty_header"])
 	lines += admin_data || NO_ADMINS_ONLINE_MESSAGE
 
 	// Add disclaimer if other staff exists
-	if(!admin_data && (staff_info["maintainer"]["data"] || staff_info["mentor"]["data"]))
+	if(!admin_data && (staff_info["developer"]["data"]))
 		lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
 
-	for(var/staff_type in list("maintainer", "mentor"))
+	for(var/staff_type in list("developer"))
 		var/list/staff_data = staff_info[staff_type]
 		if(!isnull(staff_data["data"]))
 			lines += span_bold(staff_data["header"])
@@ -158,7 +160,7 @@
 
 	message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff[via ? " (via [via])" : ""].")
 	log_admin("[key_name(src)] has checked online staff[via ? " (via [via])" : ""].")
-	to_chat(src, lines)
+	to_chat(src, fieldset_block(span_bold("Current Staff"), jointext(lines, "\n"), "boxed_message"), type = MESSAGE_TYPE_OOC)
 
 //
 
@@ -167,10 +169,10 @@
 	switch(staff_type)
 		if("admin")
 			staff_list = get_staff_list(GLOB.admins, R_ADMIN, TRUE)
-		if("maintainer")
-			staff_list = get_staff_list(GLOB.admins, R_ADMIN, FALSE)
-		if("mentor")
-			staff_list = get_staff_list(GLOB.mentors)
+		else if("developer")
+			staff_list = get_staff_list(GLOB.admins, R_DEBUG, TRUE)
+		//("mentor")
+		//	staff_list = get_staff_list(GLOB.mentors)
 
 	return length(staff_list) ? format_staff_list(staff_list, holder != null) : null
 
@@ -197,7 +199,7 @@
 				display_rank = "localhost"
 			// Convert spaces to underscores
 			var/css_class = replacetext(display_rank, " ", "_")
-			info += "• [C] is a <span class='[css_class]'>[C.holder.rank]</span>"
+			info += "• [C] is a <span class='[css_class]'><b>[C.holder.rank]</b></span>"
 		//You are just a mint green, no admin about you
 		//else if(C?.mentor_datum)
 		//	info += "• [C] is a <span class='mentor'>Mentor</span>"
@@ -210,14 +212,14 @@
 				info += "<i>(as [C.holder.fakekey])</i>"
 
 			if(isobserver(C.mob))
-				info += "- Observing"
+				info += "- <font color='gray'>Observing</font>"
 			else if(isnewplayer(C.mob))
-				info += "- Lobby"
+				info += "- <font color='darkgray'><b>Lobby</b></font>"
 			else
 				info += "- Playing"
 
 			if(C.is_afk())
-				info += "(AFK)"
+				info += "<font color='darkgray'>(AFK)</font>"
 
 		formatted += jointext(info, " ")
 	return jointext(formatted, "\n")

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -1,19 +1,13 @@
-/// BYOND's string procs don't support being used on datum references (as in it doesn't look for a name for stringification)
-/// We just use this macro to ensure that we will only pass strings to this BYOND-level function without developers needing to really worry about it.
-#define LOWER_TEXT(thing) lowertext(UNLINT("[thing]"))
-
 #define DEFAULT_WHO_CELLS_PER_ROW 4
-
-/client/verb/staffwho()
-	set category = "Admin"
-	set name = "Adminwho"
-	staff_who("Adminwho")
 
 /client/verb/who()
 	set name = "Who"
 	set category = "OOC"
 
+	// [CELADON-EDIT] - Replaced with staffwho verb
+	// OLD_CODE: var/msg = "<b>Current Players:</b>\n"
 	var/msg = ""
+	// [/CELADON-EDIT]
 
 	var/list/Lines = list()
 	var/columns_per_row = DEFAULT_WHO_CELLS_PER_ROW
@@ -25,7 +19,10 @@
 			if(!G.started_as_observer)//If you aghost to do this, KorPhaeron will deadmin you in your sleep.
 				log_admin("[key_name(usr)] checked advanced who in-round")
 			for(var/client/C in GLOB.clients)
+				// [CELADON-EDIT] - Replaced with staffwho verb
+				// OLD_CODE: var/entry = "\t[C.key]"
 				var/entry = "• [C.key]"
+				// [/CELADON-EDIT]
 				if(!C.prefs?.whois_visible)
 					entry += "\[<b>WhoIs-Invisible</b>\]"
 				if(C.holder && C.holder.fakekey)
@@ -79,105 +76,50 @@
 	msg += "</tr></table>"
 
 	msg += "<b>Total Players: [length(Lines)]</b>"
+	// [CELADON-EDIT] - Replaced with staffwho verb
+	// OLD_CODE: to_chat(src, span_infoplain("[msg]"))
 	to_chat(src, fieldset_block(span_bold("Current Players"), span_infoplain(msg), "boxed_message"), type = MESSAGE_TYPE_OOC)
+	// [/CELADON-EDIT]
 
-#undef DEFAULT_WHO_CELLS_PER_ROW
+/client/verb/adminwho()
+	// [CELADON-REMOVE] - На замену этого было сделано это: mod_celadon\qol\code\adminwho.dm
+	set category = "Admin"
+	set name = "Adminwho"
+	// [/CELADON-REMOVE]
 
-/client/proc/staff_who(via)
-	var/list/lines = list()
-	//Assoc list
-	var/list/staff_info = list(
-		"admin" = list(
-			"header" = "Current Admins:",
-			"empty_header" = "No Admins Currently Online",
-			"data" = generate_staff_list("admin")
-		),
-		"developer" = list(
-			"header" = "Current Developers:",
-			"data" = generate_staff_list("developer")
-		),
-		//"mentor" = list(
-		//	"header" = "Current Mentors:",
-		//	"data" = generate_staff_list("mentor")
-		//)
-	)
+	var/msg = "<b>Current Admins:</b>\n"
+	if(holder)
+		for(var/client/C in GLOB.admins)
+			msg += "<b>\t[C]</b> is a [C.holder.rank]"
 
-	var/admin_data = staff_info["admin"]["data"]
-	lines += span_bold(admin_data ? span_bold(staff_info["admin"]["header"]) : staff_info["admin"]["empty_header"])
-	lines += admin_data || span_info("Все запросы к администрации передаются в Discord. Если в данный момент администраторов нет в игре, сообщение автоматически уходит в Discord, где его увидят и отреагируют.")
-
-	//// Add disclaimer if other staff exists
-	//if(!admin_data && (staff_info["developer"]["data"]))
-	//	lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
-
-	for(var/staff_type in list("developer"))
-		var/list/staff_data = staff_info[staff_type]
-		if(!isnull(staff_data["data"]))
-			lines += span_bold(staff_data["header"])
-			lines += staff_data["data"]
-
-	message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff[via ? " (via [via])" : ""].")
-	log_admin("[key_name(src)] has checked online staff[via ? " (via [via])" : ""].")
-	to_chat(src, fieldset_block(span_bold("Current Staff"), jointext(lines, "\n"), "boxed_message"), type = MESSAGE_TYPE_OOC)
-
-//
-
-/client/proc/generate_staff_list(staff_type)
-	var/list/staff_list
-	switch(staff_type)
-		if("admin")
-			staff_list = get_staff_list(GLOB.admins, R_BAN, TRUE)
-		if("developer")
-			staff_list = get_staff_list(GLOB.admins, R_BAN, FALSE)
-		//("mentor")
-		//	staff_list = get_staff_list(GLOB.mentors)
-
-	return length(staff_list) ? format_staff_list(staff_list, holder != null) : null
-
-/proc/get_staff_list(list/global_list, rights = null, has_rights = null)
-	var/list/staff = list()
-	for(var/client/C in global_list)
-		if(!isnull(rights) && !isnull(has_rights))
-			if(has_rights != check_rights_for(C, rights))
-				continue
-		staff += C
-	return length(staff) ? staff : null
-
-/proc/format_staff_list(list/staff_list, show_sensitive = FALSE)
-	var/list/formatted = list()
-	for(var/client/C in staff_list)
-		if(!show_sensitive && (C.is_afk() || (!isnull(C.holder) && !isnull(C.holder.fakekey))))
-			continue
-
-		var/list/info = list()
-		//We check for admins first, since you can have a mentor datum and a holder datum at the same time
-		if(C?.holder)
-			var/display_rank = LOWER_TEXT(C.holder.rank)
-			if(display_rank == "!localhost!")
-				display_rank = "localhost"
-			// Convert spaces to underscores
-			var/css_class = replacetext(display_rank, " ", "_")
-			info += "• [C] is a <span class='[css_class]'><b>[C.holder.rank]</b></span>"
-		//You are just a mint green, no admin about you
-		//else if(C?.mentor_datum)
-		//	info += "• [C] is a <span class='mentor'>Mentor</span>"
-		else
-			message_admins("Client [C] has no admin holder or mentor datum, yet is being passed as staff in staffwho. What the FUCK.")
-			continue
-
-		if(show_sensitive)
-			if(C?.holder.fakekey)
-				info += "<i>(as [C.holder.fakekey])</i>"
+			if(C.holder.fakekey)
+				msg += " <i>(as [C.holder.fakekey])</i>"
 
 			if(isobserver(C.mob))
-				info += "- <font color='gray'>Observing</font>"
+				msg += " - Observing"
 			else if(isnewplayer(C.mob))
-				info += "- <font color='darkgray'><b>Lobby</b></font>"
+				msg += " - Lobby"
 			else
-				info += "- Playing"
+				msg += " - Playing"
 
 			if(C.is_afk())
-				info += "<font color='darkgray'>(AFK)</font>"
+				msg += " (AFK)"
+			msg += "\n"
+	else
+		for(var/client/C in GLOB.admins)
+			if(C.is_afk())
+				continue //Don't show afk admins to adminwho
+			if(!C.holder.fakekey)
+				msg += "<b>\t[C]</b> is a [C.holder.rank]\n"
+	if(length(GLOB.mentors) > 0)
+		msg += "<b>Mentors:</b> \n"
+		for(var/client/C in sortList(GLOB.clients))
+			if(C in GLOB.admins)
+				continue
+			var/mentor = GLOB.mentor_datums[C.ckey]
+			if(mentor)
+				msg += "<b>\t[C.key]</b> is a Mentor \n"
+		msg += span_info("Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.")
+	to_chat(src, msg)
 
-		formatted += jointext(info, " ")
-	return jointext(formatted, "\n")
+#undef DEFAULT_WHO_CELLS_PER_ROW

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -83,46 +83,6 @@
 	msg += "<b>Total Players: [length(Lines)]</b>"
 	to_chat(src, fieldset_block(span_bold("Current Players"), span_infoplain(msg), "boxed_message"), type = MESSAGE_TYPE_OOC)
 
-/*
-	var/msg = "<b>Current Admins:</b>\n"
-	if(holder)
-		for(var/client/C in GLOB.admins)
-			var/display_rank = LOWER_TEXT(C.holder.rank)
-			if(display_rank == "!localhost!")
-				display_rank = "localhost"
-			var/css_class = replacetext(display_rank, " ", "_")
-			msg += "• <b>\t[C]</b> is a <span class='[css_class]'>[C.holder.rank]</span>"
-
-			if(C.holder.fakekey)
-				msg += " <i>(as [C.holder.fakekey])</i>"
-
-			if(isobserver(C.mob))
-				msg += " - Observing"
-			else if(isnewplayer(C.mob))
-				msg += " - Lobby"
-			else
-				msg += " - Playing"
-
-			if(C.is_afk())
-				msg += " (AFK)"
-			msg += "\n"
-	else
-		for(var/client/C in GLOB.admins)
-			if(C.is_afk())
-				continue //Don't show afk admins to adminwho
-			if(!C.holder.fakekey)
-				msg += "<b>\t[C]</b> is a [C.holder.rank]\n"
-	if(length(GLOB.mentors) > 0)
-		msg += "<b>Mentors:</b> \n"
-		for(var/client/C in sortList(GLOB.clients))
-			if(C in GLOB.admins)
-				continue
-			var/mentor = GLOB.mentor_datums[C.ckey]
-			if(mentor)
-				msg += "<b>\t[C.key]</b> is a Mentor \n"
-		msg += span_info("Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond.")
-	to_chat(src, msg)
-*/
 #undef DEFAULT_WHO_CELLS_PER_ROW
 
 /client/proc/staff_who(via)
@@ -148,9 +108,9 @@
 	lines += span_bold(admin_data ? span_bold(staff_info["admin"]["header"]) : staff_info["admin"]["empty_header"])
 	lines += admin_data || NO_ADMINS_ONLINE_MESSAGE
 
-	// Add disclaimer if other staff exists
-	if(!admin_data && (staff_info["developer"]["data"]))
-		lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
+	//// Add disclaimer if other staff exists
+	//if(!admin_data && (staff_info["developer"]["data"]))
+	//	lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
 
 	for(var/staff_type in list("developer"))
 		var/list/staff_data = staff_info[staff_type]

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -1,3 +1,9 @@
+#define NO_ADMINS_ONLINE_MESSAGE "Adminhelps are also sent to Discord. If no admins are available in game adminhelp anyways and an admin on Discord will see it and respond."
+
+/// BYOND's string procs don't support being used on datum references (as in it doesn't look for a name for stringification)
+/// We just use this macro to ensure that we will only pass strings to this BYOND-level function without developers needing to really worry about it.
+#define LOWER_TEXT(thing) lowertext(UNLINT("[thing]"))
+
 #define DEFAULT_WHO_CELLS_PER_ROW 4
 
 /client/verb/who()
@@ -79,7 +85,11 @@
 	var/msg = "<b>Current Admins:</b>\n"
 	if(holder)
 		for(var/client/C in GLOB.admins)
-			msg += "<b>\t[C]</b> is a [C.holder.rank]"
+			var/display_rank = LOWER_TEXT(C.holder.rank)
+			if(display_rank == "!localhost!")
+				display_rank = "localhost"
+			var/css_class = replacetext(display_rank, " ", "_")
+			msg += "• <b>\t[C]</b> is a <span class='[css_class]'>[C.holder.rank]</span>"
 
 			if(C.holder.fakekey)
 				msg += " <i>(as [C.holder.fakekey])</i>"
@@ -112,3 +122,104 @@
 	to_chat(src, msg)
 
 #undef DEFAULT_WHO_CELLS_PER_ROW
+
+/client/proc/staff_who(via)
+	var/list/lines = list()
+	//Assoc list
+	var/list/staff_info = list(
+		"admin" = list(
+			"header" = "Current Admins:",
+			"empty_header" = "No Admins Currently Online",
+			"data" = generate_staff_list("admin")
+		),
+		"maintainer" = list(
+			"header" = "Current Maintainers:",
+			"data" = generate_staff_list("maintainer")
+		),
+		"mentor" = list(
+			"header" = "Current Mentors:",
+			"data" = generate_staff_list("mentor")
+		)
+	)
+
+	var/admin_data = staff_info["admin"]["data"]
+	lines += span_bold(admin_data ? staff_info["admin"]["header"] : staff_info["admin"]["empty_header"])
+	lines += admin_data || NO_ADMINS_ONLINE_MESSAGE
+
+	// Add disclaimer if other staff exists
+	if(!admin_data && (staff_info["maintainer"]["data"] || staff_info["mentor"]["data"]))
+		lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
+
+	for(var/staff_type in list("maintainer", "mentor"))
+		var/list/staff_data = staff_info[staff_type]
+		if(!isnull(staff_data["data"]))
+			lines += span_bold(staff_data["header"])
+			lines += staff_data["data"]
+
+	message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff[via ? " (via [via])" : ""].")
+	log_admin("[key_name(src)] has checked online staff[via ? " (via [via])" : ""].")
+	to_chat(src, lines)
+
+//
+
+/client/proc/generate_staff_list(staff_type)
+	var/list/staff_list
+	switch(staff_type)
+		if("admin")
+			staff_list = get_staff_list(GLOB.admins, R_ADMIN, TRUE)
+		if("maintainer")
+			staff_list = get_staff_list(GLOB.admins, R_ADMIN, FALSE)
+		if("mentor")
+			staff_list = get_staff_list(GLOB.mentors)
+
+	return length(staff_list) ? format_staff_list(staff_list, holder != null) : null
+
+/proc/get_staff_list(list/global_list, rights = null, has_rights = null)
+	var/list/staff = list()
+	for(var/client/C in global_list)
+		if(!isnull(rights) && !isnull(has_rights))
+			if(has_rights != check_rights_for(C, rights))
+				continue
+		staff += C
+	return length(staff) ? staff : null
+
+/proc/format_staff_list(list/staff_list, show_sensitive = FALSE)
+	var/list/formatted = list()
+	for(var/client/C in staff_list)
+		if(!show_sensitive && (C.is_afk() || (!isnull(C.holder) && !isnull(C.holder.fakekey))))
+			continue
+
+		var/list/info = list()
+		//We check for admins first, since you can have a mentor datum and a holder datum at the same time
+		if(C?.holder)
+			var/display_rank = LOWER_TEXT(C.holder.rank)
+			if(display_rank == "!localhost!")
+				display_rank = "localhost"
+			// Convert spaces to underscores
+			var/css_class = replacetext(display_rank, " ", "_")
+			info += "• [C] is a <span class='[css_class]'>[C.holder.rank]</span>"
+		//You are just a mint green, no admin about you
+		//else if(C?.mentor_datum)
+		//	info += "• [C] is a <span class='mentor'>Mentor</span>"
+		else
+			message_admins("Client [C] has no admin holder or mentor datum, yet is being passed as staff in staffwho. What the FUCK.")
+			continue
+
+		if(show_sensitive)
+			if(C?.holder.fakekey)
+				info += "<i>(as [C.holder.fakekey])</i>"
+
+			if(isobserver(C.mob))
+				info += "- Observing"
+			else if(isnewplayer(C.mob))
+				info += "- Lobby"
+			else
+				info += "- Playing"
+
+			if(C.is_afk())
+				info += "(AFK)"
+
+		formatted += jointext(info, " ")
+	return jointext(formatted, "\n")
+
+#undef NO_ADMINS_ONLINE_MESSAGE

--- a/mod_celadon/qol/_qol.dme
+++ b/mod_celadon/qol/_qol.dme
@@ -3,6 +3,7 @@
 
 #include "_qol.dm"
 
+#include "code/adminwho.dm"
 #include "code/BluespaceTechnician.dm"
 #include "code/hotkeyfix.dm"
 #include "code/hair.dm"

--- a/mod_celadon/qol/code/adminwho.dm
+++ b/mod_celadon/qol/code/adminwho.dm
@@ -1,0 +1,105 @@
+/// BYOND's string procs don't support being used on datum references (as in it doesn't look for a name for stringification)
+/// We just use this macro to ensure that we will only pass strings to this BYOND-level function without developers needing to really worry about it.
+#define LOWER_TEXT(thing) lowertext(UNLINT("[thing]"))
+
+/client/verb/staffwho()
+	set category = "Admin"
+	set name = "Adminwho"
+	staff_who("Adminwho")
+
+/client/proc/staff_who(via)
+	var/list/lines = list()
+	//Assoc list
+	var/list/staff_info = list(
+		"admin" = list(
+			"header" = "Current Admins:",
+			"empty_header" = "No Admins Currently Online",
+			"data" = generate_staff_list("admin")
+		),
+		"developer" = list(
+			"header" = "Current Developers:",
+			"data" = generate_staff_list("developer")
+		),
+		//"mentor" = list(
+		//	"header" = "Current Mentors:",
+		//	"data" = generate_staff_list("mentor")
+		//)
+	)
+
+	var/admin_data = staff_info["admin"]["data"]
+	lines += span_bold(admin_data ? span_bold(staff_info["admin"]["header"]) : staff_info["admin"]["empty_header"])
+	lines += admin_data || span_info("Все запросы к администрации передаются в Discord. Если в данный момент администраторов нет в игре, сообщение автоматически уходит в Discord, где его увидят и отреагируют.")
+
+	//// Add disclaimer if other staff exists
+	//if(!admin_data && (staff_info["developer"]["data"]))
+	//	lines += "<b>Non-admin staff are unable to handle adminhelp tickets.</b>"
+
+	for(var/staff_type in list("developer"))
+		var/list/staff_data = staff_info[staff_type]
+		if(!isnull(staff_data["data"]))
+			lines += span_bold(staff_data["header"])
+			lines += staff_data["data"]
+
+	message_admins("[ADMIN_LOOKUPFLW(src.mob)] has checked online staff[via ? " (via [via])" : ""].")
+	log_admin("[key_name(src)] has checked online staff[via ? " (via [via])" : ""].")
+	to_chat(src, fieldset_block(span_bold("Current Staff"), jointext(lines, "\n"), "boxed_message"), type = MESSAGE_TYPE_OOC)
+
+/client/proc/generate_staff_list(staff_type)
+	var/list/staff_list
+	switch(staff_type)
+		if("admin")
+			staff_list = get_staff_list(GLOB.admins, R_BAN, TRUE)
+		if("developer")
+			staff_list = get_staff_list(GLOB.admins, R_BAN, FALSE)
+		//("mentor")
+		//	staff_list = get_staff_list(GLOB.mentors)
+
+	return length(staff_list) ? format_staff_list(staff_list, holder != null) : null
+
+/proc/get_staff_list(list/global_list, rights = null, has_rights = null)
+	var/list/staff = list()
+	for(var/client/C in global_list)
+		if(!isnull(rights) && !isnull(has_rights))
+			if(has_rights != check_rights_for(C, rights))
+				continue
+		staff += C
+	return length(staff) ? staff : null
+
+/proc/format_staff_list(list/staff_list, show_sensitive = FALSE)
+	var/list/formatted = list()
+	for(var/client/C in staff_list)
+		if(!show_sensitive && (C.is_afk() || (!isnull(C.holder) && !isnull(C.holder.fakekey))))
+			continue
+
+		var/list/info = list()
+		//We check for admins first, since you can have a mentor datum and a holder datum at the same time
+		if(C?.holder)
+			var/display_rank = LOWER_TEXT(C.holder.rank)
+			if(display_rank == "!localhost!")
+				display_rank = "localhost"
+			// Convert spaces to underscores
+			var/css_class = replacetext(display_rank, " ", "_")
+			info += "• [C] is a <span class='[css_class]'><b>[C.holder.rank]</b></span>"
+		//You are just a mint green, no admin about you
+		//else if(C?.mentor_datum)
+		//	info += "• [C] is a <span class='mentor'>Mentor</span>"
+		else
+			message_admins("Client [C] has no admin holder or mentor datum, yet is being passed as staff in staffwho. What the FUCK.")
+			continue
+
+		if(show_sensitive)
+			if(C?.holder.fakekey)
+				info += "<i>(as [C.holder.fakekey])</i>"
+
+			if(isobserver(C.mob))
+				info += "- <font color='gray'>Observing</font>"
+			else if(isnewplayer(C.mob))
+				info += "- <font color='darkgray'><b>Lobby</b></font>"
+			else
+				info += "- Playing"
+
+			if(C.is_afk())
+				info += "<font color='darkgray'>(AFK)</font>"
+
+		formatted += jointext(info, " ")
+	return jointext(formatted, "\n")

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -985,40 +985,40 @@ em {
 
 //These must match the rank strings exactly to work
 
-.host {
+.host, .project_lead {
   color: hsl(27, 87.7%, 60%);
 }
 
-.headdev {
-  color: hsl(219, 100%, 65%);
+.head_admin {
+  color: hsl(351, 86.6%, 52%);
 }
 
-.headmin {
-  color: hsl(358, 65.9%, 62%);
-}
-
-.s_codermin {
-  color: hsl(220, 44.5%, 60%);
-}
-
-.seniormin {
-  color: hsl(351, 86.6%, 62%);
-}
-
-.codermin {
-  color: hsl(227, 96.1%, 72%);
-}
-
-.admin {
-  color: hsl(338, 94.8%, 68%);
+.trial_admin {
+  color: hsl(15, 85%, 52%);
 }
 
 .moderator {
   color: hsl(0, 78.9%, 75%);
 }
 
-.maintainer {
+.development_head {
+  color: hsl(219, 100%, 65%);
+}
+
+.coder {
+  color: hsl(220, 44.5%, 60%);
+}
+
+.tester {
   color: hsl(227, 57.4%, 80%);
+}
+
+.head_of_maps {
+  color: hsl(140, 60%, 50%);
+}
+
+.head_of_sprites {
+  color: hsl(290, 81%, 58%);
 }
 
 .mentor {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -300,6 +300,7 @@ em {
   font-weight: bold;
 }
 
+// [CELADON-EDIT] - .admin => .adminlog
 .adminlog {
   color: #5975da;
   font-weight: bold;
@@ -981,9 +982,7 @@ em {
   }
 }
 
-//RKz's cute staffwho colors (manually colorpicked from discord role colors, lightness adjusted for dark theme)
-
-//These must match the rank strings exactly to work
+// [CELADON-ADD] - Staffwho verb colors
 
 .host, .project_lead {
   color: hsl(27, 87.7%, 60%);
@@ -1032,3 +1031,5 @@ em {
 .localhost {
   color: hsl(46, 98.8%, 72%);
 }
+
+// [/CELADON-ADD] - Staffwho verb colors

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -980,3 +980,51 @@ em {
     border-color: inherit;
   }
 }
+
+//RKz's cute staffwho colors (manually colorpicked from discord role colors, lightness adjusted for dark theme)
+
+//These must match the rank strings exactly to work
+
+.host {
+  color: hsl(27, 87.7%, 60%);
+}
+
+.headdev {
+  color: hsl(219, 100%, 65%);
+}
+
+.headmin {
+  color: hsl(358, 65.9%, 62%);
+}
+
+.s_codermin {
+  color: hsl(220, 44.5%, 60%);
+}
+
+.seniormin {
+  color: hsl(351, 86.6%, 62%);
+}
+
+.codermin {
+  color: hsl(227, 96.1%, 72%);
+}
+
+.admin {
+  color: hsl(338, 94.8%, 68%);
+}
+
+.moderator {
+  color: hsl(0, 78.9%, 75%);
+}
+
+.maintainer {
+  color: hsl(227, 57.4%, 80%);
+}
+
+.mentor {
+  color: hsl(140, 55.1%, 72%);
+}
+
+.localhost {
+  color: hsl(46, 98.8%, 72%);
+}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -300,7 +300,7 @@ em {
   font-weight: bold;
 }
 
-.admin {
+.adminlog {
   color: #5975da;
   font-weight: bold;
 }
@@ -991,6 +991,10 @@ em {
 
 .head_admin {
   color: hsl(351, 86.6%, 52%);
+}
+
+.admin {
+  color: hsl(0, 50%, 52%);
 }
 
 .trial_admin {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -309,7 +309,7 @@ em {
   font-weight: bold;
 }
 
-.admin {
+.adminlog {
   color: #4473ff;
   font-weight: bold;
 }
@@ -1002,6 +1002,10 @@ h2.alert {
 
 .head_admin {
   color: hsl(351, 86.6%, 58%);
+}
+
+.admin {
+  color: hsl(0, 50%, 58%);
 }
 
 .trial_admin {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -309,6 +309,7 @@ em {
   font-weight: bold;
 }
 
+// [CELADON-EDIT] - .admin => .adminlog
 .adminlog {
   color: #4473ff;
   font-weight: bold;
@@ -992,9 +993,7 @@ h2.alert {
   }
 }
 
-//RKz's cute staffwho colors (manually colorpicked from discord role colors, some adjustments used)
-
-//These must match the rank strings exactly to work
+// [CELADON-ADD] - Staffwho verb colors
 
 .host, .project_lead {
   color: hsl(27, 80%, 50%);
@@ -1043,3 +1042,5 @@ h2.alert {
 .localhost {
   color: hsl(46, 98.8%, 68.2%);
 }
+
+// [/CELADON-ADD]

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -996,40 +996,40 @@ h2.alert {
 
 //These must match the rank strings exactly to work
 
-.host {
-  color: hsl(27, 87.7%, 44.7%);
+.host, .project_lead {
+  color: hsl(27, 80%, 50%);
 }
 
-.headdev {
-  color: hsl(219, 100%, 58.6%);
+.head_admin {
+  color: hsl(351, 86.6%, 58%);
 }
 
-.headmin {
-  color: hsl(358, 65.9%, 53.9%);
-}
-
-.s_codermin {
-  color: hsl(220, 44.5%, 41%);
-}
-
-.seniormin {
-  color: hsl(351, 86.6%, 53.1%);
-}
-
-.codermin {
-  color: hsl(227, 96.1%, 69.8%);
-}
-
-.admin {
-  color: hsl(338, 94.8%, 62.2%);
+.trial_admin {
+  color: hsl(15, 85%, 58%);
 }
 
 .moderator {
   color: hsl(0, 78.9%, 72.2%);
 }
 
-.maintainer {
+.development_head {
+  color: hsl(219, 100%, 58.6%);
+}
+
+.coder {
+  color: hsl(227, 96.1%, 69.8%);
+}
+
+.tester {
   color: hsl(227, 100%, 83.1%);
+}
+
+.head_of_maps {
+  color: hsl(140, 60%, 60%);
+}
+
+.head_of_sprites {
+  color: hsl(290, 81%, 64%);
 }
 
 .mentor {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -991,3 +991,51 @@ h2.alert {
     border-color: hsla(260, 100%, 50%, 0.5);
   }
 }
+
+//RKz's cute staffwho colors (manually colorpicked from discord role colors, some adjustments used)
+
+//These must match the rank strings exactly to work
+
+.host {
+  color: hsl(27, 87.7%, 44.7%);
+}
+
+.headdev {
+  color: hsl(219, 100%, 58.6%);
+}
+
+.headmin {
+  color: hsl(358, 65.9%, 53.9%);
+}
+
+.s_codermin {
+  color: hsl(220, 44.5%, 41%);
+}
+
+.seniormin {
+  color: hsl(351, 86.6%, 53.1%);
+}
+
+.codermin {
+  color: hsl(227, 96.1%, 69.8%);
+}
+
+.admin {
+  color: hsl(338, 94.8%, 62.2%);
+}
+
+.moderator {
+  color: hsl(0, 78.9%, 72.2%);
+}
+
+.maintainer {
+  color: hsl(227, 100%, 83.1%);
+}
+
+.mentor {
+  color: hsl(140, 55.1%, 69.4%);
+}
+
+.localhost {
+  color: hsl(46, 98.8%, 68.2%);
+}


### PR DESCRIPTION
## Описание / Что этот PR делает
Улучшает стили у функционала кнопок `adminwho` и `who`
Добавляет логгирование кнопки `adminwho`

[OLD PR](https://github.com/CeladonSS13/Shiptest/pull/2786)

## Причина создания ПР / Почему это хорошо для игры
Я устал писать причины, просто потому что это лучше чем было.

## Демонстрация изменений / Тестирование
<img width="364" height="124" alt="image" src="https://github.com/user-attachments/assets/627bf1a5-76c6-42f7-a6d4-d7c229e43905" />

## Список изменений

```yml
🆑
add: Стильные цветное информирование в who
admin: Каждый раз когда игрок проверяет админов, оповещает тех об этом
admin: Цвета ролей подсвечиваются в adminwho
/🆑
```
