### PR TITLE
FIX: Nemo, фикс рантаймов с трубами.

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_nemo.dmm
@@ -2070,9 +2070,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ship/hallway/port)
 "zS" = (
@@ -2623,9 +2620,6 @@
 /area/ship/crew/dorm/commad)
 "GS" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},


### PR DESCRIPTION
## Описание / Что этот PR делает
Удаляет 2 дубликата разных труб, что создавали 4 рантайма при прогрузке корабля.

## Причина создания ПР / Почему это хорошо для игры
Наличие рантаймов - не хорошо.

## Демонстрация изменений / Тестирование
Пример удалённых труб.
<img width="744" height="329" alt="Screenshot_1719" src="https://github.com/user-attachments/assets/7171716c-e6ee-4d45-9e69-9968b5f2522d" />
<img width="492" height="195" alt="Screenshot_1720" src="https://github.com/user-attachments/assets/19b12912-7541-4aeb-95ec-f7c3b7d7e450" />


## Список изменений

```yml
🆑
del: Удалены лишние трубы
fix: Исправлены рантаймы
/🆑
```
