### PR TITLE
FIX: Rube-Goldberg, починка рантаймов с шапкой хонкоматери.

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_rube_goldberg.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_rube_goldberg.dmm
@@ -5095,6 +5095,7 @@
 "Yj" = (
 /obj/item/bedsheet/clown,
 /obj/item/clothing/head/clownmitre,
+/turf/open/space,
 /area/ship/medical)
 "Yl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет 3 рантайма, добавляя недостающий турф космоса под предметы.

## Причина создания ПР / Почему это хорошо для игры
Рантаймы это плохо.

## Демонстрация изменений / Тестирование
<img width="295" height="99" alt="Screenshot_1746" src="https://github.com/user-attachments/assets/e4d1946b-d593-4077-a158-98a95cf78f77" />


## Список изменений

```yml
🆑
add: Добавлен турф космоса
fix: Исправлены рантаймы
/🆑
```
