### PR TITLE
FIX: Чиним спрайты плакатов солфедов

### DIFF
--- a/mod_celadon/outfit/code/solfed/assets/other_stuff.dm
+++ b/mod_celadon/outfit/code/solfed/assets/other_stuff.dm
@@ -38,6 +38,7 @@
 	name = "Poster - Mars"
 	desc = "This poster shows Mars, the 4th planet in SF-2345."
 	icon_state = "mars_poster"
+	never_random = TRUE
 
 /obj/structure/sign/poster/solfed/earth
 	name = "Poster - Terra"
@@ -45,7 +46,7 @@
 	icon_state = "earth_poster"
 	never_random = TRUE
 
-/obj/structure/sign/poster/solfed/earth
+/obj/structure/sign/poster/solfed/luna
 	name = "Poster - Luna"
 	desc = "This poster shows Luna, Terra's humble moon."
 	icon_state = "luna_poster"


### PR DESCRIPTION

## Описание / Что этот PR делает
Fix #2815
## Причина создания ПР / Почему это хорошо для игры
Кто-то решил указать два одинаковых пути для постера Земля и Луна, что по итогу всё ломалось
## Демонстрация изменений / Тестирование
Все работает
<img width="267" height="264" alt="image" src="https://github.com/user-attachments/assets/bf5ede76-47f9-4e2f-946a-5cf1624e76ec" />
## Список изменений

```yml
🆑 Azzy.Dreemurr
fix: СолФед постеры вновь корректно отображаются без Error
/🆑
```
