### PR TITLE
FIX: Убираем возможность проверять персонажей игроков через кнопку

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -239,7 +239,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		if(isobserver(mob) && isobserver(C.mob) && !C.holder?.fakekey)
 			// Show us the player's mob name in the list in front of their displayed key
 			// Add the player's displayed key to the list
-			players["[C.mob]([displayed_key])"] = displayed_key
+			players["[displayed_key]"] = displayed_key // [CELADON-EDIT] - Убираем возможность смотреть кто на каком персонаже играет. ORIGINAL: players["[C.mob]([displayed_key])"] = displayed_key
 
 		// Add the player's displayed key to the list if we or the player aren't a ghost or they're using a fakekey
 		else


### PR DESCRIPTION
## Описание / Что этот PR делает
Убираем возможность смотреть через кнопку кто и за какого персонажа играет. Отменяем метахейт.

## Причина создания ПР / Почему это хорошо для игры
Возможность смотреть кто играет на персонаже должна быть только у администраторов.

## Демонстрация изменений / Тестирование

Ранее: Показвало сикеи и имена персонажей гостов.
<img width="385" height="407" alt="image" src="https://github.com/user-attachments/assets/62e70ce1-540c-4920-bc85-9b0cef68d23e" />

Теперь: Только сикеи.
<img width="322" height="276" alt="image" src="https://github.com/user-attachments/assets/31b2a2f9-fdc1-47bd-a5b6-84894e73bad2" />

## Список изменений

```yml
🆑
fix: Убираем возможность смотреть персонажей игроков через кнопку ignore.
/🆑
```
