### PR TITLE
TWEAK: Убираем отображение квирков в мед. сканере

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -227,9 +227,10 @@ GENE SCANNER
 				trauma_desc += B.scan_desc
 				trauma_text += trauma_desc
 			render_list += "<span class='alert ml-1'>Cerebral traumas detected: subject appears to be suffering from [english_list(trauma_text)].</span>\n"
-		if(C.roundstart_quirks.len)
-			render_list += "<span class='info ml-1'>Subject has the following physiological traits: [C.get_trait_string(see_all=see_all_quirks)].</span>\n"
-
+		// [CELADON-DELETE] - Убираем возможность смотреть квирки через медсканер.
+		// if(C.roundstart_quirks.len)
+		// 	render_list += "<span class='info ml-1'>Subject has the following physiological traits: [C.get_trait_string(see_all=see_all_quirks)].</span>\n"
+		// [/CELADON-DELETE]
 	if(advanced)
 		render_list += "<span class='info ml-1'>Brain Activity Level: [(200 - M.getOrganLoss(ORGAN_SLOT_BRAIN))/2]%.</span>\n"
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Убираем нелогичный момент с возможностью проверять квирки с помощью мед. анализатора.

## Причина создания ПР / Почему это хорошо для игры
Связано с https://github.com/CeladonSS13/Shiptest/pull/2838.

## Демонстрация изменений / Тестирование
Ранее была возможность видеть квирки так:
<img width="1030" height="546" alt="image" src="https://github.com/user-attachments/assets/71284dd9-69de-4cf1-8005-d9d84ac0cca0" />

## Список изменений

```yml
🆑
tweak: Убрана возможность проверять квирки через мед. сканер.
/🆑
```
