### PR TITLE
FIX: Wading modifier fix when dock

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -128,8 +128,6 @@ GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
 	var/atom/movable/to_check = buckled || movable
 	if(!(to_check.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && !movable.throwing)
 		remove_immerse_overlay(movable)
-	if(buckled)
-		return
 	if(isliving(movable))
 		var/mob/living/living_mob = movable
 		living_mob.remove_movespeed_modifier(/datum/movespeed_modifier/wading)

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -128,6 +128,10 @@ GLOBAL_LIST_INIT(immerse_ignored_movable, typecacheof(list(
 	var/atom/movable/to_check = buckled || movable
 	if(!(to_check.movement_type & MOVETYPES_NOT_TOUCHING_GROUND) && !movable.throwing)
 		remove_immerse_overlay(movable)
+// [CELADON-DELETE] - Удалено, так как вызывало бесконечное замедление персонажа, если он был привязан к стулу, а корабль садился на воду. 
+//	if(buckled)
+//		return
+// [/CELADON-DELETE]
 	if(isliving(movable))
 		var/mob/living/living_mob = movable
 		living_mob.remove_movespeed_modifier(/datum/movespeed_modifier/wading)


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксит проблему замедления при приземлении шаттлов на тайлы с водой/лавой
## Причина создания ПР / Почему это хорошо для игры
No more tilted when dock
## Демонстрация изменений / Тестирование
Запускаем локалку. Приземляемся с включенным гравгеном на тайл с водой будучи пристегнутым, отцепляемся, ходим.
## Список изменений

```yml
🆑
fix: Исправлено замедление при приземлении шаттла на воду
/🆑
```
