### PR TITLE
FIX: Attachment menu for powered guns

### DIFF
--- a/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/gauss.dm
+++ b/mod_celadon/weapons/code/modules/projectiles/guns/ballistic/gauss.dm
@@ -16,6 +16,9 @@
 	if(!internal_magazine && loc == user && user.is_holding(src) && cell && tac_reloads && !(gun_firemodes[firemode_index] == FIREMODE_UNDERBARREL))
 		if(do_after(user, 3.5 SECONDS, src, hidden = TRUE))
 			eject_cell(user)
+		return
+	var/datum/component/attachment_holder/h = GetComponent(/datum/component/attachment_holder)
+	h.handle_alt_click(h.parent, user)
 
 NO_MAG_GUN_HELPER(automatic/powered/gauss/gar)
 NO_MAG_GUN_HELPER(automatic/powered/gauss/gar/suns)


### PR DESCRIPTION
## Описание / Что этот PR делает
Фиксит проблему снятия обвесов на оружиях типа гаусс, и других, наследуемых от powered
## Причина создания ПР / Почему это хорошо для игры
Powered оружие для стрельбы использует батарейки и магазины. При нажатии AltClick кукла могла снять только батарею, обвесы на оружие снять этим же хоткеем нельзя. Фиксы это хорошо, фиксы это здорово (возможно костыльное, но не надо было вообще переопределять AltClick у powered таким образом)
## Демонстрация изменений / Тестирование
Зайти на локалку, заспавнить гаусс, повесить на него прицел, снять батарейку через alt click, снять прицел через alt click. Положить гаусс на пол и снять прицел через alt click НЕ снимая батарейку тоже можно.
## Список изменений
```yml
🆑
fix: Убираем баг с невозможностью снять обвесы через alt click на гаусках
/🆑
```
