### PR TITLE
Ship's sensors start at max value

### DIFF
--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -151,10 +151,10 @@
 				Dock(position, force = TRUE)
 
 			refresh_engines()
-		// CELADON EDIT START
+		// [CELADON-ADD]
 		default_sensor_range = source_template.def_sensor_range
 		sensor_range = default_sensor_range
-		// CELADON EDIT END
+		// [/CELADON-ADD]
 		ship_account = new(name, source_template.starting_funds)
 		if(outpost_special_docking_perms)
 			outpost_special_dock_perms = TRUE

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -151,8 +151,9 @@
 				Dock(position, force = TRUE)
 
 			refresh_engines()
-		// [CELADON-ADD]
+
 		default_sensor_range = source_template.def_sensor_range
+		// [CELADON-ADD] - Сенсоры корабля при создании теперь получают максимальное значение, вместо 1.
 		sensor_range = default_sensor_range
 		// [/CELADON-ADD]
 		ship_account = new(name, source_template.starting_funds)

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -151,7 +151,10 @@
 				Dock(position, force = TRUE)
 
 			refresh_engines()
+		// CELADON EDIT START
 		default_sensor_range = source_template.def_sensor_range
+		sensor_range = default_sensor_range
+		// CELADON EDIT END
 		ship_account = new(name, source_template.starting_funds)
 		if(outpost_special_docking_perms)
 			outpost_special_dock_perms = TRUE

--- a/code/modules/overmap/ships/controlled_ship_datum.dm
+++ b/code/modules/overmap/ships/controlled_ship_datum.dm
@@ -151,7 +151,6 @@
 				Dock(position, force = TRUE)
 
 			refresh_engines()
-
 		default_sensor_range = source_template.def_sensor_range
 		// [CELADON-ADD] - Сенсоры корабля при создании теперь получают максимальное значение, вместо 1.
 		sensor_range = default_sensor_range


### PR DESCRIPTION
## Описание / Что этот PR делает

Сенсоры корабля при создании теперь получают максимальное значение вместо 1, избавляя игроков от необходимости каждый раз вручную увеличивать их показатель

## Причина создания ПР / Почему это хорошо для игры

qol

## Демонстрация изменений / Тестирование

Локально

## Список изменений

```yml
🆑
tweak: Сенсоры корабля теперь изначально установлены на максимально возможное значение, а не единицу.
/🆑
```
