### PR TITLE
FIX: исправление 6 ишшуев по картам

### DIFF
--- a/_maps/_mod_celadon/configs/nanotrasen_savior.json
+++ b/_maps/_mod_celadon/configs/nanotrasen_savior.json
@@ -20,7 +20,7 @@
 	],
 	"job_slots": {
 		"Medical Director": {
-			"outfit": "/datum/outfit/job/cel/nanotrasen/cmo/deforest_cmo",
+			"outfit": "/datum/outfit/job/cel/nanotrasen/captain/deforest_captain",
 			"officer": true,
 			"slots": 1
 		},

--- a/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
@@ -1410,14 +1410,14 @@
 /turf/open/floor/plating,
 /area/ship/engineering)
 "rH" = (
-/obj/structure/filingcabinet/medical,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/borderfloor{
 	dir = 6
 	},
 /obj/effect/turf_decal/corner/opaque/green{
 	dir = 1
 	},
+/obj/structure/filingcabinet,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "rZ" = (

--- a/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_riggs.dmm
@@ -4026,7 +4026,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/starboard)
 "Vq" = (
-/obj/structure/filingcabinet/security,
+/obj/structure/filingcabinet,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/plasteel/grimy,
 /area/ship/security)

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_celestis.dmm
@@ -144,7 +144,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "bF" = (
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -1126,9 +1126,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
 "hi" = (
-/obj/machinery/camera{
-	dir = 6
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/patterned,
 /area/ship/cargo)
 "hk" = (
@@ -1307,7 +1305,7 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering/engine)
 "hC" = (
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -1323,9 +1321,6 @@
 /area/ship/hallway/central)
 "hJ" = (
 /obj/effect/turf_decal/techfloor,
-/obj/machinery/camera{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -1336,6 +1331,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering/engine)
 "hK" = (
@@ -1691,7 +1689,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "ka" = (
@@ -1873,11 +1871,11 @@
 /area/ship/medical)
 "lm" = (
 /obj/effect/turf_decal/trimline/opaque/vired/line,
-/obj/machinery/camera{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/security)
@@ -2284,8 +2282,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/camera{
-	dir = 10
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
@@ -2823,7 +2821,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering/engines/starboard)
 "qT" = (
@@ -3758,7 +3756,7 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/telecomms_floor,
@@ -3807,11 +3805,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engine)
@@ -4073,6 +4071,13 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"xR" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/machinery/computer/cryopod/directional/east,
+/turf/open/floor/plasteel/telecomms_floor,
+/area/ship/crew/cryo)
 "xZ" = (
 /obj/machinery/door/airlock/medical/glass{
 	dir = 1;
@@ -4124,13 +4129,13 @@
 /obj/effect/turf_decal/trimline/opaque/deforestblue/line{
 	dir = 1
 	},
-/obj/machinery/camera,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/sign/poster/nanotrasen/deforest_hypospray{
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "yu" = (
@@ -4807,7 +4812,6 @@
 /obj/item/stack/tape,
 /obj/item/clothing/shoes/sneakers/brown,
 /obj/item/spacecash/bundle/loadsamoney,
-/obj/machinery/camera,
 /obj/item/clothing/suit/hooded/wintercoat/cargo,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
@@ -4898,13 +4902,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/camera,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering/engine)
 "CK" = (
@@ -4919,8 +4923,8 @@
 "CX" = (
 /obj/effect/turf_decal/trimline/opaque/ntblue/line,
 /obj/effect/turf_decal/spline/fancy/opaque/vired,
-/obj/machinery/camera{
-	dir = 10
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
@@ -5361,9 +5365,6 @@
 /area/ship/engineering/engine)
 "FA" = (
 /obj/structure/crate_shelf,
-/obj/machinery/camera{
-	dir = 1
-	},
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo)
 "FB" = (
@@ -5585,7 +5586,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono,
@@ -5593,7 +5594,7 @@
 "Hp" = (
 /obj/structure/table/optable,
 /obj/machinery/light/directional/north,
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/ship/medical)
 "Hq" = (
@@ -5611,7 +5612,7 @@
 /turf/open/floor/plasteel/white,
 /area/ship/general/science)
 "Hv" = (
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /obj/effect/landmark/start/shaft_miner,
@@ -5904,7 +5905,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ship/crew/toilet)
 "Jw" = (
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -6362,7 +6363,7 @@
 "MQ" = (
 /obj/effect/turf_decal/spline/fancy/opaque/nakamuraayellow,
 /obj/effect/turf_decal/trimline/opaque/nakamuraayellow/line,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/mono,
@@ -6793,7 +6794,7 @@
 /obj/item/clothing/suit/space/hardsuit/engine,
 /obj/item/clothing/mask/gas,
 /obj/item/tank/internals/oxygen/yellow,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -6896,7 +6897,7 @@
 	pixel_x = -11;
 	pixel_y = 24
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7102,13 +7103,13 @@
 /area/ship/hallway/central)
 "QM" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/camera{
-	dir = 8
-	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = -5;
 	pixel_y = -22
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/bridge)
@@ -7117,7 +7118,7 @@
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "QT" = (
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/carpet/executive,
 /area/ship/crew/law_office)
 "Ra" = (
@@ -7812,10 +7813,10 @@
 /area/ship/engineering/engine)
 "UP" = (
 /obj/effect/turf_decal/spline/fancy/opaque/black,
-/obj/machinery/camera{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/camera/autoname{
 	dir = 1
 	},
 /turf/open/floor/plasteel/patterned,
@@ -7917,7 +7918,7 @@
 	pixel_x = 0;
 	pixel_y = 2
 	},
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ship/medical)
 "VZ" = (
@@ -8145,10 +8146,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer4{
 	dir = 8
 	},
-/obj/machinery/camera,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering/engine)
 "XD" = (
@@ -8235,7 +8236,6 @@
 /area/ship/external/dark)
 "Yl" = (
 /obj/effect/turf_decal/corner/opaque/white/diagonal,
-/obj/machinery/camera,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -8243,6 +8243,7 @@
 	pixel_x = 10;
 	pixel_y = 23
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/ship/crew/canteen/kitchen)
 "Yq" = (
@@ -8341,9 +8342,7 @@
 /obj/effect/turf_decal/spline/fancy/opaque/ntblue{
 	dir = 1
 	},
-/obj/machinery/camera{
-	dir = 6
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/mono,
 /area/ship/hallway/central)
 "Zk" = (
@@ -9778,7 +9777,7 @@ bw
 fR
 ba
 KM
-KM
+xR
 vF
 fR
 pD

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -534,7 +534,7 @@
 "dd" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Quarters";
-	req_access_txt = "19"
+	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2498,7 +2498,8 @@
 /obj/structure/closet/secure_closet{
 	anchored = 1;
 	icon_state = "rd";
-	name = "science director's locker"
+	name = "science director's locker";
+	req_access_txt = "30"
 	},
 /obj/item/aicard,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -4058,7 +4059,8 @@
 /obj/structure/closet/secure_closet{
 	icon_state = "qm";
 	name = "captain's locker";
-	anchored = 1
+	anchored = 1;
+	req_access_txt = "20"
 	},
 /obj/item/gun/energy/sharplite/x26,
 /obj/item/stock_parts/cell/gun/sharplite/mini,
@@ -4245,7 +4247,7 @@
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
 	dir = 8;
-	req_one_access = list(41)
+	req_access_txt = "19"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4

--- a/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
+++ b/_maps/_mod_celadon/shuttles/nanotrasen/nanotrasen_squab.dmm
@@ -443,14 +443,14 @@
 	pixel_x = 1;
 	pixel_y = -32
 	},
-/obj/machinery/camera{
-	dir = 10;
-	pixel_x = 12;
-	pixel_y = 0
-	},
 /obj/structure/extinguisher_cabinet/directional/south{
 	pixel_x = -10;
 	pixel_y = -28
+	},
+/obj/machinery/camera/autoname{
+	dir = 10;
+	pixel_x = 12;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/cargo)
@@ -1018,8 +1018,8 @@
 	pixel_x = -4;
 	pixel_y = -1
 	},
-/obj/machinery/camera{
-	dir = 10
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/tech,
 /area/ship/science/robotics)
@@ -1287,11 +1287,11 @@
 /area/ship/security)
 "jC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
 	},
 /obj/structure/sign/number/random,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "jR" = (
@@ -1336,6 +1336,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
 /obj/effect/mapping_helpers/crate_shelve,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/cargo/port)
@@ -1489,7 +1490,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	layer = 2.041
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 10;
 	pixel_x = -10;
 	pixel_y = 0
@@ -1995,7 +1996,7 @@
 /obj/effect/turf_decal/trimline/transparent/white/filled/warning{
 	dir = 4
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -2939,7 +2940,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	pixel_x = 10;
 	pixel_y = 0
 	},
@@ -3906,7 +3907,7 @@
 /obj/effect/turf_decal/borderfloorblack{
 	dir = 5
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 4;
 	pixel_x = 0;
 	pixel_y = -12
@@ -4045,11 +4046,11 @@
 	},
 /obj/structure/chair/plastic,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/camera{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/engineering)
@@ -4235,7 +4236,7 @@
 /obj/effect/turf_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/plasteel/tech/techmaint,
@@ -4433,7 +4434,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 10;
 	pixel_x = -10;
 	pixel_y = 0
@@ -4826,7 +4827,6 @@
 /obj/effect/turf_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/camera,
 /obj/item/modular_computer/tablet/preset/advanced{
 	icon_state = "tablet-brown"
 	},
@@ -4850,6 +4850,7 @@
 	pixel_x = 0;
 	pixel_y = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/patterned/grid/dark,
 /area/ship/cargo/port)
 "QU" = (
@@ -5024,7 +5025,7 @@
 	pixel_x = 9;
 	pixel_y = 6
 	},
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 10
 	},
 /turf/open/floor/wood/yew,
@@ -5199,7 +5200,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/camera,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo/office)
 "SA" = (
@@ -5225,7 +5226,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/camera{
+/obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_cybersun_cirrus.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_cybersun_cirrus.dmm
@@ -4788,6 +4788,9 @@
 	dir = 8
 	},
 /obj/structure/catwalk/over/plated_catwalk/dark,
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engines/starboard)
 "HR" = (
@@ -5098,6 +5101,9 @@
 	dir = 2;
 	pixel_x = 10;
 	pixel_y = 21
+	},
+/obj/structure/cable/cyan{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/engines/starboard)

--- a/mod_celadon/outfit/code/nanotrasen/_card_id.dm
+++ b/mod_celadon/outfit/code/nanotrasen/_card_id.dm
@@ -30,6 +30,11 @@
 	assignment = "Assistant"
 
 // MARK: DeForest
+/obj/item/card/id/cel/nanotrasen/deforest_cmo/captain
+	desc = "A DeForest Medical ID with no proper access to speak of. This one indicates a DeForest Captain."
+	icon_state = "iddf_chiefmedicalofficer"
+	assignment = "Captain"
+
 /obj/item/card/id/cel/nanotrasen/deforest_cmo
 	desc = "A DeForest Medical ID with no proper access to speak of. This one indicates a Medical Director."
 	icon_state = "iddf_chiefmedicalofficer"

--- a/mod_celadon/outfit/code/nanotrasen/_card_id.dm
+++ b/mod_celadon/outfit/code/nanotrasen/_card_id.dm
@@ -31,7 +31,7 @@
 
 // MARK: DeForest
 /obj/item/card/id/cel/nanotrasen/deforest_cmo/captain
-	desc = "A DeForest Medical ID with no proper access to speak of. This one indicates a DeForest Captain."
+	desc = "A DeForest Medical ID with no proper access to speak of. This one indicates a Captain."
 	icon_state = "iddf_chiefmedicalofficer"
 	assignment = "Captain"
 

--- a/mod_celadon/outfit/code/nanotrasen/deforest_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/deforest_outfit.dm
@@ -1,4 +1,28 @@
-// MARK: NT DeForest
+// MARK: Captain
+
+/datum/outfit/job/cel/nanotrasen/captain/deforest_captain
+
+	name = "NT DeForest - Captain"
+
+	belt = /obj/item/pda/heads/cmo
+
+	ears = /obj/item/radio/headset/nanotrasen/captain
+	head = /obj/item/clothing/head/beret/cmo
+	uniform = /obj/item/clothing/under/nanotrasen/medical/director
+	shoes = /obj/item/clothing/shoes/laceup
+	glasses = /obj/item/clothing/glasses/sunglasses
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
+	suit = /obj/item/clothing/suit/toggle/labcoat/nanotrasen/blue
+	dcoat = /obj/item/clothing/suit/hooded/wintercoat/medical
+	backpack = /obj/item/storage/backpack/medic
+	satchel = /obj/item/storage/backpack/satchel/med
+	courierbag = /obj/item/storage/backpack/messenger/med
+
+	chameleon_extras = /obj/item/stamp/cmo
+
+	id = /obj/item/card/id/cel/nanotrasen/deforest_cmo/captain
+
+// MARK: Command
 
 /datum/outfit/job/cel/nanotrasen/cmo/deforest_cmo
 	name = "NT DeForest - Medical Director"
@@ -7,6 +31,8 @@
 	id = /obj/item/card/id/cel/nanotrasen/deforest_cmo
 
 	belt = /obj/item/pda/heads/cmo
+
+// MARK: Crew
 
 /datum/outfit/job/cel/nanotrasen/scientist/deforest_researcher
 	name = "NT DeForest - Scientist"

--- a/mod_celadon/outfit/code/nanotrasen/nslogistics_outfit.dm
+++ b/mod_celadon/outfit/code/nanotrasen/nslogistics_outfit.dm
@@ -59,7 +59,7 @@
 
 /datum/outfit/job/cel/nanotrasen/engineer/nslogistics
 	name = "NT N+S Logistics - Repair Technician"
-	job_icon = "engineer"
+	job_icon = "stationengineer"
 
 	head = /obj/item/clothing/head/hardhat/nanotrasen/blue
 	suit = /obj/item/clothing/suit/nanotrasen/vest/blue


### PR DESCRIPTION
## Описание / Что этот PR делает

https://github.com/CeladonSS13/Shiptest/issues/2811
Камеры на Squab и Celestis теперь autoname и показываются в изначально намаппленных консолях камер (на сквабе таковой нет)

https://github.com/CeladonSS13/Shiptest/issues/2849
Два куска кабеля проведены, АПЦ запитано

https://github.com/CeladonSS13/Shiptest/issues/2809
Панель криокамер установлена

https://github.com/CeladonSS13/Shiptest/issues/2792
Картотека заменена на пустую(в том числе и у СБ)

https://github.com/CeladonSS13/Shiptest/issues/2683
Создан новый, приведённый к стандарту, аутфит капитана Дефорест, у него ПОЛНЫЙ, а не СМОшный доступ.

На Squab добавлена капельница в ящик с кровью
На Squab РД теперь может зайти на мостик и к себе без капитана
На Squab ролька инженера получила иконку гаечного ключа на СБхуде(у меня на локалке они ПОЧЕМУ-ТО не работают, но оно должно примениться)

## Причина создания ПР / Почему это хорошо для игры

## Демонстрация изменений / Тестирование

https://github.com/CeladonSS13/Shiptest/issues/2811

<img width="1919" height="951" alt="Снимок экрана 2026-06-13 135410" src="https://github.com/user-attachments/assets/939c1efe-2105-40f4-a45a-e38f87d4fa19" />

https://github.com/CeladonSS13/Shiptest/issues/2849

<img width="1091" height="543" alt="image" src="https://github.com/user-attachments/assets/4a354153-3661-4a51-8c58-6f32d3e1b589" />

https://github.com/CeladonSS13/Shiptest/issues/2809

<img width="720" height="393" alt="image" src="https://github.com/user-attachments/assets/a60d5472-fabc-42d6-a1dd-df3f3ffd6435" />

## Список изменений

```yml
🆑
map: Камеры Celestis теперь привязываются к его консолям камер, в его дормах появилась консоль крио.
map: Теперь все АПЦ Cirrus работают исправно.
map: Картотеки в меде и СБ Riggs теперь пустые.
map: Капитан Savior теперь не просто СМО(получил полный доступ).
map: Squab получил капельницу в ящик с кровью, иконку джобки инженера и фикс доступов мостика.
/🆑
```
