### PR TITLE
FIX: Возвращает функционал всех on_process проков квирков

### DIFF
--- a/mod_celadon/return_content_quirks/code/traits/good.dm
+++ b/mod_celadon/return_content_quirks/code/traits/good.dm
@@ -2,6 +2,7 @@
 	name = "Drunken Resilience"
 	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
 	value = 2
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	mob_traits = list(TRAIT_DRUNK_HEALING)
 	gain_text = "<span class='notice'>You feel like a drink would do you good.</span>"
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
@@ -26,6 +27,7 @@
 	name = "Jolly"
 	desc = "You sometimes just feel happy, for no reason at all."
 	value = 1
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	mob_traits = list(TRAIT_JOLLY)
 	medical_record_text = "Patient demonstrates constant euthymia irregular for environment. It's a bit much, to be honest."
 

--- a/mod_celadon/return_content_quirks/code/traits/negative.dm
+++ b/mod_celadon/return_content_quirks/code/traits/negative.dm
@@ -2,6 +2,7 @@
 	name = "Bad Back"
 	desc = "Thanks to your poor posture, backpacks and other bags never sit right on your back. More evently weighted objects are fine, though."
 	value = -2
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>Your back REALLY hurts!</span>"
 	lose_text = "<span class='notice'>Your back feels better.</span>"
 	medical_record_text = "Patient scans indicate severe and chronic back pain."
@@ -17,6 +18,7 @@
 	name = "Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."
 	value = -2
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
 	lose_text = "<span class='notice'>You feel vigorous again.</span>"
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
@@ -33,6 +35,7 @@
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
 	value = -3
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>You feel smooth.</span>"
 	lose_text = "<span class='notice'>You feel wrinkled again.</span>"
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
@@ -45,6 +48,7 @@
 	desc = "You sometimes just hate life."
 	mob_traits = list(TRAIT_DEPRESSION)
 	value = -1
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>You start feeling depressed.</span>"
 	lose_text = "<span class='notice'>You no longer feel depressed.</span>" //if only it were that easy!
 	medical_record_text = "Patient has a mild mood disorder causing them to experience acute episodes of depression."
@@ -57,6 +61,7 @@
 	name = "Family Heirloom"
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
 	value = -1
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	var/obj/item/heirloom
 	var/where
 	medical_record_text = "Patient demonstrates an unnatural attachment to a family heirloom."
@@ -201,6 +206,7 @@
 	name = "Nyctophobia"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
 	value = -1
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	medical_record_text = "Patient demonstrates a fear of the dark. (Seriously?)"
 
 /datum/quirk/nyctophobia/on_process(seconds_per_tick)
@@ -239,6 +245,7 @@
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
 	value = -2
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	//no mob trait because it's handled uniquely
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
@@ -259,6 +266,7 @@
 	name = "Social Anxiety"
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	value = -1
+	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
 	lose_text = "<span class='notice'>You feel easier about talking again.</span>" //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."


### PR DESCRIPTION
## Описание / Что этот PR делает
Были сломаны все квирки что использовали `on_process` прок (depression, nyctophobia, heirloom)

## Причина создания ПР / Почему это хорошо для игры
Квирки были сломаны

## Демонстрация изменений / Тестирование
<img width="454" height="226" alt="image" src="https://github.com/user-attachments/assets/38326c19-3569-47af-bdce-7d300c171f49" />

## Список изменений

```yml
🆑
fix: Исправлены квирки использующие on_process прок.
/🆑
```
