### PR TITLE
FIX: Don't push module to unit if it's already equipped

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -447,6 +447,12 @@
 		if(BP)
 			BP.deactivate(R, user)
 			to_chat(user, span_notice("You remove the defibrillator unit to make room for the compact upgrade."))
+		// [CELADON-ADD] - FIX - Исправление бага, который позволяет устанавливать бесконечное количество подобных модулей.
+		var/obj/item/shockpaddles/cyborg/LS = locate() in R.module
+		if(LS)
+			to_chat(user, span_warning("This unit is already equipped with a defibrillator module!"))
+			return FALSE
+		// [/CELADON-ADD]
 		var/obj/item/shockpaddles/cyborg/S = new(R.module)
 		R.module.basic_modules += S
 		R.module.add_module(S, FALSE, TRUE)
@@ -472,7 +478,14 @@
 
 /obj/item/borg/upgrade/processor/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
+
 	if(.)
+		// [CELADON-ADD] - FIX - Исправление бага, который позволяет устанавливать бесконечное количество подобных модулей.
+		var/obj/item/surgical_processor/LP = locate() in R.module
+		if(LP)
+			to_chat(user, span_warning("This unit is already equipped with a surgical processor module!"))
+			return FALSE
+		// [/CELADON-ADD]
 		var/obj/item/surgical_processor/SP = new(R.module)
 		R.module.basic_modules += SP
 		R.module.add_module(SP, FALSE, TRUE)


### PR DESCRIPTION
## Описание / Что этот PR делает

**- Закрываем баг - https://github.com/CeladonSS13/Shiptest/issues/2876.**
Связано с https://github.com/shiptest-ss13/Shiptest/pull/6415

Ранее была возможность пихать модули `defibrillator` и `surgical processor` в борга бесконечно, что приводило к такому виду:

<img width="573" height="360" alt="image" src="https://github.com/user-attachments/assets/4b340675-4477-4275-ba55-2deb851c08a9" />
<img width="1918" height="1072" alt="image" src="https://github.com/user-attachments/assets/814b3b71-ac32-46ec-bf41-a1ddee725347" />

## Демонстрация изменений / Тестирование

После попытки вставить аналогичный модуль, что уже присутствует в борге, плата будет платать на пол, абсолютно также, как уже реализовано с другими модулями.

## Список изменений

```yml
🆑
fix: Исправление бага, что позволял бесконечно стакать модули в борге.
/🆑
```
