### PR TITLE
UPDATE: Обновление стоимости текущих квирков

### DIFF
--- a/code/datums/traits/negative/bad_touch.dm
+++ b/code/datums/traits/negative/bad_touch.dm
@@ -2,7 +2,7 @@
 	name = "Bad Touch"
 	desc = "You don't like hugs. You'd really prefer if people just left you alone."
 	mob_traits = list(TRAIT_BADTOUCH)
-	value = -1
+	value = 0 // [CELADON-EDIT] - OLD CODE: -1
 	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_MOODLET_BASED | QUIRK_HIDE_FROM_SCAN
 	gain_text = span_danger("You just want people to leave you alone.")
 	lose_text = span_notice("You could use a big hug.")

--- a/code/datums/traits/negative/frail.dm
+++ b/code/datums/traits/negative/frail.dm
@@ -1,7 +1,7 @@
 /datum/quirk/frail
 	name = "Frail"
 	desc = "You have skin of paper and bones of glass! You suffer wounds much more easily than most."
-	value = -2
+	value = -3 // [CELADON-EDIT] - OLD CODE: -2
 	mob_traits = TRAIT_EASILY_WOUNDED
 	gain_text = span_danger("You feel frail.")
 	lose_text = span_notice("You feel sturdy again.")

--- a/code/datums/traits/negative/light_drinker.dm
+++ b/code/datums/traits/negative/light_drinker.dm
@@ -1,7 +1,7 @@
 /datum/quirk/light_drinker
 	name = "Light Drinker"
 	desc = "You just can't handle your drinks and get drunk very quickly."
-	value = -1
+	value = 0 // [CELADON-EDIT] - OLD CODE: -1
 	mob_traits = list(TRAIT_LIGHT_DRINKER)
 	gain_text = span_notice("Just the thought of drinking alcohol makes your head spin.")
 	lose_text = span_danger("You're no longer severely affected by alcohol.")

--- a/code/datums/traits/negative/prosopagnosia.dm
+++ b/code/datums/traits/negative/prosopagnosia.dm
@@ -1,6 +1,6 @@
 /datum/quirk/prosopagnosia
 	name = "Prosopagnosia"
 	desc = "You have a mental disorder that prevents you from being able to recognize faces at all."
-	value = -1
+	value = 0 // [CELADON-EDIT] - OLD CODE: -1
 	mob_traits = list(TRAIT_PROSOPAGNOSIA)
 	medical_record_text = "Patient suffers from prosopagnosia and cannot recognize faces."

--- a/code/datums/traits/negative/scarred_eye.dm
+++ b/code/datums/traits/negative/scarred_eye.dm
@@ -2,7 +2,7 @@
 	name = "Scarred Eye"
 	desc = "An accident in your past has cost you one of your eyes, but you got a cool eyepatch. Yarr!"
 	//icon = FA_ICON_EYE_SLASH
-	value = -1
+	value = 0 // [CELADON-EDIT] - OLD CODE: -1
 	gain_text = span_danger("After all this time, your eye still stings a bit...")
 	lose_text = span_notice("Your peripherial vision grows by about thirty percent.")
 	medical_record_text = "Patient has severe scarring on one of their eyes, resulting in partial vision loss."

--- a/code/datums/traits/neutral/rilena_fan.dm
+++ b/code/datums/traits/neutral/rilena_fan.dm
@@ -1,7 +1,7 @@
 /datum/quirk/fan_rilena
 	name = "RILENA Super Fan"
 	desc = "You are a major fan of the popular webseries RILENA: LMR. You get a mood boost from plushies of your favorite characters, and wearing your Xader pin."
-	value = 0
+	value = 1 // [CELADON-EDIT] - OLD CODE: 0
 	mob_traits = list(TRAIT_FAN_RILENA)
 	gain_text = span_notice("You are a huge fan of a certain combination webcomic and bullet hell game.")
 	lose_text = span_danger("Suddenly, bullet hell games and webcomics don't seem all that interesting anymore...")

--- a/code/datums/traits/neutral/vegetarian.dm
+++ b/code/datums/traits/neutral/vegetarian.dm
@@ -1,7 +1,7 @@
 /datum/quirk/vegetarian
 	name = "Vegetarian"
 	desc = "You find the idea of eating meat morally and physically repulsive."
-	value = 0
+	value = -1 // [CELADON-EDIT] - OLD CODE: 0
 	gain_text = span_notice("You feel repulsion at the idea of eating meat.")
 	lose_text = span_notice("You feel like eating meat isn't that bad.")
 	medical_record_text = "Patient reports a vegetarian diet."

--- a/mod_celadon/quirks/code/neutral.dm
+++ b/mod_celadon/quirks/code/neutral.dm
@@ -1,7 +1,7 @@
 /datum/quirk/dwarfism
 	name = "Dwarfism"
 	desc = "A mutation believed to be the cause of dwarfism."
-	value = 4 // [CELADON-ADD] - NO_FUN_ALLOWED_SPECIES
+	value = 4
 	mob_traits = list(TRAIT_DWARF)
 	gain_text = span_notice("Everything around you seems to grow..")
 	lose_text = span_danger("Everything around you seems to shrink..")

--- a/mod_celadon/return_content_quirks/code/traits/negative.dm
+++ b/mod_celadon/return_content_quirks/code/traits/negative.dm
@@ -17,7 +17,7 @@
 /datum/quirk/blooddeficiency
 	name = "Blood Deficiency"
 	desc = "Your body can't produce enough blood to sustain itself."
-	value = -2
+	value = -3
 	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
 	lose_text = "<span class='notice'>You feel vigorous again.</span>"
@@ -60,7 +60,7 @@
 /datum/quirk/family_heirloom
 	name = "Family Heirloom"
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
-	value = -1
+	value = 0
 	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_PROCESSES
 	var/obj/item/heirloom
 	var/where
@@ -228,7 +228,7 @@
 /datum/quirk/nonviolent
 	name = "Pacifist"
 	desc = "The thought of violence makes you sick. So much so, in fact, that you can't hurt anyone."
-	value = -2
+	value = -5
 	mob_traits = list(TRAIT_PACIFISM)
 	gain_text = "<span class='danger'>You feel repulsed by the thought of violence!</span>"
 	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
@@ -237,7 +237,7 @@
 /datum/quirk/poor_aim
 	name = "Poor Aim"
 	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
-	value = -1
+	value = -2
 	mob_traits = list(TRAIT_POOR_AIM)
 	medical_record_text = "Patient possesses a strong tremor in both hands."
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Пересмотр стоимости текущих квирков.
Делаем цену квиркам более корректной под реалии шиптеста. 

Идея от `trupexe` и корректировки от @Vairkharst (Evandel/Shiptest Head) 

<img width="1206" height="428" alt="image" src="https://github.com/user-attachments/assets/4d230b5d-0b60-4369-9aae-a91ea107fdea" />


## Демонстрация изменений / Тестирование

**Стоимость квирков:**

Bad Touch: `-1` > `0`
Frail: `-2` > `-3`
Light Drinker: `-1` > `0`
Prosopagnosia: `-1` > `0`
Scarred Eye: `-1` > `0`
RILENA Super Fan: `0` > `1`
Vegetarian: `0` > `-1`
Blood Deficiency: `-2` > `-3`
Family Heirloom: `-1` > `0`
Pacifist: `-2` > `-5`
Poor Aim: `-1` > `-2`

## Список изменений

```yml
🆑
balance: Изменена стоимость некоторых квирков.
/🆑
```
