### PR TITLE
FIX: ИИ вновь может вайпнуть ядро в OOC панели

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1039,6 +1039,7 @@
 
 	// We warned you.
 	var/obj/structure/AIcore/latejoin_inactive/inactivecore = new /obj/structure/AIcore/latejoin_inactive(loc)
+	new /obj/item/mmi/posibrain(loc)
 	transfer_fingerprints_to(inactivecore)
 
 	if(GLOB.announcement_systems.len)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1034,12 +1034,18 @@
 	set desc = "Wipe your core. This is functionally equivalent to cryo, freeing up your job slot."
 
 	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
+	// [CELADON-EDIT] - Fix Runtimes
+	// OLD CODE: if(tgui_alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo). Are you entirely sure you want to do this?", "Wipe Core", list("No", "Yes")) != "Yes")
 	if(tgui_alert(src,"WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo). Are you entirely sure you want to do this?", "Wipe Core", list("No", "Yes")) != "Yes")
+	// [/CELADON-EDIT]
 		return
 
 	// We warned you.
+	// [CELADON-EDIT] - Fix Runtimes
+	// OLD CODE: var/obj/structure/AIcore/latejoin_inactive/inactivecore = New(loc)
 	var/obj/structure/AIcore/latejoin_inactive/inactivecore = new /obj/structure/AIcore/latejoin_inactive(loc)
 	new /obj/item/mmi/posibrain(loc)
+	// [/CELADON-EDIT]
 	transfer_fingerprints_to(inactivecore)
 
 	if(GLOB.announcement_systems.len)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1034,11 +1034,11 @@
 	set desc = "Wipe your core. This is functionally equivalent to cryo, freeing up your job slot."
 
 	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
-	if(tgui_alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo). Are you entirely sure you want to do this?", "Wipe Core", list("No", "Yes")) != "Yes")
+	if(tgui_alert(src,"WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo). Are you entirely sure you want to do this?", "Wipe Core", list("No", "Yes")) != "Yes")
 		return
 
 	// We warned you.
-	var/obj/structure/AIcore/latejoin_inactive/inactivecore = New(loc)
+	var/obj/structure/AIcore/latejoin_inactive/inactivecore = new /obj/structure/AIcore/latejoin_inactive(loc)
 	transfer_fingerprints_to(inactivecore)
 
 	if(GLOB.announcement_systems.len)


### PR DESCRIPTION
## Описание / Что этот PR делает

Фикс бага https://github.com/CeladonSS13/Shiptest/issues/2812

Игроку не выдавало TGUI-окно, однако даже если бы и выдавало, создавались рантаймы из-за того, что вместо неактивного ядра пыталось создаться обычное ядро.

Кнопка вайпа: `OOC - Wipe Core`

- Глаза ИИ больше не дублируются.
- Рантаймы не возникают.
- Когда игрок вайпается, то будет создаваться пустой позитронный мозг на тайле с ИИ.

## Список изменений

```yml
🆑
fix: исправлен вывод TGUI окна игроку на ИИ.
fix: исправлено создание неактивного ИИ на месте вайпнутого.
/🆑
```
