### PR TITLE
FIX: Don't push module to unit if it's already equipped №2

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -569,8 +569,10 @@
 /obj/item/borg/upgrade/rped/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-
-		var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R
+		// [CELADON-EDIT] - FIX - Исправление бага, который позволяет устанавливать бесконечное количество подобных модулей.
+		// var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R
+		var/obj/item/borg/upgrade/rped/RPED = locate() in R
+		// [/CELADON-EDIT]
 		if(RPED)
 			to_chat(user, span_warning("This unit is already equipped with a RPED module!"))
 			return FALSE
@@ -582,7 +584,10 @@
 /obj/item/borg/upgrade/rped/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-		var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R.module
+		// [CELADON-EDIT] - FIX - Исправление бага, который позволяет устанавливать бесконечное количество подобных модулей.
+		// var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R.module
+		var/obj/item/borg/upgrade/rped/RPED = locate() in R.module
+		// [/CELADON-EDIT]
 		if (RPED)
 			R.module.remove_module(RPED, TRUE)
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Доработки PR`a - https://github.com/CeladonSS13/Shiptest/pull/2878

## Причина создания ПР / Почему это хорошо для игры
Ранее была возможность пихать модули RPED в борга бесконечно, теперь нельзя.

## Список изменений
```yml
🆑
fix: Исправлена возможность стакать модули RPED в борге.
/🆑
```
