### PR TITLE
DEL: Удаляем контейнеры с romerol на текущих модульных картах

### DIFF
--- a/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
+++ b/_maps/_mod_celadon/RandomRuins/JungleRuins/jungle_medtech_outbreak.dmm
@@ -1253,6 +1253,7 @@
 /obj/item/reagent_containers/glass/bottle{
 	desc = "A small bottle, it is cracked in several spots.";
 	name = "Empty Romerol sample";
+	list_reagents = null;
 	pixel_x = -9;
 	pixel_y = 2
 	},

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/ntfacility.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/ntfacility.dmm
@@ -121,7 +121,8 @@
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/romerol{
 	desc = "A serum that restart a patients heart without the use of a defibilator. Although it deals tissue damage when its in a alive patient, it heals organ damage. The more badly damaged a a patient is, the more resucator is needed.";
-	name = "resuscator bottle"
+	name = "resuscator bottle";
+	list_reagents = null
 	},
 /obj/item/reagent_containers/syringe,
 /obj/effect/decal/cleanable/dirt/dust,

--- a/_maps/_mod_celadon/RandomRuins/SpaceRuins/vi_deepstorage.dmm
+++ b/_maps/_mod_celadon/RandomRuins/SpaceRuins/vi_deepstorage.dmm
@@ -2320,7 +2320,8 @@
 "oy" = (
 /obj/item/reagent_containers/glass/bottle/romerol{
 	desc = "A small bottle with the words 'CONTAGIOUS SAMPLE' written on it. Probably not the best idea to drink it.";
-	name = "contagion bottle"
+	name = "contagion bottle";
+	list_reagents = null
 	},
 /obj/structure/safe/floor,
 /obj/machinery/camera/autoname{


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь бутылки с Romerol будут появляться пустыми на руинках.

## Причина создания ПР / Почему это хорошо для игры
Romerol позволял стать зомби и получить почти что бессмертие, кроме этого была возможность заражать остальных и устраивать хаос на аванпосте.

## Демонстрация изменений / Тестирование
<img width="543" height="93" alt="image" src="https://github.com/user-attachments/assets/a25d99b0-4f68-4ce9-9bc6-da088e10db49" />

## Список изменений

```yml
🆑
map: Все пузырьки с romerol на руинах успешно выпиты (реагенты очищены).
/🆑
```
