### PR TITLE
FIX: Невидимый броник на Elegia

### DIFF
--- a/mod_celadon/items/code/clothing/suits.dm
+++ b/mod_celadon/items/code/clothing/suits.dm
@@ -73,7 +73,7 @@
 
 /obj/item/clothing/suit/armor/vest/cybersun/trauma
 	name = "cybersun trauma team armor vest"
-	icon_state = "traumavest"
+	icon_state = "trauma_vest"
 	desc = "A set of stamped plasteel armor plates decorated with a medical cross and colors associated with the medical division of Cybersun."
 
 /obj/item/clothing/suit/toggle/leather_jacket


### PR DESCRIPTION
## Описание / Что этот PR делает

Делает `cybersun trauma team armor vest` видимым

## Причина создания ПР / Почему это хорошо для игры

мелкий баг которого не должно быть, да и возникали проблемы по типу `"почему я не могу надеть броню...."`

## Демонстрация изменений / Тестирование
Было
<img width="167" height="155" alt="изображение" src="https://github.com/user-attachments/assets/1bde2669-d8c0-4026-ac9e-a69d0869aa33" />
<img width="405" height="123" alt="изображение" src="https://github.com/user-attachments/assets/ac3d87d7-e740-42d6-95a0-a1577eb6d35d" />
Стало
<img width="180" height="166" alt="изображение" src="https://github.com/user-attachments/assets/2981877a-d3a2-4adc-ad36-0b3d140e40cf" />
<img width="430" height="127" alt="изображение" src="https://github.com/user-attachments/assets/93cc169e-4175-4ee0-9c4a-cf167fc48804" />



## Список изменений

```yml
🆑
fix: Исправлено отображение броника на Elegia
/🆑
```
