### PR TITLE
FIX: Исправление доступов для фракции Solar Federation

### DIFF
--- a/mod_celadon/outfit/code/solfed/_outfit.dm
+++ b/mod_celadon/outfit/code/solfed/_outfit.dm
@@ -14,16 +14,20 @@
 
 /datum/outfit/job/cel/solfed/proc/get_solfed_captain_access(mob/living/carbon/human/H)
 	var/obj/item/storage/wallet/W = null
+	var/obj/item/card/id/I = null
 	for (var/obj/item/O in H.contents)
 		if (istype(O, /obj/item/storage/wallet))
 			W = O
 			break
-	if (W)
-		var/obj/item/card/id/I = null
-		for (var/obj/item/O in W.contents)
-			if (istype(O, /obj/item/card/id))
-				I = O
-				break
+		else if(istype(O, /obj/item/card/id))
+			I = O
+			break
+	if (W | I)
+		if(W)
+			for (var/obj/item/O in W.contents)
+				if (istype(O, /obj/item/card/id))
+					I = O
+					break
 		if (I)
 			I.access += list(ACCESS_SOLGOV, ACCESS_CAPTAIN, ACCESS_ENGINE, ACCESS_MEDICAL, ACCESS_ARMORY, ACCESS_BRIG, ACCESS_SECURITY, ACCESS_OUTPOST_FACTION_SOLFED)
 			I.update_label()
@@ -33,16 +37,20 @@
 
 /datum/outfit/job/cel/solfed/proc/get_solfed_head_access(mob/living/carbon/human/H)
 	var/obj/item/storage/wallet/W = null
+	var/obj/item/card/id/I = null
 	for (var/obj/item/O in H.contents)
 		if (istype(O, /obj/item/storage/wallet))
 			W = O
 			break
-	if (W)
-		var/obj/item/card/id/I = null
-		for (var/obj/item/O in W.contents)
-			if (istype(O, /obj/item/card/id))
-				I = O
-				break
+		else if(istype(O, /obj/item/card/id))
+			I = O
+			break
+	if (W | I)
+		if(W)
+			for (var/obj/item/O in W.contents)
+				if (istype(O, /obj/item/card/id))
+					I = O
+					break
 		if (I)
 			I.access += list(ACCESS_ENGINE, ACCESS_MEDICAL, ACCESS_ARMORY, ACCESS_BRIG, ACCESS_SECURITY, ACCESS_OUTPOST_FACTION_SOLFED)
 			I.update_label()
@@ -52,16 +60,20 @@
 
 /datum/outfit/job/cel/solfed/proc/get_solfed_marine_access(mob/living/carbon/human/H)
 	var/obj/item/storage/wallet/W = null
+	var/obj/item/card/id/I = null
 	for (var/obj/item/O in H.contents)
 		if (istype(O, /obj/item/storage/wallet))
 			W = O
 			break
-	if (W)
-		var/obj/item/card/id/I = null
-		for (var/obj/item/O in W.contents)
-			if (istype(O, /obj/item/card/id))
-				I = O
-				break
+		else if(istype(O, /obj/item/card/id))
+			I = O
+			break
+	if (W | I)
+		if(W)
+			for (var/obj/item/O in W.contents)
+				if (istype(O, /obj/item/card/id))
+					I = O
+					break
 		if (I)
 			I.access += list(ACCESS_ENGINE, ACCESS_MEDICAL, ACCESS_BRIG, ACCESS_SECURITY, ACCESS_OUTPOST_FACTION_SOLFED)
 			I.update_label()
@@ -71,16 +83,20 @@
 
 /datum/outfit/job/cel/solfed/proc/get_solfed_engineer_access(mob/living/carbon/human/H)
 	var/obj/item/storage/wallet/W = null
+	var/obj/item/card/id/I = null
 	for (var/obj/item/O in H.contents)
 		if (istype(O, /obj/item/storage/wallet))
 			W = O
 			break
-	if (W)
-		var/obj/item/card/id/I = null
-		for (var/obj/item/O in W.contents)
-			if (istype(O, /obj/item/card/id))
-				I = O
-				break
+		else if(istype(O, /obj/item/card/id))
+			I = O
+			break
+	if (W | I)
+		if(W)
+			for (var/obj/item/O in W.contents)
+				if (istype(O, /obj/item/card/id))
+					I = O
+					break
 		if (I)
 			I.access += list(ACCESS_ENGINE, ACCESS_MEDICAL, ACCESS_SECURITY, ACCESS_OUTPOST_FACTION_SOLFED)
 			I.update_label()
@@ -92,16 +108,20 @@
 
 /datum/outfit/job/cel/solfed/proc/get_solfed_general_access(mob/living/carbon/human/H)
 	var/obj/item/storage/wallet/W = null
+	var/obj/item/card/id/I = null
 	for (var/obj/item/O in H.contents)
 		if (istype(O, /obj/item/storage/wallet))
 			W = O
 			break
-	if (W)
-		var/obj/item/card/id/I = null
-		for (var/obj/item/O in W.contents)
-			if (istype(O, /obj/item/card/id))
-				I = O
-				break
+		else if(istype(O, /obj/item/card/id))
+			I = O
+			break
+	if (W | I)
+		if(W)
+			for (var/obj/item/O in W.contents)
+				if (istype(O, /obj/item/card/id))
+					I = O
+					break
 		if (I)
 			I.access += list(ACCESS_OUTPOST_FACTION_SOLFED)
 			I.update_label()
@@ -238,7 +258,7 @@
 
 	accessory = /obj/item/clothing/accessory/medal/gold/captain
 
-/datum/outfit/job/cel/solfed/captain/post_equip(mob/living/carbon/human/H)
+/datum/outfit/job/cel/solfed/intelof/post_equip(mob/living/carbon/human/H)
 	. = ..()
 	get_solfed_captain_access(H)
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Существовала проблема, что при спавне на корабле солфеда без кошелька доступы не выдавались, а значит при спавне из крио даже капитан не мог выйти.

fix #2899 

Проблема касалась не только капитана, но и других ролей солфеда.
Также заметил, что дважды отрабатывал код, создавая лишнюю нагрузку, связано с ошибкой прошлого кодера.

## Демонстрация изменений / Тестирование
<img width="360" height="620" alt="image" src="https://github.com/user-attachments/assets/87c5ca2b-c7b5-467c-8f6f-7cb1a3c8cc93" />

## Список изменений

```yml
🆑
fix: Исправлена проблема с отсутствием доступов при спавнне без кошелька.
/🆑
```
