### PR TITLE
FIX: Фикс пары вещей на Боксе и Люксе

### DIFF
--- a/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
@@ -917,6 +917,7 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
+/obj/item/trash/cheesie,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)
 "dm" = (
@@ -2329,9 +2330,6 @@
 /obj/item/reagent_containers/food/drinks/waterbottle{
 	pixel_x = 4;
 	pixel_y = 2
-	},
-/obj/item/trash/cheesie{
-	pixel_x = -25
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew)

--- a/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
+++ b/_maps/_mod_celadon/shuttles/independent/independent_box.dmm
@@ -2527,12 +2527,14 @@
 	pixel_y = -32
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -8;
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 5
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/wrench/medical{
+	pixel_x = -4
 	},
 /turf/open/floor/plasteel/mono/dark,
 /area/ship/medical)

--- a/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
+++ b/_maps/_mod_celadon/shuttles/syndicate/syndicate_luxembourg.dmm
@@ -212,7 +212,7 @@
 /obj/structure/window/plasma/reinforced/spawner/west{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
 	dir = 1
 	},
 /turf/open/floor/engine/plasma,


### PR DESCRIPTION
## Описание / Что этот PR делает
Фикс гениального мусора на боксе и возвращение мед. ключа который ранее также куда-то дели:
<img width="444" height="428" alt="image" src="https://github.com/user-attachments/assets/3a79d76b-19a3-4af7-9351-c303906fb099" />
<img width="218" height="72" alt="image" src="https://github.com/user-attachments/assets/8f694f13-fdd6-44cb-81df-69a196af2189" />
<img width="493" height="544" alt="image" src="https://github.com/user-attachments/assets/c631574b-7d02-41af-a4c3-7aacee05e229" />

fix https://github.com/CeladonSS13/Shiptest/issues/2623 ишуя связанное с вентеляцией на Люксенбурге:
<img width="612" height="524" alt="image" src="https://github.com/user-attachments/assets/905a56e3-1db6-4417-ad43-92479a66e624" />
<img width="1107" height="621" alt="image" src="https://github.com/user-attachments/assets/0a601a3a-120a-44d0-9a75-966b79378060" />

## Причина создания ПР / Почему это хорошо для игры
Фиксы для корабликов
## Демонстрация изменений / Тестирование
Показал выше
## Список изменений

```yml
🆑Azzy.Dreemurr
map: Мелко фикс мусора на боксе и возвращение мед. ключа на стол крио. Починка вентиляции на Люксенбурге
/🆑
```
