### PR TITLE
TWEAK: Добавляет лицевым маскам с боевых кораблей защиту от перцовки.

### DIFF
--- a/mod_celadon/outfit/_outfit.dme
+++ b/mod_celadon/outfit/_outfit.dme
@@ -68,4 +68,6 @@
 
 #include "code/gamma/gamma.dm"
 
+#include "code/masks.dm"
+
 #endif

--- a/mod_celadon/outfit/code/masks.dm
+++ b/mod_celadon/outfit/code/masks.dm
@@ -1,0 +1,18 @@
+// Adds pepperspray protection to masks from battleships
+/obj/item/clothing/mask/balaclava
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	visor_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+
+/obj/item/clothing/mask/breath/ngr
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	visor_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+
+/obj/item/clothing/mask/breath/facemask
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	visor_flags = BLOCK_GAS_SMOKE_EFFECT | ALLOWINTERNALS
+	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
+	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF


### PR DESCRIPTION
## Описание / Что этот PR делает
Добавляет всем маскам типа `balaclava` и `face mask` что выдаются боевым кораблям InteQ и ЕРТ кораблям НТ защиту от перцовки, как у обычной СБ маски. Изменения применяются через модуль одежды.

## Причина создания ПР / Почему это хорошо для игры
Как видно на скриншоте, упомянутые маски выдаются ЕРТ отрядам на кораблях НТ и любым оперативникам InteQ, все имеют возможность подключения к внутренней системе обеспечения и по логике должны защищать от перцового газа.


<img width="187" height="214" alt="Screenshot_1948" src="https://github.com/user-attachments/assets/61e1ef4c-80e6-4914-9b66-2b0a4551847d" />

Работа по баг-репорту:
resolve: #2911 

## Демонстрация изменений / Тестирование
Bro trust me

## Список изменений

```yml
🆑
tweak: Защита для масок `face mask` и `balaclava`.
/🆑
```
