### PR TITLE
FIX: Слот-машина теперь принимает чипы с токенами

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -82,6 +82,7 @@
 		to_chat(user, span_notice("You insert [credits.value] credits into [src]'s slot!"))
 		balance += credits.value
 		qdel(credits)
+	//[CELADON-FIX]
 	else if(istype(object, /obj/item/holochip))
 		var/obj/item/holochip/credits = object
 		if(!user.temporarilyRemoveItemFromInventory(credits))
@@ -89,6 +90,7 @@
 		to_chat(user, span_notice("You insert chip with [credits.credits] credits into [src]'s slot!"))
 		balance += credits.credits
 		qdel(credits)
+	//[/CELADON-FIX]
 	else
 		return ..()
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -82,6 +82,13 @@
 		to_chat(user, span_notice("You insert [credits.value] credits into [src]'s slot!"))
 		balance += credits.value
 		qdel(credits)
+	else if(istype(object, /obj/item/holochip))
+		var/obj/item/holochip/credits = object
+		if(!user.temporarilyRemoveItemFromInventory(credits))
+			return
+		to_chat(user, span_notice("You insert chip with [credits.credits] credits into [src]'s slot!"))
+		balance += credits.credits
+		qdel(credits)
 	else
 		return ..()
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -82,7 +82,7 @@
 		to_chat(user, span_notice("You insert [credits.value] credits into [src]'s slot!"))
 		balance += credits.value
 		qdel(credits)
-	//[CELADON-FIX]
+	//[CELADON-ADD] - Добавляет возможность использовать holochips.
 	else if(istype(object, /obj/item/holochip))
 		var/obj/item/holochip/credits = object
 		if(!user.temporarilyRemoveItemFromInventory(credits))
@@ -90,7 +90,7 @@
 		to_chat(user, span_notice("You insert chip with [credits.credits] credits into [src]'s slot!"))
 		balance += credits.credits
 		qdel(credits)
-	//[/CELADON-FIX]
+	//[/CELADON-ADD]
 	else
 		return ..()
 


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь Слот-машина принимает не только бумажные деньги, но и чипы с деньгами. 
## Демонстрация изменений / Тестирование
Ну... оно работает
## Список изменений
```yml
🆑
fix: Слот-машина теперь принимает чипы с токенами
/🆑
```
closed https://github.com/CeladonSS13/Shiptest/issues/2920