### PR TITLE
FIX: Исправлено отображение крови

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -112,9 +112,10 @@
 	. = ..()
 	var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 	if(darkheart)
-	//[CELADON-EDIT]
-		. += /*span_notice(*/"Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."/*)*/
-	//[/CELADON-EDIT]
+	// [CELADON-EDIT]
+		// . += span_notice("Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].")
+		. += "Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."
+	// [/CELADON-EDIT]
 
 /obj/item/organ/heart/vampire
 	name = "vampire heart"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -112,7 +112,7 @@
 	. = ..()
 	var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 	if(darkheart)
-		. += span_notice("Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].")
+		. += "Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."
 
 
 /obj/item/organ/heart/vampire

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -112,9 +112,9 @@
 	. = ..()
 	var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 	if(darkheart)
-	//[CELADON-ADD]
-		. += "Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."
-	//[/CELADON-ADD]
+	//[CELADON-EDIT]
+		. += /*span_notice(*/"Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."/*)*/
+	//[/CELADON-EDIT]
 
 /obj/item/organ/heart/vampire
 	name = "vampire heart"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -112,8 +112,9 @@
 	. = ..()
 	var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 	if(darkheart)
+	//[CELADON-ADD]
 		. += "Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."
-
+	//[/CELADON-ADD]
 
 /obj/item/organ/heart/vampire
 	name = "vampire heart"


### PR DESCRIPTION
## Описание / Что этот PR делает
Исправляет отображение количества крови у вампирского сердца... Правда это сердце бесполезно, но механ когда-нибуть в другой раз
## Причина создания ПР / Почему это хорошо для игры
Фиксим баги
## Демонстрация изменений / Тестирование
<img width="197" height="61" alt="image" src="https://github.com/user-attachments/assets/f00e2030-4e42-4939-ba61-89845e1ce4f9" />

## Список изменений

```yml
🆑
fix: Исправлено отображение крови у вампирского сердца
/🆑
```
