### PR TITLE
HOTFIX: Cargo delivery areas

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_asteroid.dmm
@@ -6365,7 +6365,7 @@
 /obj/structure/crate_shelf,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "efa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -6511,7 +6511,7 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "ekt" = (
 /obj/effect/turf_decal/siding/wood{
 	color = "#792f27";
@@ -12853,7 +12853,7 @@
 "isZ" = (
 /obj/machinery/computer/cargo/faction/inteq,
 /turf/open/floor/plasteel/tech/techmaint,
-/area/outpost/faction/inteq)
+/area/outpost/cargo/faction/inteq)
 "itc" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/turf_decal/box/corners{
@@ -14767,7 +14767,7 @@
 	},
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "jBF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -15029,7 +15029,7 @@
 /obj/effect/turf_decal/trimline/opaque/nsorange/warning,
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "jOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16520,7 +16520,7 @@
 	},
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "kGl" = (
 /obj/machinery/door/airlock/wood/glass{
 	dir = 8
@@ -19091,7 +19091,7 @@
 	},
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "mmq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -20052,7 +20052,7 @@
 "ndm" = (
 /obj/machinery/computer/cargo/faction/solfed,
 /turf/open/floor/plasteel/mono,
-/area/outpost/faction/solfed)
+/area/outpost/cargo/faction/solfed)
 "ndE" = (
 /turf/closed/indestructible/reinforced,
 /area/outpost/vacant_rooms)
@@ -20709,7 +20709,7 @@
 	},
 /obj/structure/crate_shelf,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "nzL" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel/darkgreenfull/darkgreen{
@@ -24128,7 +24128,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark_2,
-/area/outpost/cargo/faction/nanotrasen)
+/area/outpost/faction/nanotrasen)
 "pJA" = (
 /obj/machinery/door/poddoor/ert{
 	id = "OutpostPoligonExit_6";
@@ -28286,7 +28286,7 @@
 "sxr" = (
 /obj/machinery/computer/cargo/faction/syndicate,
 /turf/open/floor/mineral/plastitanium,
-/area/outpost/faction/syndi)
+/area/outpost/cargo/faction/syndicate)
 "sxs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -35644,7 +35644,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/faction/nanotrasen)
+/area/outpost/cargo/faction/nanotrasen)
 "xrk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -30558,7 +30558,7 @@
 /obj/machinery/computer/cargo/faction/solfed,
 /obj/structure/sign/flag/solfed/directional/south,
 /turf/open/floor/plasteel/patterned/cargo_one,
-/area/outpost/faction/solfed)
+/area/outpost/cargo/faction/solfed)
 "qzN" = (
 /obj/item/radio/intercom/wideband/table{
 	dir = 1;
@@ -37083,7 +37083,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/outpost/faction/nanotrasen)
+/area/outpost/cargo/faction/nanotrasen)
 "udk" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/asteroid/icerock/temperate,
@@ -40791,7 +40791,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/plastitanium,
-/area/outpost/faction/syndi)
+/area/outpost/cargo/faction/syndicate)
 "wlp" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 5


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь поды будут падать в заданную для нее зону, а не куда попало

## Причина создания ПР / Почему это хорошо для игры
Не будет сапплай подов в туалете

## Демонстрация изменений / Тестирование
Работает, честно

Было:
<img width="357" height="300" alt="image" src="https://github.com/user-attachments/assets/f1b0d986-b748-48c6-b049-38ab219e87e0" />

Стало:
<img width="146" height="173" alt="image" src="https://github.com/user-attachments/assets/fc6df1f7-0bf0-46e7-bc9d-16aea930b904" />

## Список изменений

```yml
🆑
fix: Исправление зоны карго.
/🆑
```
